### PR TITLE
feat(build): add Windows x64 baseline native build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -220,6 +220,72 @@ jobs:
             scripts/installers/windows/Output/*.exe \
             --clobber
 
+  build-windows-baseline-installer:
+    needs: release
+    runs-on: windows-latest
+    # Run after release job succeeds, or run standalone when manually triggered
+    if: ${{ always() && (needs.release.result == 'success' || github.event_name == 'workflow_dispatch') }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Get version
+        id: version
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          if [ "$EVENT_NAME" == "workflow_dispatch" ]; then
+            VERSION="$INPUT_TAG"
+          else
+            VERSION="${GITHUB_REF#refs/tags/}"
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "version_number=${VERSION#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Download Windows baseline zip from release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          gh release download "$RELEASE_VERSION" \
+            --pattern "*windows-x64-baseline.zip" \
+            --dir scripts/installers/windows
+
+      - name: Extract zip
+        shell: pwsh
+        run: |
+          $zip = Get-ChildItem scripts/installers/windows/*.zip | Select-Object -First 1
+          Expand-Archive -Path $zip.FullName -DestinationPath scripts/installers/windows/extracted
+          # Move contents from nested folder to build/
+          $nested = Get-ChildItem scripts/installers/windows/extracted | Select-Object -First 1
+          New-Item -ItemType Directory -Force -Path scripts/installers/windows/build
+          Move-Item "$($nested.FullName)/*" scripts/installers/windows/build/
+          Remove-Item scripts/installers/windows/extracted -Recurse
+          Remove-Item $zip.FullName
+
+      - name: Build installer with Inno Setup
+        shell: pwsh
+        env:
+          APP_VERSION: ${{ steps.version.outputs.version_number }}
+        run: |
+          # Inno Setup is pre-installed on windows-latest
+          & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" `
+            /DMyAppVersion=$env:APP_VERSION `
+            scripts/installers/windows/pulsarr-baseline.iss
+
+      - name: Upload installer to release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          gh release upload "$RELEASE_VERSION" \
+            scripts/installers/windows/Output/*.exe \
+            --clobber
+
   build-macos-installer:
     needs: release
     runs-on: macos-latest

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Standalone builds with easy installers are available for Linux, macOS, and Windo
 | Platform | Install Method |
 |----------|---------------|
 | **Linux** | `curl -fsSL https://raw.githubusercontent.com/jamcalli/Pulsarr/master/scripts/installers/linux/install.sh \| sudo bash` |
-| **Windows** | Download and run `pulsarr-vX.X.X-windows-x64-setup.exe` from the [latest release](https://github.com/jamcalli/pulsarr/releases/latest) |
+| **Windows** | Download and run `pulsarr-vX.X.X-windows-x64-setup.exe` from the [latest release](https://github.com/jamcalli/pulsarr/releases/latest) (use `baseline` variant for older CPUs without AVX2) |
 | **macOS** | Download `pulsarr-vX.X.X-macos-{arch}.dmg` from the [latest release](https://github.com/jamcalli/pulsarr/releases/latest) |
 
 See the [Native Installation Guide](https://jamcalli.github.io/Pulsarr/docs/installation/native-installation) for detailed instructions, service management, and manual options.

--- a/docs/docs/installation/native-installation.md
+++ b/docs/docs/installation/native-installation.md
@@ -76,7 +76,9 @@ curl -fsSL https://raw.githubusercontent.com/jamcalli/Pulsarr/master/scripts/ins
 
 ### Installer (Recommended)
 
-1. Download `pulsarr-vX.X.X-windows-x64-setup.exe` from the [latest release](https://github.com/jamcalli/Pulsarr/releases/latest)
+1. Download the installer from the [latest release](https://github.com/jamcalli/Pulsarr/releases/latest):
+   - **Most systems:** `pulsarr-vX.X.X-windows-x64-setup.exe`
+   - **Older CPUs without AVX2:** `pulsarr-vX.X.X-windows-x64-baseline-setup.exe` (pre-Haswell Intel or pre-Excavator AMD)
 
 2. Run the installer
    :::note SmartScreen Warning
@@ -212,6 +214,7 @@ For users who prefer full control, standalone zip files are available for each p
    - `pulsarr-vX.X.X-macos-x64.zip`
    - `pulsarr-vX.X.X-macos-arm64.zip`
    - `pulsarr-vX.X.X-windows-x64.zip`
+   - `pulsarr-vX.X.X-windows-x64-baseline.zip` (older CPUs without AVX2)
 
 2. Extract the zip to your desired location
 

--- a/docs/docs/installation/quick-start.md
+++ b/docs/docs/installation/quick-start.md
@@ -127,7 +127,7 @@ Standalone builds with easy installers are available for Linux, macOS, and Windo
 | Platform | Recommended Method |
 |----------|-------------------|
 | **Linux** | One-line installer: `curl -fsSL https://raw.githubusercontent.com/jamcalli/Pulsarr/master/scripts/installers/linux/install.sh \| sudo bash` |
-| **Windows** | Download and run `pulsarr-vX.X.X-windows-x64-setup.exe` |
+| **Windows** | Download and run `pulsarr-vX.X.X-windows-x64-setup.exe` (or `baseline` variant for older CPUs without AVX2) |
 | **macOS** | Download `pulsarr-vX.X.X-macos-{arch}.dmg` and drag Pulsarr to Applications |
 
 See the [Native Installation Guide](./native-installation) for detailed instructions, service management, and manual installation options.

--- a/scripts/build-native.ts
+++ b/scripts/build-native.ts
@@ -80,6 +80,12 @@ const PLATFORMS: Platform[] = [
     bunBinary: 'bun.exe',
     zipSuffix: 'windows-x64',
   },
+  {
+    detectName: 'windows-x64-baseline',
+    bunArchive: 'bun-windows-x64-baseline',
+    bunBinary: 'bun.exe',
+    zipSuffix: 'windows-x64-baseline',
+  },
 ]
 
 // --- Helpers ---

--- a/scripts/installers/windows/pulsarr-baseline.iss
+++ b/scripts/installers/windows/pulsarr-baseline.iss
@@ -1,0 +1,182 @@
+; Pulsarr Windows Installer (x64 Baseline - SSE4.2, for older CPUs without AVX2)
+; Built with Inno Setup - https://jrsoftware.org/isinfo.php
+
+#define MyAppName "Pulsarr"
+#define MyAppPublisher "Pulsarr"
+#define MyAppURL "https://github.com/jamcalli/Pulsarr"
+#define MyAppExeName "start.bat"
+#define MyAppDataDir "{commonappdata}\Pulsarr"
+
+; Version is passed from CI: iscc /DMyAppVersion=x.x.x pulsarr-baseline.iss
+#ifndef MyAppVersion
+  #define MyAppVersion "0.0.0"
+#endif
+
+[Setup]
+AppId={{B8A42C5E-7D91-4F8C-B5E3-9A7C6D8E2F10}
+AppName={#MyAppName}
+AppVersion={#MyAppVersion}
+AppVerName={#MyAppName} {#MyAppVersion}
+AppPublisher={#MyAppPublisher}
+AppPublisherURL={#MyAppURL}
+AppSupportURL={#MyAppURL}/issues
+AppUpdatesURL={#MyAppURL}/releases
+DefaultDirName={commonappdata}\{#MyAppName}
+DefaultGroupName={#MyAppName}
+AllowNoIcons=yes
+LicenseFile=license.txt
+OutputDir=Output
+OutputBaseFilename=pulsarr-v{#MyAppVersion}-windows-x64-baseline-setup
+SetupIconFile=pulsarr.ico
+UninstallDisplayIcon={app}\pulsarr.ico
+Compression=lzma2
+SolidCompression=yes
+WizardStyle=modern
+PrivilegesRequired=admin
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+MinVersion=10.0
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Types]
+Name: "full"; Description: "Full installation (with Windows Service)"
+Name: "compact"; Description: "Compact installation (manual start)"
+Name: "custom"; Description: "Custom installation"; Flags: iscustom
+
+[Components]
+Name: "main"; Description: "Pulsarr Application"; Types: full compact custom; Flags: fixed
+Name: "service"; Description: "Install as Windows Service"; Types: full
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+Name: "startafterinstall"; Description: "Start Pulsarr after installation"; GroupDescription: "Startup:"; Flags: checkedonce
+
+[Files]
+; Main application files (from extracted native build zip)
+Source: "build\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs; Components: main
+; Icon for uninstaller
+Source: "pulsarr.ico"; DestDir: "{app}"; Flags: ignoreversion; Components: main
+
+[Dirs]
+; App directory permissions for non-admin user access
+Name: "{app}"; Permissions: users-modify
+; Create data directory with full permissions
+Name: "{#MyAppDataDir}"; Permissions: users-full
+Name: "{#MyAppDataDir}\db"; Permissions: users-full
+Name: "{#MyAppDataDir}\logs"; Permissions: users-full
+
+[Icons]
+Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; WorkingDir: "{app}"
+Name: "{group}\{#MyAppName} Web UI"; Filename: "http://localhost:3003"
+Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"
+Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; WorkingDir: "{app}"; Tasks: desktopicon
+
+[Run]
+; Create .env from template if it doesn't exist
+Filename: "cmd.exe"; Parameters: "/c if not exist ""{#MyAppDataDir}\.env"" copy ""{app}\.env.example"" ""{#MyAppDataDir}\.env"""; Flags: runhidden
+; Install and start service
+Filename: "{app}\pulsarr-service.exe"; Parameters: "install"; StatusMsg: "Installing Windows service..."; Flags: runhidden; Components: service
+Filename: "{app}\pulsarr-service.exe"; Parameters: "start"; StatusMsg: "Starting Pulsarr service..."; Flags: runhidden; Components: service; Tasks: startafterinstall
+; Start manually if not installing service
+Filename: "{app}\{#MyAppExeName}"; Description: "Start {#MyAppName}"; Flags: nowait postinstall skipifsilent shellexec; Tasks: startafterinstall; Components: not service
+
+[UninstallRun]
+; Stop and uninstall service
+Filename: "{app}\pulsarr-service.exe"; Parameters: "stop"; Flags: runhidden; RunOnceId: "StopService"
+Filename: "{app}\pulsarr-service.exe"; Parameters: "uninstall"; Flags: runhidden; RunOnceId: "UninstallService"
+
+[UninstallDelete]
+; Clean up service wrapper logs if any
+Type: files; Name: "{app}\pulsarr-service.wrapper.log"
+Type: files; Name: "{app}\pulsarr-service.out.log"
+Type: files; Name: "{app}\pulsarr-service.err.log"
+
+[Code]
+const
+  CRLF = #13#10;
+
+var
+  DataDirPage: TInputDirWizardPage;
+  DeleteDataCheckbox: TNewCheckBox;
+
+procedure InitializeWizard;
+begin
+  { Add custom page for data directory selection (optional, for advanced users) }
+  { For now, we use the default ProgramData\Pulsarr location }
+end;
+
+function PrepareToInstall(var NeedsRestart: Boolean): String;
+var
+  ResultCode: Integer;
+begin
+  Result := '';
+  { Stop existing service if running }
+  if FileExists(ExpandConstant('{app}\pulsarr-service.exe')) then
+  begin
+    Exec(ExpandConstant('{app}\pulsarr-service.exe'), 'stop', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+  end;
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+var
+  StartBatContent: String;
+  ServiceXmlContent: String;
+  DataDir: String;
+begin
+  if CurStep = ssPostInstall then
+  begin
+    DataDir := ExpandConstant('{#MyAppDataDir}');
+
+    { Create modified start.bat that sets dataDir }
+    StartBatContent := '@echo off' + CRLF + 'cd /d "%~dp0"' + CRLF + CRLF + 'set "dataDir=' + DataDir + '"' + CRLF + CRLF + 'echo Running database migrations...' + CRLF + '.\bun.exe run --bun migrations\migrate.ts' + CRLF + CRLF + 'echo Starting Pulsarr...' + CRLF + '.\bun.exe run --bun dist\server.js %*' + CRLF + CRLF + 'echo.' + CRLF + 'echo Pulsarr has exited (code: %ERRORLEVEL%)' + CRLF + 'if not defined PULSARR_SERVICE pause' + CRLF;
+    SaveStringToFile(ExpandConstant('{app}\start.bat'), StartBatContent, False);
+
+    { Create modified pulsarr-service.xml that sets dataDir }
+    ServiceXmlContent := '<service>' + CRLF + '  <id>pulsarr</id>' + CRLF + '  <name>Pulsarr</name>' + CRLF + '  <description>Plex watchlist tracker and notification center</description>' + CRLF + '  <executable>%BASE%\start.bat</executable>' + CRLF + '  <startmode>Automatic</startmode>' + CRLF + '  <log mode="none"/>' + CRLF + '  <stopparentprocessfirst>true</stopparentprocessfirst>' + CRLF + '  <env name="PULSARR_SERVICE" value="1"/>' + CRLF + '  <env name="dataDir" value="' + DataDir + '"/>' + CRLF + '  <onfailure action="restart" delay="10 sec"/>' + CRLF + '  <onfailure action="restart" delay="30 sec"/>' + CRLF + '  <resetfailure>1 hour</resetfailure>' + CRLF + '</service>' + CRLF;
+    SaveStringToFile(ExpandConstant('{app}\pulsarr-service.xml'), ServiceXmlContent, False);
+  end;
+end;
+
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+var
+  DataDir: String;
+  MsgResult: Integer;
+begin
+  if CurUninstallStep = usPostUninstall then
+  begin
+    DataDir := ExpandConstant('{#MyAppDataDir}');
+    if DirExists(DataDir) then
+    begin
+      MsgResult := MsgBox('Do you want to delete all Pulsarr data?' + CRLF + CRLF + 'This includes your configuration (.env) and database.' + CRLF + 'Location: ' + DataDir, mbConfirmation, MB_YESNO);
+      if MsgResult = IDYES then
+      begin
+        DelTree(DataDir, True, True, True);
+      end;
+    end;
+  end;
+end;
+
+function UpdateReadyMemo(Space, NewLine, MemoUserInfoInfo, MemoDirInfo, MemoTypeInfo, MemoComponentsInfo, MemoGroupInfo, MemoTasksInfo: String): String;
+var
+  S: String;
+begin
+  S := '';
+
+  if MemoDirInfo <> '' then
+    S := S + MemoDirInfo + NewLine + NewLine;
+
+  S := S + 'Data Directory:' + NewLine + Space + ExpandConstant('{#MyAppDataDir}') + NewLine + NewLine;
+
+  if MemoComponentsInfo <> '' then
+    S := S + MemoComponentsInfo + NewLine + NewLine;
+
+  if MemoGroupInfo <> '' then
+    S := S + MemoGroupInfo + NewLine + NewLine;
+
+  if MemoTasksInfo <> '' then
+    S := S + MemoTasksInfo + NewLine;
+
+  Result := S;
+end;


### PR DESCRIPTION
- Add windows-x64-baseline platform to build script
- Add Inno Setup installer script for baseline variant
- Add CI job to build and upload baseline installer
- Update docs to reference baseline builds for older CPUs

## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a baseline variant of the Windows installer designed for systems with older CPUs lacking AVX2 instruction set support, expanding compatibility with legacy hardware.

* **Documentation**
  * Updated Windows installation guide to recommend the baseline variant for users with older CPUs without AVX2 support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->