### PR TITLE
fix(apprise): exclude attachments for email services

### DIFF
--- a/src/types/apprise.types.ts
+++ b/src/types/apprise.types.ts
@@ -35,15 +35,19 @@ export interface AppriseUrlFormatInfo {
   url: string
   schema: string
   format: AppriseNotifyFormat
+  /** Whether this service displays attachments inline (false for email services) */
+  supportsInlineAttachment: boolean
 }
 
 /**
- * Batch of URLs grouped by format for sending.
+ * Batch of URLs grouped by format and attachment support for sending.
  */
 export interface AppriseNotificationBatch {
   urls: string[]
   body: string
   format: 'text' | 'html'
+  /** Whether to include attachment field for this batch */
+  includeAttachment: boolean
 }
 
 export interface AppriseNotification {


### PR DESCRIPTION
- Add EMAIL_SCHEMAS set to identify email notification services
- Extend notification batching to group by attachment support
- Exclude attachment field for email services (images render via HTML)
- Prevents redundant file attachments in email notifications

## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced attachment handling across notification channels with improved support for services that don't support inline attachments
  * Notifications are now intelligently batched based on format and attachment delivery capabilities for better compatibility

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->