### PR TITLE
fix: replace hardcoded timeout values with a constant for Plex API operations

### DIFF
--- a/src/services/plex-server.service.ts
+++ b/src/services/plex-server.service.ts
@@ -30,6 +30,9 @@ import { toItemsSingle } from '@utils/plex.js'
 import { XMLParser } from 'fast-xml-parser'
 import type { FastifyBaseLogger, FastifyInstance } from 'fastify'
 
+// HTTP timeout constants
+const PLEX_API_TIMEOUT = 30000 // 30 seconds for Plex API operations
+
 /**
  * PlexServerService class for maintaining state and providing Plex operations
  */
@@ -182,7 +185,7 @@ export class PlexServerService {
           'X-Plex-Token': adminToken,
           'X-Plex-Client-Identifier': 'Pulsarr',
         },
-        signal: AbortSignal.timeout(8000),
+        signal: AbortSignal.timeout(PLEX_API_TIMEOUT),
       })
 
       if (!resourcesResponse.ok) {
@@ -430,7 +433,7 @@ export class PlexServerService {
           'X-Plex-Token': adminToken,
           'X-Plex-Client-Identifier': 'Pulsarr',
         },
-        signal: AbortSignal.timeout(8000),
+        signal: AbortSignal.timeout(PLEX_API_TIMEOUT),
       })
 
       if (!usersResponse.ok) {
@@ -585,7 +588,7 @@ export class PlexServerService {
           'X-Plex-Client-Identifier': 'Pulsarr',
           // This endpoint returns XML format
         },
-        signal: AbortSignal.timeout(8000),
+        signal: AbortSignal.timeout(PLEX_API_TIMEOUT),
       })
 
       if (!response.ok) {
@@ -777,7 +780,7 @@ export class PlexServerService {
           'X-Plex-Token': token,
           'X-Plex-Client-Identifier': 'Pulsarr',
         },
-        signal: AbortSignal.timeout(8000),
+        signal: AbortSignal.timeout(PLEX_API_TIMEOUT),
       })
 
       if (!response.ok) {
@@ -850,7 +853,7 @@ export class PlexServerService {
           'X-Plex-Token': token,
           'X-Plex-Client-Identifier': 'Pulsarr',
         },
-        signal: AbortSignal.timeout(8000),
+        signal: AbortSignal.timeout(PLEX_API_TIMEOUT),
       })
 
       if (!response.ok) {
@@ -1022,7 +1025,7 @@ export class PlexServerService {
             'X-Plex-Token': token,
             'X-Plex-Client-Identifier': 'Pulsarr',
           },
-          signal: AbortSignal.timeout(8000),
+          signal: AbortSignal.timeout(PLEX_API_TIMEOUT),
         })
 
         if (!response.ok) {
@@ -1436,7 +1439,7 @@ export class PlexServerService {
           'X-Plex-Token': adminToken,
           'X-Plex-Client-Identifier': 'Pulsarr',
         },
-        signal: AbortSignal.timeout(8000),
+        signal: AbortSignal.timeout(PLEX_API_TIMEOUT),
       })
 
       if (!response.ok) {
@@ -1495,7 +1498,7 @@ export class PlexServerService {
           'X-Plex-Token': adminToken,
           'X-Plex-Client-Identifier': 'Pulsarr',
         },
-        signal: AbortSignal.timeout(8000),
+        signal: AbortSignal.timeout(PLEX_API_TIMEOUT),
       })
 
       if (!response.ok) {
@@ -1548,7 +1551,7 @@ export class PlexServerService {
           'X-Plex-Token': adminToken,
           'X-Plex-Client-Identifier': 'Pulsarr',
         },
-        signal: AbortSignal.timeout(8000),
+        signal: AbortSignal.timeout(PLEX_API_TIMEOUT),
       })
 
       if (!response.ok) {
@@ -1603,7 +1606,7 @@ export class PlexServerService {
           'X-Plex-Token': adminToken,
           'X-Plex-Client-Identifier': 'Pulsarr',
         },
-        signal: AbortSignal.timeout(8000),
+        signal: AbortSignal.timeout(PLEX_API_TIMEOUT),
       })
 
       if (!response.ok) {
@@ -1813,7 +1816,7 @@ export class PlexServerService {
           'X-Plex-Token': adminToken,
           'X-Plex-Client-Identifier': 'Pulsarr',
         },
-        signal: AbortSignal.timeout(8000),
+        signal: AbortSignal.timeout(PLEX_API_TIMEOUT),
       })
 
       if (!response.ok) {


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced premature timeout errors when connecting to Plex by increasing the default timeout, improving reliability in slower network conditions.
  * Fewer failed requests and more consistent responses during long-running Plex operations.

* **Refactor**
  * Centralized timeout configuration for Plex API calls to ensure consistent behavior across the app.
  * Standardized timeout handling without altering existing features or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->