### PR TITLE
fix(services): prevent webhook queue race condition and approval stuc…

### DIFF
--- a/src/services/webhook-queue/batching/queue-manager.ts
+++ b/src/services/webhook-queue/batching/queue-manager.ts
@@ -154,6 +154,15 @@ export async function addEpisodeToQueue(
     deps,
   )
 
+  // Guard: queue may have been cleaned up by timeout during async ensureSeasonQueue
+  if (!queue[tvdbId]?.seasons[seasonNumber]) {
+    logger.warn(
+      { tvdbId, seasonNumber },
+      'Season queue was cleaned up during initialization, skipping episode',
+    )
+    return
+  }
+
   // Check for duplicate
   if (
     isEpisodeAlreadyQueued(tvdbId, seasonNumber, episode.episodeNumber, queue)
@@ -226,6 +235,15 @@ export async function addEpisodesToQueue(
     instanceId,
     deps,
   )
+
+  // Guard: queue may have been cleaned up by timeout during async ensureSeasonQueue
+  if (!queue[tvdbId]?.seasons[seasonNumber]) {
+    logger.warn(
+      { tvdbId, seasonNumber },
+      'Season queue was cleaned up during initialization, skipping episodes',
+    )
+    return
+  }
 
   // Filter out duplicates
   const newEpisodes = episodes.filter(


### PR DESCRIPTION
…k pending

- Add defensive guard in addEpisodeToQueue/addEpisodesToQueue after async ensureSeasonQueue to prevent crash when timeout cleans up queue during slow Sonarr API calls
- Treat Sonarr/Radarr "already been added" errors as successful routing in approval service instead of rolling back to pending forever

## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Approvals now succeed when content already exists in Radarr or Sonarr, preventing false failures.
  * Added defensive checks to skip processing when episode queue entries are unexpectedly cleaned up, avoiding errors and logging a warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->