### PR TITLE
fix(discord webhook): add method to check for existing webhook notifi…

### DIFF
--- a/src/services/database.service.ts
+++ b/src/services/database.service.ts
@@ -2300,6 +2300,33 @@ export class DatabaseService {
   }
 
   /**
+   * Checks if a webhook notification exists for a particular item and user
+   *
+   * This method is used to prevent duplicate webhook notifications when
+   * processing watchlist items.
+   *
+   * @param userId - ID of the user who would receive the notification
+   * @param type - Type of notification to check for
+   * @param title - Title of the content item
+   * @returns Promise resolving to the notification if found, undefined otherwise
+   */
+  async getExistingWebhookNotification(
+    userId: number,
+    type: string,
+    title: string,
+  ): Promise<{ id: number } | undefined> {
+    return await this.knex('notifications')
+      .where({
+        user_id: userId,
+        type,
+        title,
+        sent_to_webhook: true,
+      })
+      .select('id')
+      .first()
+  }
+
+  /**
    * Resets notification status for content items
    *
    * @param options - Options for filtering which notifications to reset

--- a/src/utils/plex.ts
+++ b/src/utils/plex.ts
@@ -753,7 +753,7 @@ export const getRssFromPlexToken = async (
 
 export const fetchWatchlistFromRss = async (
   url: string,
-  prefix: 'selfRSS' | 'otherRSS',
+  prefix: 'selfRSS' | 'friendsRSS',
   userId: number,
   log: FastifyBaseLogger,
 ): Promise<Set<Item>> => {


### PR DESCRIPTION
fix(discord webhook): add method to check for existing webhook notifications and prevent duplicates

fix(discord webhook): changed mismatched identifier from other to friends

## Description
<!-- A clear and concise description of the changes in this PR -->

There was a mismatch between identifiers for determining friends pending rss items match for sending webhooks.
Added prevention to ensure no duplicate webhooks are sent for user / item

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality