### PR TITLE
perf(services): use /episode endpoint for season completion detection

### DIFF
--- a/src/schemas/notifications/webhook.schema.ts
+++ b/src/schemas/notifications/webhook.schema.ts
@@ -24,6 +24,7 @@ export const SonarrEpisodeSchema = z.object({
 })
 
 export const SonarrSeriesSchema = z.object({
+  id: z.number().optional(),
   title: z.string(),
   tvdbId: z.number(),
   tags: z.array(z.string()).optional(),

--- a/src/services/sonarr-manager.service.ts
+++ b/src/services/sonarr-manager.service.ts
@@ -446,6 +446,27 @@ export class SonarrManagerService {
   }
 
   /**
+   * Get the episode count for a specific season from a specific instance.
+   * Uses the fast /episode endpoint instead of the slow /series endpoint.
+   */
+  async getSeasonEpisodeCount(
+    instanceId: number,
+    seriesId: number,
+    seasonNumber: number,
+  ): Promise<number | null> {
+    const sonarrService = this.sonarrServices.get(instanceId)
+    if (!sonarrService) {
+      this.log.warn(
+        { instanceId, seriesId, seasonNumber },
+        'Sonarr instance not found for episode count lookup',
+      )
+      return null
+    }
+
+    return sonarrService.getSeasonEpisodeCount(seriesId, seasonNumber)
+  }
+
+  /**
    * Get full series data by TVDB ID from any available instance
    * Tries each instance until one returns data
    * @param tvdbId - The TVDB ID to look up

--- a/src/services/sonarr.service.ts
+++ b/src/services/sonarr.service.ts
@@ -1852,6 +1852,29 @@ export class SonarrService {
   }
 
   /**
+   * Get the episode count for a specific season using the fast episode endpoint.
+   * Uses /episode?seriesId=X&seasonNumber=Y which is a direct indexed query,
+   * avoiding the expensive statistics computation of the /series endpoint.
+   */
+  async getSeasonEpisodeCount(
+    seriesId: number,
+    seasonNumber: number,
+  ): Promise<number | null> {
+    try {
+      const episodes = await this.getFromSonarr<SonarrEpisode[]>(
+        `episode?seriesId=${seriesId}&seasonNumber=${seasonNumber}`,
+      )
+      return episodes.length
+    } catch (err) {
+      this.log.error(
+        { error: err, seriesId, seasonNumber },
+        'Error fetching season episode count',
+      )
+      return null
+    }
+  }
+
+  /**
    * Update monitoring for specific episodes
    * @param episodes Array of episode updates with id and monitored status
    */

--- a/src/services/webhook-queue.service.ts
+++ b/src/services/webhook-queue.service.ts
@@ -108,8 +108,12 @@ export class WebhookQueueService {
     return {
       logger: this.log,
       queue: this._queue,
-      getSeriesByTvdbId: (tvdbId) =>
-        this.fastify.sonarrManager.getSeriesByTvdbIdFromAny(tvdbId),
+      getSeasonEpisodeCount: (instanceId, seriesId, seasonNumber) =>
+        this.fastify.sonarrManager.getSeasonEpisodeCount(
+          instanceId,
+          seriesId,
+          seasonNumber,
+        ),
     }
   }
 
@@ -386,7 +390,13 @@ export class WebhookQueueService {
       'Processing individual episode completion',
     )
 
-    ensureShowQueue(tvdbId, body.series.title, this._queue, this.log)
+    ensureShowQueue(
+      tvdbId,
+      body.series.title,
+      this._queue,
+      this.log,
+      body.series.id,
+    )
 
     // Recent episode - notify immediately
     if (this.isRecentEpisode(episode.airDateUtc)) {
@@ -416,7 +426,13 @@ export class WebhookQueueService {
     seasonNumber: number,
     instance: SonarrInstance | null,
   ): Promise<void> {
-    ensureShowQueue(tvdbId, body.series.title, this._queue, this.log)
+    ensureShowQueue(
+      tvdbId,
+      body.series.title,
+      this._queue,
+      this.log,
+      body.series.id,
+    )
 
     // Split recent vs non-recent
     const recentEpisodes = body.episodes.filter((ep) =>

--- a/src/services/webhook-queue/batching/queue-manager.ts
+++ b/src/services/webhook-queue/batching/queue-manager.ts
@@ -77,10 +77,19 @@ export function ensureShowQueue(
   title: string,
   queue: WebhookQueue,
   logger: FastifyBaseLogger,
+  sonarrSeriesId?: number,
 ): void {
   if (!queue[tvdbId]) {
-    logger.debug({ tvdbId }, 'Initializing webhook queue for show')
-    queue[tvdbId] = { seasons: {}, title }
+    logger.debug(
+      { tvdbId, sonarrSeriesId },
+      'Initializing webhook queue for show',
+    )
+    queue[tvdbId] = { seasons: {}, title, sonarrSeriesId }
+  } else if (
+    sonarrSeriesId !== undefined &&
+    queue[tvdbId].sonarrSeriesId === undefined
+  ) {
+    queue[tvdbId].sonarrSeriesId = sonarrSeriesId
   }
 }
 

--- a/src/types/webhook.types.ts
+++ b/src/types/webhook.types.ts
@@ -37,5 +37,6 @@ export interface WebhookQueue {
       [seasonNumber: number]: SeasonQueue
     }
     title: string
+    sonarrSeriesId?: number
   }
 }


### PR DESCRIPTION
- Replace /series?tvdbId=X with /episode?seriesId=X&seasonNumber=Y for episode count lookup
- Capture series.id from webhook payload to target the specific Sonarr instance directly

## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Performance improvement
- [x] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added season episode count retrieval capability to improve data handling.

* **Refactor**
  * Optimized season data fetching by replacing full series lookups with targeted episode count queries.
  * Enhanced webhook queue system to track and propagate series identifiers throughout processing workflows.
  * Extended schema to support optional series ID field in webhooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->