### PR TITLE
fix: normalize email addresses to lowercase across schemas and database methods

### DIFF
--- a/migrations/migrations/047_20250703_normalize_admin_emails.ts
+++ b/migrations/migrations/047_20250703_normalize_admin_emails.ts
@@ -1,0 +1,28 @@
+import type { Knex } from 'knex'
+
+/**
+ * Normalizes existing admin user email addresses to lowercase for case-insensitive handling.
+ * This ensures consistency with the updated email validation schemas that now convert emails to lowercase.
+ */
+export async function up(knex: Knex): Promise<void> {
+  // Update all admin user emails to lowercase
+  await knex.raw(`
+    UPDATE admin_users 
+    SET email = LOWER(email), 
+        updated_at = CURRENT_TIMESTAMP
+    WHERE email != LOWER(email)
+  `)
+}
+
+/**
+ * Reverts the email normalization by restoring original case.
+ * Note: This down migration cannot perfectly restore the original case
+ * since we don't store the original values. This is primarily for testing.
+ */
+export async function down(knex: Knex): Promise<void> {
+  // No practical way to restore original case without storing it
+  // This is primarily for testing rollback functionality
+  console.log(
+    'Note: Cannot restore original email case - normalized emails remain lowercase',
+  )
+}

--- a/src/client/features/auth/schemas/login-schema.ts
+++ b/src/client/features/auth/schemas/login-schema.ts
@@ -8,6 +8,7 @@ export const loginFormSchema = z.object({
   email: z
     .string()
     .trim()
+    .toLowerCase()
     .min(1, 'Email is required')
     .email('Please enter a valid email address')
     .refine((email) => email.includes('@'), {

--- a/src/client/features/create-user/schemas/create-user-schema.ts
+++ b/src/client/features/create-user/schemas/create-user-schema.ts
@@ -7,6 +7,7 @@ export const PasswordSchema = z
 export const EmailSchema = z
   .string()
   .trim()
+  .toLowerCase()
   .min(1, 'Email is required')
   .email('Please enter a valid email address')
   .refine((email) => email.includes('@'), {

--- a/src/schemas/auth/admin-user.ts
+++ b/src/schemas/auth/admin-user.ts
@@ -10,7 +10,7 @@ export const CreateAdminErrorSchema = z.object({
 })
 
 export const CreateAdminSchema = z.object({
-  email: z.string().email(),
+  email: z.string().trim().toLowerCase().email(),
   username: z.string().min(3).max(255),
   password: z.string().min(8, 'Password must be at least 8 characters'),
 })

--- a/src/schemas/auth/auth.ts
+++ b/src/schemas/auth/auth.ts
@@ -9,7 +9,7 @@ export interface AdminUser {
 }
 
 export const CredentialsSchema = z.object({
-  email: z.string().email().max(255),
+  email: z.string().trim().toLowerCase().email().max(255),
   password: z
     .string()
     .min(8, 'Password must be at least 8 characters')

--- a/src/schemas/auth/login.ts
+++ b/src/schemas/auth/login.ts
@@ -16,7 +16,7 @@ export const PasswordSchema = z
   .min(8, 'Password must be at least 8 characters')
 
 export const CredentialsSchema = z.object({
-  email: z.string().email().max(255),
+  email: z.string().trim().toLowerCase().email().max(255),
   password: PasswordSchema,
 })
 

--- a/src/services/database/methods/users.ts
+++ b/src/services/database/methods/users.ts
@@ -314,7 +314,7 @@ export async function getAdminUser(
 ): Promise<AdminUser | undefined> {
   return await this.knex('admin_users')
     .select('id', 'username', 'email', 'password', 'role')
-    .where({ email })
+    .whereRaw('LOWER(email) = LOWER(?)', [email])
     .first()
 }
 
@@ -358,10 +358,12 @@ export async function updateAdminPassword(
   hashedPassword: string,
 ): Promise<boolean> {
   try {
-    const updated = await this.knex('admin_users').where({ email }).update({
-      password: hashedPassword,
-      updated_at: this.timestamp,
-    })
+    const updated = await this.knex('admin_users')
+      .whereRaw('LOWER(email) = LOWER(?)', [email])
+      .update({
+        password: hashedPassword,
+        updated_at: this.timestamp,
+      })
     return updated > 0
   } catch (error) {
     this.log.error('Error updating admin password:', error)


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email addresses for admin users are now automatically converted to lowercase during account creation, login, and related authentication processes.

* **Bug Fixes**
  * Email matching for admin users is now case-insensitive, ensuring consistent authentication and password updates regardless of email casing.

* **Chores**
  * Existing admin user emails in the database have been normalized to lowercase for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->