### PR TITLE
fix: Remove cache buster from RSS requests

### DIFF
--- a/src/utils/plex/rss.ts
+++ b/src/utils/plex/rss.ts
@@ -114,10 +114,6 @@ export const fetchWatchlistFromRss = async (
   try {
     const urlObj = new URL(url)
     urlObj.searchParams.append('format', 'json')
-    urlObj.searchParams.append(
-      'cache_buster',
-      Math.random().toString(36).substring(2, 14),
-    )
 
     const response = await fetch(urlObj.toString(), {
       headers: {


### PR DESCRIPTION
## Description

This type of cache invalidation is no longer supported by the Plex backend.

## Related Issues

Related to #762

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Performance improvement

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RSS feed loading performance and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->