### PR TITLE
chore: clean up README.md to clarify routing rules and enhance notifi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,14 +125,13 @@ Pulsarr offers a powerful predicate-based routing system that intelligently dire
   - Genre (e.g., Anime → dedicated instance)
   - User (e.g., specific users' content → specific profiles/folders)
   - Language (e.g., Spanish content → spanish content folder)
-  - Year (e.g., pre-2000 movies → classics folder)
+  - Year (e.g., pre-2000 movies → classics folder in another instance)
   - Certification (e.g., R-rated → separate folder)
 - **Visual Rule Builder**: Intuitive interface for creating and managing routing rules
-- **Priority-based Processing**: Assign weights to rules to control which takes precedence
-- **Rule Testing**: Verify routing behavior before applying
-- **Multi-Instance Routing**: Content can be simultaneously sent to multiple instances when different rules match, allowing for content to exist in multiple libraries or servers
+- **Priority-based Processing**: Assign weights to rules to control which takes precedence (used when multiple rules send content to the same instance)
+- **Multi-Instance Routing**: Content can be simultaneously sent to multiple instances when different rules match, allowing for content to exist in multiple instances
 
-**Example**: "Route Japanese Anime requested by specific users to the Anime instance with high-quality profile, while sending all other anime content to the standard instance."
+**Example**: "Route Japanese Anime requested by specific users to the Anime instance with high-quality profile, while sending all other anime content to the default instance."
 
 The routing system processes all matching rules that target different instances, allowing the same content to appear in multiple libraries as needed. When multiple rules target the same instance, only the highest priority rule is applied for that specific instance.
 
@@ -610,7 +609,7 @@ Navigate to the Utilities page in the Pulsarr web interface and configure your d
 - Content types to delete (movies, ended shows, continuing shows)
 - Whether to delete associated files from disk
 - User sync setting preferences (if someone isn't allowed to make requests, ignore their watchlist in the deletion process)
-- Notification preferences for deletion events (will send results to webhook, message, both, or none)
+- Notification preferences for deletion events (fully configurable)
 - Maximum deletion prevention threshold (a failsafe)
 
 Set up a schedule for automatic deletion operations


### PR DESCRIPTION
chore: clean up README.md to clarify routing rules and enhance notification preferences

## Description
<!-- A clear and concise description of the changes in this PR -->

Fixed some wording in the readme. 

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that routing by year can direct content to a classics folder in a different instance.
  - Refined explanation of priority-based processing to specify how weights affect precedence.
  - Updated multi-instance routing details to highlight that content can exist in multiple instances.
  - Changed example fallback instance from "standard" to "default."
  - Updated Delete Sync notification preferences to indicate they are now fully configurable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->