### PR TITLE
fix: Slower watchlist requests

### DIFF
--- a/src/utils/plex/watchlist-api.ts
+++ b/src/utils/plex/watchlist-api.ts
@@ -88,7 +88,7 @@ export const getWatchlist = async (
   // Wait if we're already rate limited before making any API call
   await rateLimiter.waitIfLimited(log, progressInfo)
 
-  const containerSize = 300
+  const containerSize = 100
   const url = new URL(
     'https://discover.provider.plex.tv/library/sections/watchlist/all',
   )
@@ -384,6 +384,9 @@ export const getWatchlistForUser = async (
       }
 
       if (watchlist.pageInfo.hasNextPage && watchlist.pageInfo.endCursor) {
+        // We should be playing nice with the Plex servers
+        await new Promise((resolve) => setTimeout(resolve, 5_000 + Math.ceil(Math.random() * 10_000)))
+
         const nextPageItems = await getWatchlistForUser(
           config,
           log,

--- a/src/utils/plex/watchlist-fetcher.ts
+++ b/src/utils/plex/watchlist-fetcher.ts
@@ -103,6 +103,9 @@ export const fetchSelfWatchlist = async (
           throw innerError
         }
       }
+
+      // We should be playing nice with the Plex servers
+      await new Promise((resolve) => setTimeout(resolve, 5_000 + Math.ceil(Math.random() * 10_000)))
     } catch (err) {
       log.error({ error: err }, 'Error fetching watchlist for token')
 
@@ -178,7 +181,7 @@ export const getOthersWatchlist = async (
   log.info(`Starting fetch of watchlists for ${friends.size} friends`)
 
   // Simple concurrency pool implementation
-  const MAX_CONCURRENT = 4 // Maximum number of concurrent friend fetches
+  const MAX_CONCURRENT = 2 // Maximum number of concurrent friend fetches
   const friendsArray = Array.from(friends)
   const results: Array<{
     user: Friend & { userId: number }
@@ -233,7 +236,7 @@ export const getOthersWatchlist = async (
 
     // Introduce a small delay between batches to avoid rate limits
     if (i + MAX_CONCURRENT < friendsArray.length) {
-      await new Promise((resolve) => setTimeout(resolve, 500))
+      await new Promise((resolve) => setTimeout(resolve, 1_000 + Math.ceil(Math.random() * 4_000)))
     }
   }
 

--- a/test/unit/utils/plex/watchlist-api.test.ts
+++ b/test/unit/utils/plex/watchlist-api.test.ts
@@ -123,7 +123,7 @@ describe('plex/watchlist-api', () => {
       await getWatchlist('token', mockLogger, 100)
 
       expect(capturedParams?.get('X-Plex-Container-Start')).toBe('100')
-      expect(capturedParams?.get('X-Plex-Container-Size')).toBe('300')
+      expect(capturedParams?.get('X-Plex-Container-Size')).toBe('100')
     })
 
     it('should include correct headers in request', async () => {


### PR DESCRIPTION
## Description

- Reduce the container size parameter to 100 (it will be enforced soon upstream)
- Pause with random times between watchlist pagination requests
- Reduce parallel friends watchlist fetch to 2 (from 4)

## Type of Change

- [x] Performance improvement

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted watchlist batch processing to optimize data retrieval
  * Enhanced request throttling for improved system stability
  * Refined concurrent request handling for better resource efficiency

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->