### PR TITLE
fix: enhance user redirection logic based on Plex token availability

### DIFF
--- a/src/services/database.service.ts
+++ b/src/services/database.service.ts
@@ -142,7 +142,7 @@ export class DatabaseService {
   async createUser(
     userData: Omit<User, 'id' | 'created_at' | 'updated_at'>,
   ): Promise<User> {
-    const [id] = await this.knex('users')
+    const result = await this.knex('users')
       .insert({
         ...userData,
         created_at: this.timestamp,
@@ -150,11 +150,19 @@ export class DatabaseService {
       })
       .returning('id')
 
-    if (!id) throw new Error('Failed to create user')
+    // Handle different return formats
+    const id =
+      typeof result[0] === 'object' && result[0] !== null
+        ? result[0].id // Handle case where result is an array of objects
+        : result[0] // Handle case where result is an array of values
+
+    if (id === undefined || id === null) {
+      throw new Error('Failed to create user')
+    }
 
     const user: User = {
       ...userData,
-      id,
+      id: Number(id),
       created_at: this.timestamp,
       updated_at: this.timestamp,
     }

--- a/src/services/plex-watchlist.service.ts
+++ b/src/services/plex-watchlist.service.ts
@@ -108,7 +108,10 @@ export class PlexWatchlistService {
       existingItems,
     )
 
-    const processedItems = await this.processAndSaveNewItems(brandNewItems)
+    const processedItems = await this.processAndSaveNewItems(
+      brandNewItems,
+      true,
+    )
     await this.linkExistingItems(existingItemsToLink)
 
     const allItemsMap = new Map<Friend, Set<WatchlistItem>>()
@@ -561,6 +564,7 @@ export class PlexWatchlistService {
 
   private async processAndSaveNewItems(
     brandNewItems: Map<Friend, Set<TokenWatchlistItem>>,
+    isSelfWatchlist = false,
   ): Promise<Map<Friend, Set<WatchlistItem>>> {
     if (brandNewItems.size === 0) {
       return new Map<Friend, Set<WatchlistItem>>()
@@ -571,10 +575,8 @@ export class PlexWatchlistService {
     const operationId = `process-${Date.now()}`
     const emitProgress = this.fastify.progress.hasActiveConnections()
 
-    const firstUser = Array.from(brandNewItems.keys())[0]
-    const type = firstUser.username.startsWith('token')
-      ? 'self-watchlist'
-      : 'others-watchlist'
+    // Use the passed parameter to determine the type
+    const type = isSelfWatchlist ? 'self-watchlist' : 'others-watchlist'
 
     if (emitProgress) {
       this.fastify.progress.emit({
@@ -582,7 +584,7 @@ export class PlexWatchlistService {
         type,
         phase: 'start',
         progress: 0,
-        message: `Starting ${type === 'self-watchlist' ? 'self' : 'others'} watchlist processing`,
+        message: `Starting ${isSelfWatchlist ? 'self' : 'others'} watchlist processing`,
       })
     }
 


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

Fixed a bug related to returned user id being an object instead of a number
Fixed redirect logic related to authbypass settings.

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Users are now redirected to the Plex setup page if Plex tokens are not configured, instead of always being sent to the dashboard.

- **Bug Fixes**
  - Improved compatibility when creating users by handling different database response formats.

- **Refactor**
  - Enhanced watchlist processing by explicitly specifying the type of watchlist, leading to clearer progress messages and improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->