### PR TITLE
fix: bug delete sync safety check before playlist protection fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
         "knex": "^3.1.0",
         "lucide-react": "^0.539.0",
         "next-themes": "^0.4.6",
+        "p-limit": "^7.1.0",
         "pg": "^8.16.0",
         "pino": "9.7.0",
         "pino-pretty": "^13.0.0",
@@ -7902,15 +7903,15 @@
       }
     },
     "node_modules/p-limit": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.1.0.tgz",
+      "integrity": "sha512-7LbrpOjbzBWFHFgRtVrIAwBwW1bB7c7n914Q2+CXr1TvOfbTrVHAEH1Ya9PwDwAoKLeiRrczymYWPwaHNOQ0vA==",
       "license": "MIT",
       "dependencies": {
-        "yocto-queue": "^1.0.0"
+        "yocto-queue": "^1.2.1"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7923,6 +7924,21 @@
       "license": "MIT",
       "dependencies": {
         "p-limit": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
       },
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "knex": "^3.1.0",
     "lucide-react": "^0.539.0",
     "next-themes": "^0.4.6",
+    "p-limit": "^7.1.0",
     "pg": "^8.16.0",
     "pino": "9.7.0",
     "pino-pretty": "^13.0.0",

--- a/src/services/delete-sync.service.ts
+++ b/src/services/delete-sync.service.ts
@@ -1561,9 +1561,19 @@ export class DeleteSyncService {
                 `series/${sonarrId}`,
               )
 
-              return removedTagIds.some((id) =>
+              const hasRemoval = removedTagIds.some((id) =>
                 (seriesDetails.tags || []).includes(id),
               )
+              if (!hasRemoval) return false
+              if (
+                this.config.enablePlexPlaylistProtection &&
+                this.protectedGuids
+              ) {
+                const guids = parseGuids(show.guids)
+                // Count only if NOT protected
+                return !this.isAnyGuidProtected(guids)
+              }
+              return true
             } catch (error) {
               this.log.error(
                 `Error checking tags for series "${show.title}":`,
@@ -1660,9 +1670,19 @@ export class DeleteSyncService {
                 `movie/${radarrId}`,
               )
 
-              return removedTagIds.some((id) =>
+              const hasRemoval = removedTagIds.some((id) =>
                 (movieDetails.tags || []).includes(id),
               )
+              if (!hasRemoval) return false
+              if (
+                this.config.enablePlexPlaylistProtection &&
+                this.protectedGuids
+              ) {
+                const guids = parseGuids(movie.guids)
+                // Count only if NOT protected
+                return !this.isAnyGuidProtected(guids)
+              }
+              return true
             } catch (error) {
               this.log.error(
                 `Error checking tags for movie "${movie.title}":`,

--- a/src/services/delete-sync.service.ts
+++ b/src/services/delete-sync.service.ts
@@ -217,14 +217,14 @@ export class DeleteSyncService {
           `Running tag-based deletion using tag "${this.config.removedTagPrefix}"`,
         )
 
-        // Process tag-based deletion workflow
+        // Process tag-based delete sync workflow
         result = await this.processTagBasedDeleteSync(
           existingSeries,
           existingMovies,
           dryRun,
         )
       } else {
-        // Watchlist-based deletion workflow
+        // Watchlist-based delete sync workflow
 
         // Step 4: Refresh watchlists to ensure current data
         const refreshResult = await this.refreshWatchlists()

--- a/src/services/delete-sync.service.ts
+++ b/src/services/delete-sync.service.ts
@@ -133,7 +133,7 @@ export class DeleteSyncService {
 
       if (playlistMap.size === 0) {
         throw new Error(
-          `Could not find or create protection playlists "${this.getProtectionPlaylistName()}" for any users`,
+          `Could not find or create protection playlists "${this.getProtectionPlaylistName()}" for any users - Plex server may be unreachable`,
         )
       }
 
@@ -840,6 +840,16 @@ export class DeleteSyncService {
     this.log.info(
       `Beginning tag-based deletion ${dryRun ? 'analysis' : 'process'} using tag "${this.config.removedTagPrefix}"`,
     )
+
+    // Validate once to avoid per-item warnings/work
+    const removalTagPrefix = (this.config.removedTagPrefix ?? '')
+      .trim()
+      .toLowerCase()
+    if (!removalTagPrefix) {
+      return this.createEmptyResult(
+        'Tag-based deletion requested but removedTagPrefix is blank – skipping operation',
+      )
+    }
 
     // Reset workflow caches before processing
     this.plexServer.clearWorkflowCaches()

--- a/src/services/delete-sync.service.ts
+++ b/src/services/delete-sync.service.ts
@@ -903,14 +903,21 @@ export class DeleteSyncService {
           this.countTaggedMovies(existingMovies),
         ])
 
-      const eligibleSeries = existingSeries.filter((s) =>
-        s.series_status !== 'ended'
-          ? this.config.deleteContinuingShow
-          : this.config.deleteEndedShow,
+      const eligibleSeriesCount = existingSeries.reduce(
+        (acc, s) =>
+          acc +
+          (s.series_status !== 'ended'
+            ? this.config.deleteContinuingShow
+              ? 1
+              : 0
+            : this.config.deleteEndedShow
+              ? 1
+              : 0),
+        0,
       )
       const totalItems =
         (this.config.deleteMovie ? existingMovies.length : 0) +
-        eligibleSeries.length
+        eligibleSeriesCount
       const totalTaggedItems = taggedForDeletionSeries + taggedForDeletionMovies
 
       if (totalItems === 0) {
@@ -1018,6 +1025,9 @@ export class DeleteSyncService {
             continue
           }
 
+          // Parse GUIDs once and reuse for both protection check and deletion
+          const movieGuidList = parseGuids(movie.guids)
+
           // Check if the movie is protected based on its GUIDs
           if (this.config.enablePlexPlaylistProtection) {
             // Double-check if protectedGuids is correctly initialized
@@ -1033,7 +1043,6 @@ export class DeleteSyncService {
             }
 
             // Check for any movie GUID in the protected set
-            const movieGuidList = parseGuids(movie.guids)
             let isProtected = false
 
             for (const guid of movieGuidList) {
@@ -1056,7 +1065,6 @@ export class DeleteSyncService {
           }
 
           // Add to the list of movies to delete (or would delete in dry run)
-          const movieGuidList = parseGuids(movie.guids)
           moviesToDelete.push({
             title: movie.title,
             guid: movieGuidList[0] || 'unknown',
@@ -1209,6 +1217,9 @@ export class DeleteSyncService {
             continue
           }
 
+          // Parse GUIDs once and reuse for both protection check and deletion
+          const showGuidList = parseGuids(show.guids)
+
           // Check if the show is protected based on its GUIDs
           if (this.config.enablePlexPlaylistProtection) {
             // Double-check if protectedGuids is correctly initialized
@@ -1224,7 +1235,6 @@ export class DeleteSyncService {
             }
 
             // Check for any show GUID in the protected set
-            const showGuidList = parseGuids(show.guids)
             let isProtected = false
 
             for (const guid of showGuidList) {
@@ -1247,7 +1257,6 @@ export class DeleteSyncService {
           }
 
           // Add to the list of shows to delete (or would delete in dry run)
-          const showGuidList = parseGuids(show.guids)
           showsToDelete.push({
             title: show.title,
             guid: showGuidList[0] || 'unknown',

--- a/src/services/delete-sync.service.ts
+++ b/src/services/delete-sync.service.ts
@@ -160,6 +160,26 @@ export class DeleteSyncService {
   }
 
   /**
+   * Returns true if any of the provided GUIDs exist in the protected set.
+   * Optional onHit callback lets callers log the first matching GUID.
+   */
+  private isAnyGuidProtected(
+    guidList: string[],
+    onHit?: (guid: string) => void,
+  ): boolean {
+    if (!this.config.enablePlexPlaylistProtection || !this.protectedGuids) {
+      return false
+    }
+    for (const guid of guidList) {
+      if (this.protectedGuids.has(guid)) {
+        onHit?.(guid)
+        return true
+      }
+    }
+    return false
+  }
+
+  /**
    * Initialize the service and its dependencies
    */
   async initialize(): Promise<boolean> {
@@ -1043,17 +1063,11 @@ export class DeleteSyncService {
             }
 
             // Check for any movie GUID in the protected set
-            let isProtected = false
-
-            for (const guid of movieGuidList) {
-              if (this.protectedGuids.has(guid)) {
-                this.log.debug(
-                  `Movie "${movie.title}" is protected by GUID "${guid}"`,
-                )
-                isProtected = true
-                break
-              }
-            }
+            const isProtected = this.isAnyGuidProtected(movieGuidList, (guid) =>
+              this.log.debug(
+                `Movie "${movie.title}" is protected by GUID "${guid}"`,
+              ),
+            )
 
             if (isProtected) {
               this.log.info(
@@ -1235,17 +1249,11 @@ export class DeleteSyncService {
             }
 
             // Check for any show GUID in the protected set
-            let isProtected = false
-
-            for (const guid of showGuidList) {
-              if (this.protectedGuids.has(guid)) {
-                this.log.debug(
-                  `Show "${show.title}" is protected by GUID "${guid}"`,
-                )
-                isProtected = true
-                break
-              }
-            }
+            const isProtected = this.isAnyGuidProtected(showGuidList, (guid) =>
+              this.log.debug(
+                `Show "${show.title}" is protected by GUID "${guid}"`,
+              ),
+            )
 
             if (isProtected) {
               this.log.info(
@@ -1908,17 +1916,13 @@ export class DeleteSyncService {
               }
 
               // Check for any movie GUID in the protected set
-              let isProtected = false
-
-              for (const guid of movieGuidList) {
-                if (this.protectedGuids.has(guid)) {
+              const isProtected = this.isAnyGuidProtected(
+                movieGuidList,
+                (guid) =>
                   this.log.debug(
                     `Movie "${movie.title}" is protected by GUID "${guid}"`,
-                  )
-                  isProtected = true
-                  break
-                }
-              }
+                  ),
+              )
 
               if (isProtected) {
                 this.log.info(
@@ -2067,17 +2071,13 @@ export class DeleteSyncService {
               }
 
               // Check for any show GUID in the protected set
-              let isProtected = false
-
-              for (const guid of showGuidList) {
-                if (this.protectedGuids.has(guid)) {
+              const isProtected = this.isAnyGuidProtected(
+                showGuidList,
+                (guid) =>
                   this.log.debug(
                     `Show "${show.title}" is protected by GUID "${guid}"`,
-                  )
-                  isProtected = true
-                  break
-                }
-              }
+                  ),
+              )
 
               if (isProtected) {
                 this.log.info(

--- a/src/services/delete-sync.service.ts
+++ b/src/services/delete-sync.service.ts
@@ -125,7 +125,7 @@ export class DeleteSyncService {
     }
 
     try {
-      this.log.debug('Loading protection playlists (cached)...')
+      this.log.debug('Loading protection playlists and caching results...')
 
       // Create protection playlists for users if missing
       const playlistMap =
@@ -218,28 +218,7 @@ export class DeleteSyncService {
    *
    * @returns Promise resolving to detailed results of the delete operation
    */
-  async run(dryRun = false): Promise<{
-    total: {
-      deleted: number
-      skipped: number
-      processed: number
-      protected?: number
-    }
-    movies: {
-      deleted: number
-      skipped: number
-      protected?: number
-      items: Array<{ title: string; guid: string; instance: string }>
-    }
-    shows: {
-      deleted: number
-      skipped: number
-      protected?: number
-      items: Array<{ title: string; guid: string; instance: string }>
-    }
-    safetyTriggered?: boolean
-    safetyMessage?: string
-  }> {
+  async run(dryRun = false): Promise<DeleteSyncResult> {
     // Check if delete sync is already running
     if (this._running) {
       this.log.warn(
@@ -364,8 +343,6 @@ export class DeleteSyncService {
 
           try {
             this.log.info('Beginning deletion analysis based on configuration')
-            this.log.info('Clearing workflow-specific caches')
-            this.plexServer.clearWorkflowCaches()
             this.log.info(
               `Plex playlist protection is enabled with playlist name "${this.getProtectionPlaylistName()}"`,
             )


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Service initialization endpoint to prepare integration before operations.
  * Playlist protection respected and protection data cached per run.

* **Improvements**
  * Watchlist refresh now uses exponential backoff with limited retries.
  * GUID-based lookups, per-instance tag caching, and controlled concurrency improve stability and performance.
  * Safer validation for removal-tag prefix and max-deletion settings, with clearer progress and protection-aware checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->