### PR TITLE
fix(approvals): use DELETE method for bulk delete mutation

### DIFF
--- a/src/client/features/approvals/hooks/useApprovalMutations.ts
+++ b/src/client/features/approvals/hooks/useApprovalMutations.ts
@@ -192,7 +192,7 @@ export function useBulkReject() {
 export function useBulkDelete() {
   return useAppMutation<BulkOperationResponse, Error, BulkDeleteRequest>({
     mutationFn: async (params) => {
-      return apiClient.post(
+      return apiClient.deleteWithBody(
         '/v1/approval/requests/bulk/delete',
         params,
         BulkOperationResponseSchema,

--- a/src/client/lib/apiClient.ts
+++ b/src/client/lib/apiClient.ts
@@ -119,4 +119,15 @@ export const apiClient = {
     fetch(api(path), { method: 'DELETE' }).then((r) =>
       handleResponse<T>(r, schema),
     ),
+
+  deleteWithBody: <T>(
+    path: string,
+    body: unknown,
+    schema?: z.ZodType<T>,
+  ): Promise<T> =>
+    fetch(api(path), {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }).then((r) => handleResponse<T>(r, schema)),
 }


### PR DESCRIPTION
- Add deleteWithBody method to apiClient for DELETE requests with body
- Update useBulkDelete hook to use deleteWithBody instead of post
- Fixes "resource not found" error introduced during React Query migration

## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated bulk delete operation to use DELETE HTTP method with request body support
  * Added new API capability for DELETE requests that include JSON-encoded bodies in the API client

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->