### PR TITLE
fix: fix constraint mismatch preventing multi-edition label tracking

### DIFF
--- a/migrations/migrations/062_20251031_add_rating_key_to_label_tracking_constraint.ts
+++ b/migrations/migrations/062_20251031_add_rating_key_to_label_tracking_constraint.ts
@@ -1,0 +1,158 @@
+import type { Knex } from 'knex'
+
+/**
+ * Adds plex_rating_key to the unique constraint on plex_label_tracking table.
+ *
+ * This fixes a bug where multiple editions of the same movie (sharing the same content GUIDs
+ * but with different Plex rating keys) could not be tracked separately. Each edition in Plex
+ * is a distinct item with its own rating key, so we need to include the rating key in the
+ * unique constraint to allow separate label tracking per edition.
+ *
+ * Changes the unique constraint from:
+ *   (content_guids, user_id, content_type)
+ * to:
+ *   (content_guids, user_id, content_type, plex_rating_key)
+ */
+export async function up(knex: Knex): Promise<void> {
+  const isPostgres = knex.client.config.client === 'pg'
+
+  if (isPostgres) {
+    // PostgreSQL: Drop the old functional index and create a new one with plex_rating_key
+    await knex.raw(`
+      DROP INDEX IF EXISTS plex_label_tracking_content_unique
+    `)
+
+    await knex.raw(`
+      CREATE UNIQUE INDEX plex_label_tracking_content_unique
+      ON plex_label_tracking(md5(content_guids::text), user_id, content_type, plex_rating_key)
+    `)
+  } else {
+    // SQLite: Drop the old unique constraint and create a new one with plex_rating_key
+    // SQLite doesn't support ALTER TABLE DROP CONSTRAINT, so we need to recreate the table
+    await knex.raw(`
+      CREATE TABLE plex_label_tracking_new (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        content_guids TEXT NOT NULL,
+        content_type TEXT NOT NULL CHECK(content_type IN ('movie', 'show')),
+        user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+        plex_rating_key VARCHAR(50) NOT NULL,
+        labels_applied TEXT NOT NULL DEFAULT '[]',
+        synced_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE(content_guids, user_id, content_type, plex_rating_key)
+      )
+    `)
+
+    // Copy data from old table to new table
+    await knex.raw(`
+      INSERT INTO plex_label_tracking_new
+        (id, content_guids, content_type, user_id, plex_rating_key, labels_applied, synced_at)
+      SELECT id, content_guids, content_type, user_id, plex_rating_key, labels_applied, synced_at
+      FROM plex_label_tracking
+    `)
+
+    // Drop old table and rename new table
+    await knex.raw(`DROP TABLE plex_label_tracking`)
+    await knex.raw(
+      `ALTER TABLE plex_label_tracking_new RENAME TO plex_label_tracking`,
+    )
+
+    // Recreate indexes
+    await knex.raw(
+      `CREATE INDEX idx_plex_label_tracking_user_id ON plex_label_tracking(user_id)`,
+    )
+    await knex.raw(
+      `CREATE INDEX idx_plex_label_tracking_plex_rating_key ON plex_label_tracking(plex_rating_key)`,
+    )
+    await knex.raw(
+      `CREATE INDEX idx_plex_label_tracking_synced_at ON plex_label_tracking(synced_at)`,
+    )
+    await knex.raw(
+      `CREATE INDEX idx_plex_label_tracking_content_type ON plex_label_tracking(content_type)`,
+    )
+  }
+}
+
+/**
+ * Reverts the unique constraint to its original form without plex_rating_key.
+ *
+ * Note: This migration down could cause data loss if there are multiple records
+ * with the same (content_guids, user_id, content_type) but different plex_rating_keys.
+ * The first record for each combination will be kept, and duplicates will be removed.
+ */
+export async function down(knex: Knex): Promise<void> {
+  const isPostgres = knex.client.config.client === 'pg'
+
+  if (isPostgres) {
+    // Remove duplicates before applying the old constraint
+    await knex.raw(`
+      DELETE FROM plex_label_tracking
+      WHERE id NOT IN (
+        SELECT MIN(id)
+        FROM plex_label_tracking
+        GROUP BY md5(content_guids::text), user_id, content_type
+      )
+    `)
+
+    // Drop the new index and restore the old one
+    await knex.raw(`
+      DROP INDEX IF EXISTS plex_label_tracking_content_unique
+    `)
+
+    await knex.raw(`
+      CREATE UNIQUE INDEX plex_label_tracking_content_unique
+      ON plex_label_tracking(md5(content_guids::text), user_id, content_type)
+    `)
+  } else {
+    // Remove duplicates before applying the old constraint
+    await knex.raw(`
+      DELETE FROM plex_label_tracking
+      WHERE id NOT IN (
+        SELECT MIN(id)
+        FROM plex_label_tracking
+        GROUP BY content_guids, user_id, content_type
+      )
+    `)
+
+    // Recreate table with old constraint
+    await knex.raw(`
+      CREATE TABLE plex_label_tracking_new (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        content_guids TEXT NOT NULL,
+        content_type TEXT NOT NULL CHECK(content_type IN ('movie', 'show')),
+        user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+        plex_rating_key VARCHAR(50) NOT NULL,
+        labels_applied TEXT NOT NULL DEFAULT '[]',
+        synced_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE(content_guids, user_id, content_type)
+      )
+    `)
+
+    // Copy data from old table to new table
+    await knex.raw(`
+      INSERT INTO plex_label_tracking_new
+        (id, content_guids, content_type, user_id, plex_rating_key, labels_applied, synced_at)
+      SELECT id, content_guids, content_type, user_id, plex_rating_key, labels_applied, synced_at
+      FROM plex_label_tracking
+    `)
+
+    // Drop old table and rename new table
+    await knex.raw(`DROP TABLE plex_label_tracking`)
+    await knex.raw(
+      `ALTER TABLE plex_label_tracking_new RENAME TO plex_label_tracking`,
+    )
+
+    // Recreate indexes
+    await knex.raw(
+      `CREATE INDEX idx_plex_label_tracking_user_id ON plex_label_tracking(user_id)`,
+    )
+    await knex.raw(
+      `CREATE INDEX idx_plex_label_tracking_plex_rating_key ON plex_label_tracking(plex_rating_key)`,
+    )
+    await knex.raw(
+      `CREATE INDEX idx_plex_label_tracking_synced_at ON plex_label_tracking(synced_at)`,
+    )
+    await knex.raw(
+      `CREATE INDEX idx_plex_label_tracking_content_type ON plex_label_tracking(content_type)`,
+    )
+  }
+}

--- a/src/services/database/methods/plex-label-tracking.ts
+++ b/src/services/database/methods/plex-label-tracking.ts
@@ -141,7 +141,7 @@ export async function trackPlexLabelsBulk(
                     synced_at
                   )
                   VALUES (?::jsonb, ?, ?, ?, ?::jsonb, ?)
-                  ON CONFLICT (md5(content_guids::text), user_id, content_type)
+                  ON CONFLICT (md5(content_guids::text), user_id, content_type, plex_rating_key)
                   DO UPDATE SET
                     content_guids = excluded.content_guids,
                     plex_rating_key = excluded.plex_rating_key,


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Label tracking now properly tracks each edition separately, allowing independent management of labels across different versions of the same content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->