### PR TITLE
fix(plex-watchlist): handle empty self watchlist gracefully and impro…

### DIFF
--- a/src/services/plex-watchlist.service.ts
+++ b/src/services/plex-watchlist.service.ts
@@ -81,8 +81,13 @@ export class PlexWatchlistService {
       }),
     )
 
+    // Don't error out if a user has no items in their watch list.
     if (userWatchlistMap.size === 0) {
-      throw new Error('Unable to fetch watchlist items')
+      this.log.info('No items in self watchlist, returning empty result')
+      return {
+        total: 0,
+        users: [],
+      }
     }
 
     const { allKeys, userKeyMap } =

--- a/src/utils/plex.ts
+++ b/src/utils/plex.ts
@@ -104,7 +104,7 @@ export const getWatchlist = async (
     throw new Error(`Unexpected content type: ${contentType}`)
   } catch (error) {
     log.error(`Error in getWatchlist: ${error}`)
-    // Incase of error eturn an empty response that matches the expected structure
+    // Incase of error return an empty response that matches the expected structure
     return { MediaContainer: { Metadata: [], totalSize: 0 } }
   }
 }


### PR DESCRIPTION
fix(plex-watchlist): handle empty self watchlist gracefully and improve error handling

## Description
<!-- A clear and concise description of the changes in this PR -->

Fixed a bug to allow for empty primary token watchlists

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality