### PR TITLE
fix(plex): reset save status to 'idle' when editing user

### DIFF
--- a/src/client/features/plex/hooks/usePlexUser.ts
+++ b/src/client/features/plex/hooks/usePlexUser.ts
@@ -31,6 +31,7 @@ export function usePlexUser() {
 
   const handleEditUser = (user: UserWatchlistInfo) => {
     setSelectedUser(user)
+    setSaveStatus('idle')
     setIsEditModalOpen(true)
   }
 


### PR DESCRIPTION
fix(plex): memoized edituser form to fix double click cancel save

## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] My changes work with existing functionality