### PR TITLE
fix(apprise): override Telegram schema format to text for compatibility

### DIFF
--- a/src/services/notifications/channels/apprise-format-cache.ts
+++ b/src/services/notifications/channels/apprise-format-cache.ts
@@ -83,6 +83,9 @@ export async function fetchSchemaFormats(
  * Telegram reports as HTML-native via Apprise /details, but only supports a tiny
  * subset of HTML tags (<b>, <i>, <a>, <code>, <pre>). Full HTML with <div>, <p>,
  * <hr>, etc. causes Telegram API errors. Force text format for these schemas.
+ *
+ * Add entries here if other services exhibit similar format misreporting issues.
+ * The override takes precedence over the format reported by Apprise /details.
  */
 const SCHEMA_FORMAT_OVERRIDES: Record<string, 'text' | 'html' | 'markdown'> = {
   tgram: 'text',


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved notification format handling so certain channels (e.g., Telegram) consistently use their native text format.
* **Bug Fixes**
  * Formatting selection more reliably applies channel-specific formats before falling back to defaults, reducing incorrect message rendering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->