### PR TITLE
feat(logging): use local timezone with date in log timestamps

### DIFF
--- a/src/client/features/utilities/pages/log-viewer.tsx
+++ b/src/client/features/utilities/pages/log-viewer.tsx
@@ -56,11 +56,12 @@ const LOG_LEVEL_COLORS: Record<string, string> = {
   FATAL: 'text-white bg-red-500 px-0.5 rounded-sm', // bgRed
 }
 
-// Regex to match pino-pretty format: [HH:MM:ss TZ] LEVEL: [MODULE] message
+// Regex to match pino-pretty format: [yyyy-mm-dd HH:MM:ss TZ] LEVEL: [MODULE] message
 // Groups: 1=timestamp, 2=level, 3=colon, 4=rest (module + message)
 // Case-insensitive to match backend LOG_LEVEL_REGEX
+// Flexible timestamp matching to support various formats (with/without date, timezone)
 const LOG_LINE_REGEX =
-  /^(\[[\d:]+\s+\w+\])\s*(TRACE|DEBUG|INFO|WARN|ERROR|FATAL)(:)\s*(.*)/i
+  /^(\[[^\]]+\])\s*(TRACE|DEBUG|INFO|WARN|ERROR|FATAL)(:)\s*(.*)/i
 
 // Regex to extract module name like [PLEX_SESSION_MONITOR] from message
 // Includes digits to support names like [PLEX2]

--- a/src/services/log-streaming.service.ts
+++ b/src/services/log-streaming.service.ts
@@ -165,7 +165,7 @@ export class LogStreamingService {
     }
   }
 
-  // Regex to match pino-pretty format: [HH:MM:ss TZ] LEVEL: message
+  // Regex to extract log level from pino-pretty format: [timestamp] LEVEL: message
   // Captures the level name after ] and before :
   private static readonly LOG_LEVEL_REGEX =
     /]\s*(TRACE|DEBUG|INFO|WARN|ERROR|FATAL):/i

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -231,7 +231,7 @@ function getTerminalOptions(): LoggerOptions {
     transport: {
       target: 'pino-pretty',
       options: {
-        translateTime: 'HH:MM:ss Z',
+        translateTime: 'SYS:yyyy-mm-dd HH:MM:ss Z',
         ignore: 'pid,hostname',
         colorize: true, // Force colors even in Docker
       },
@@ -256,7 +256,7 @@ function getFileOptions(): FileLoggerOptions {
 
   // Create a pretty stream for file output (no colors)
   const prettyFileStream = pretty({
-    translateTime: 'HH:MM:ss Z',
+    translateTime: 'SYS:yyyy-mm-dd HH:MM:ss Z',
     ignore: 'pid,hostname',
     colorize: false, // No colors for file output
     destination: fileStream,
@@ -332,14 +332,14 @@ export function createLoggerConfig(): PulsarrLoggerOptions {
 
     // Create a proper pretty stream for terminal output
     const prettyStream = pretty({
-      translateTime: 'HH:MM:ss Z',
+      translateTime: 'SYS:yyyy-mm-dd HH:MM:ss Z',
       ignore: 'pid,hostname',
       colorize: true, // Force colors even in Docker
     })
 
     // Create a pretty stream for file output (no colors)
     const prettyFileStream = pretty({
-      translateTime: 'HH:MM:ss Z',
+      translateTime: 'SYS:yyyy-mm-dd HH:MM:ss Z',
       ignore: 'pid,hostname',
       colorize: false, // No colors for file output
       destination: fileStream,


### PR DESCRIPTION
- Change pino-pretty translateTime from UTC to system timezone
- Add date to timestamp format: [yyyy-mm-dd HH:MM:ss TZ]
- Update log viewer regex to handle flexible timestamp formats
- Update log streaming service comment for accuracy

## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Performance improvement
- [x] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated log timestamp format to include full dates alongside time for improved traceability and better correlation of logs across different sessions and time periods.
  * Enhanced log parsing to be more permissive, allowing it to handle a wider variety of timestamp formats and configurations for increased compatibility and flexibility in various logging scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->