### PR TITLE
fix: handle friends with empty watchlists properly

### DIFF
--- a/src/utils/plex.ts
+++ b/src/utils/plex.ts
@@ -763,7 +763,8 @@ export const getOthersWatchlist = async (
 
   // Add each result to the map
   for (const { user, watchlistItems, success } of results) {
-    if (success && watchlistItems.size > 0) {
+    if (success) {
+      // Always add the user to the map, even if they have no items
       userWatchlistMap.set(user, watchlistItems)
       log.debug(
         `Added ${watchlistItems.size} items for friend ${user.username}`,
@@ -775,8 +776,13 @@ export const getOthersWatchlist = async (
     (acc, items) => acc + items.size,
     0,
   )
+  const friendsWithItems = Array.from(userWatchlistMap.entries()).filter(
+    ([_, items]) => items.size > 0
+  ).length
+  const friendsWithEmptyWatchlists = userWatchlistMap.size - friendsWithItems
+
   log.info(
-    `Others' watchlist fetched successfully with ${totalItems} total items from ${userWatchlistMap.size} friends`,
+    `Others' watchlist fetched successfully with ${totalItems} total items from ${friendsWithItems} friends (${friendsWithEmptyWatchlists} friends with empty watchlists)`,
   )
   return userWatchlistMap
 }


### PR DESCRIPTION
This fix ensures that friends with empty watchlists are still included in the userWatchlistMap, preventing an error when all friends have empty watchlists. Previously, the system would throw an 'Unable to fetch others' watchlist items' error in this scenario.

The enhanced logging also makes it clearer when friends have empty watchlists.

## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] My changes work with existing functionality