### PR TITLE
feat: enhance delete sync notifications with protected item counts

### DIFF
--- a/src/services/discord-notifications.service.ts
+++ b/src/services/discord-notifications.service.ts
@@ -665,15 +665,22 @@ export class DiscordNotificationService {
    */
   private createDeleteSyncEmbed(
     results: {
-      total: { deleted: number; skipped: number; processed: number }
+      total: {
+        deleted: number
+        skipped: number
+        processed: number
+        protected?: number
+      }
       movies: {
         deleted: number
         skipped: number
+        protected?: number
         items: Array<{ title: string; guid: string; instance: string }>
       }
       shows: {
         deleted: number
         skipped: number
+        protected?: number
         items: Array<{ title: string; guid: string; instance: string }>
       }
       safetyTriggered?: boolean
@@ -702,11 +709,16 @@ export class DiscordNotificationService {
         "The following content was removed because it's no longer in any user's watchlist."
     }
 
+    // Add protected playlist information if there are protected items
+    if (results.total.protected && results.total.protected > 0) {
+      description += `\n\n${results.total.protected} items were preserved because they are in protected playlists.`
+    }
+
     // Create fields for the embed
     const fields = [
       {
         name: 'Summary',
-        value: `Processed: ${results.total.processed} items\nDeleted: ${results.total.deleted} items\nSkipped: ${results.total.skipped} items`,
+        value: `Processed: ${results.total.processed} items\nDeleted: ${results.total.deleted} items\nSkipped: ${results.total.skipped} items${results.total.protected ? `\nProtected: ${results.total.protected} items` : ''}`,
         inline: false,
       },
     ]
@@ -727,8 +739,14 @@ export class DiscordNotificationService {
         .map((item) => `• ${item.title}`)
         .join('\n')
 
+      // Include protected count if available
+      const protectedInfo =
+        results.movies.protected && results.movies.protected > 0
+          ? ` (${results.movies.protected} protected)`
+          : ''
+
       fields.push({
-        name: `Movies (${results.movies.deleted} deleted)`,
+        name: `Movies (${results.movies.deleted} deleted${protectedInfo})`,
         value: movieList || 'None',
         inline: false,
       })
@@ -741,9 +759,15 @@ export class DiscordNotificationService {
         })
       }
     } else {
+      // Include protected count if available
+      const protectedInfo =
+        results.movies.protected && results.movies.protected > 0
+          ? ` (${results.movies.protected} protected)`
+          : ''
+
       fields.push({
         name: 'Movies',
-        value: 'No movies deleted',
+        value: `No movies deleted${protectedInfo}`,
         inline: false,
       })
     }
@@ -755,8 +779,14 @@ export class DiscordNotificationService {
         .map((item) => `• ${item.title}`)
         .join('\n')
 
+      // Include protected count if available
+      const protectedInfo =
+        results.shows.protected && results.shows.protected > 0
+          ? ` (${results.shows.protected} protected)`
+          : ''
+
       fields.push({
-        name: `TV Shows (${results.shows.deleted} deleted)`,
+        name: `TV Shows (${results.shows.deleted} deleted${protectedInfo})`,
         value: showList || 'None',
         inline: false,
       })
@@ -769,9 +799,15 @@ export class DiscordNotificationService {
         })
       }
     } else {
+      // Include protected count if available
+      const protectedInfo =
+        results.shows.protected && results.shows.protected > 0
+          ? ` (${results.shows.protected} protected)`
+          : ''
+
       fields.push({
         name: 'TV Shows',
-        value: 'No TV shows deleted',
+        value: `No TV shows deleted${protectedInfo}`,
         inline: false,
       })
     }
@@ -797,15 +833,22 @@ export class DiscordNotificationService {
    */
   async sendDeleteSyncNotification(
     results: {
-      total: { deleted: number; skipped: number; processed: number }
+      total: {
+        deleted: number
+        skipped: number
+        processed: number
+        protected?: number
+      }
       movies: {
         deleted: number
         skipped: number
+        protected?: number
         items: Array<{ title: string; guid: string; instance: string }>
       }
       shows: {
         deleted: number
         skipped: number
+        protected?: number
         items: Array<{ title: string; guid: string; instance: string }>
       }
       safetyTriggered?: boolean


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

Added new deletion protection playlist item count to the summaries for both Discord and Apprise. 

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Delete sync notifications now display counts of "protected" items that were preserved, both in summary and detailed sections, for movies and TV shows.
  - Protected item counts are included in both Apprise and Discord notifications, enhancing visibility of items retained due to protected playlists.

- **Style**
  - Improved notification formatting and layout to accommodate protected item counts for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->