### PR TITLE
fix: config store not loaded on delete sync page load

### DIFF
--- a/src/client/features/utilities/hooks/useDeleteSyncForm.ts
+++ b/src/client/features/utilities/hooks/useDeleteSyncForm.ts
@@ -161,6 +161,7 @@ export function useDeleteSyncForm() {
   useEffect(() => {
     if (
       config &&
+      config.deletionMode !== undefined &&
       (!formInitializedRef.current || scheduleTime) &&
       saveStatus === 'idle'
     ) {
@@ -171,7 +172,7 @@ export function useDeleteSyncForm() {
 
       form.reset(
         {
-          deletionMode: config.deletionMode || 'watchlist',
+          deletionMode: config.deletionMode ?? 'watchlist',
           deleteMovie: config.deleteMovie || false,
           deleteEndedShow: config.deleteEndedShow || false,
           deleteContinuingShow: config.deleteContinuingShow || false,

--- a/src/client/features/utilities/pages/delete-sync.tsx
+++ b/src/client/features/utilities/pages/delete-sync.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { Button } from '@/components/ui/button'
 import {
   Loader2,
@@ -38,6 +39,7 @@ import {
 } from '@/components/ui/tooltip'
 import { useDeleteSync } from '@/features/utilities/hooks/useDeleteSync'
 import { useNavigate } from 'react-router-dom'
+import { useConfigStore } from '@/stores/configStore'
 import { DeleteSyncConfirmationModal } from '@/features/utilities/components/delete-sync/delete-sync-confirmation-modal'
 import { DeleteSyncDryRunModal } from '@/features/utilities/components/delete-sync/delete-sync-dry-run-modal'
 import { useMediaQuery } from '@/hooks/use-media-query'
@@ -82,7 +84,14 @@ export default function DeleteSyncPage() {
     setShowDryRunModal,
   } = useDeleteSync()
 
+  const { initialize: configInitialize } = useConfigStore()
+
   const navigate = useNavigate()
+
+  // Initialize config store on mount
+  useEffect(() => {
+    configInitialize()
+  }, [configInitialize])
 
   // Determine status based on job state
   const getStatus = () => {


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

- Fixed a bug where the config store was not initializing on the delete sync page causing default values to be displayed.

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form initialization to prevent unintended resets when certain configuration values are undefined.
  * Ensured accurate handling of default values during form reset.

* **Chores**
  * Configuration is now properly initialized when the Delete Sync page loads, enhancing reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->