### PR TITLE
feat: Increase the RSS check interval

### DIFF
--- a/src/plugins/custom/watchlist-workflow.ts
+++ b/src/plugins/custom/watchlist-workflow.ts
@@ -10,7 +10,12 @@ declare module 'fastify' {
 
 export default fp(
   async (fastify: FastifyInstance) => {
-    const rssCheckIntervalMs = (fastify.config.syncIntervalSeconds || 10) * 1000
+    // Spread out the RSS checks randomly between 1 and 5 minutes - we should be playing nice with the Plex servers
+    const syncIntervalSeconds = fastify.config.syncIntervalSeconds || 10
+    const rssCheckIntervalMs =
+      (6 * syncIntervalSeconds +
+        Math.ceil(Math.random() * 4 * 6 * syncIntervalSeconds)) *
+      1_000
     const queueProcessDelayMs =
       (fastify.config.queueProcessDelaySeconds || 60) * 1000
 

--- a/src/services/watchlist-workflow.service.ts
+++ b/src/services/watchlist-workflow.service.ts
@@ -111,8 +111,10 @@ export class WatchlistWorkflowService {
   constructor(
     private readonly baseLog: FastifyBaseLogger,
     private readonly fastify: FastifyInstance,
-    private readonly rssCheckIntervalMs: number = 10000,
-    private readonly queueProcessDelayMs: number = 60000,
+    // Spread out the RSS checks randomly between 1 and 5 minutes - we should be playing nice with the Plex servers
+    private readonly rssCheckIntervalMs: number = 60_000 +
+      Math.ceil(Math.random() * 240_000),
+    private readonly queueProcessDelayMs: number = 60_000,
   ) {
     this.log.info('Initializing Watchlist Workflow Service')
   }


### PR DESCRIPTION
## Description

The current logic of fetching RSS feeds is too aggressive in terms of the interval used (defaults to 10 seconds).

Let's be more considerate with the Plex backend servers :sweat_smile: 

I know that changing the value in `src/plugins/custom/watchlist-workflow.ts` is probably not the best place, but I want to change the behavior of all the existing installations which already have `syncIntervalSeconds` set to 10 seconds in their DB. I'm open to better suggestions on how to transition _ALL_ installations to a larger interval.

Also, there should be a random factor added to the interval of continuously requested data.

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Performance improvement

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality