### PR TITLE
fix(log-viewer): use platform-aware path resolution on native installs

### DIFF
--- a/src/services/log-streaming.service.ts
+++ b/src/services/log-streaming.service.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'node:events'
 import { open, stat } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import type { LogEntry, LogLevel } from '@schemas/logs/logs.schema.js'
+import { resolveLogPath } from '@utils/data-dir.js'
 import { createServiceLogger } from '@utils/logger.js'
 import type { FastifyBaseLogger, FastifyInstance } from 'fastify'
 
@@ -32,12 +33,7 @@ export class LogStreamingService {
     this.eventEmitter = new EventEmitter()
     // Allow many concurrent SSE consumers without warnings
     this.eventEmitter.setMaxListeners(100)
-    this.logFilePath = resolve(
-      process.cwd(),
-      'data',
-      'logs',
-      'pulsarr-current.log',
-    )
+    this.logFilePath = resolve(resolveLogPath(), 'pulsarr-current.log')
   }
 
   static getInstance(

--- a/src/services/tag-migration.service.ts
+++ b/src/services/tag-migration.service.ts
@@ -18,14 +18,13 @@
  */
 
 import { readFile, unlink } from 'node:fs/promises'
-import { dirname, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
-import { resolveDataDir } from '@utils/data-dir.js'
+import { resolve } from 'node:path'
+import type { CleanupOrphanedRefsResponse } from '@root/schemas/tags/user-tags.schema.js'
+import { projectRoot, resolveDataDir } from '@utils/data-dir.js'
+import { createServiceLogger } from '@utils/logger.js'
+import { normalizeTagLabel } from '@utils/tag-normalization.js'
+import type { FastifyBaseLogger, FastifyInstance } from 'fastify'
 
-// Path resolution following the same pattern as logger.ts and knexfile.ts
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-const projectRoot = resolve(__dirname, '../..')
 const dataDir = resolveDataDir()
 
 /**
@@ -37,11 +36,6 @@ function getMigrationFilePath(): string {
   const baseDir = dataDir ?? resolve(projectRoot, 'data')
   return resolve(baseDir, '.pulsarr-tag-migration.json')
 }
-
-import type { CleanupOrphanedRefsResponse } from '@root/schemas/tags/user-tags.schema.js'
-import { createServiceLogger } from '@utils/logger.js'
-import { normalizeTagLabel } from '@utils/tag-normalization.js'
-import type { FastifyBaseLogger, FastifyInstance } from 'fastify'
 
 /**
  * Tag structure returned from Sonarr/Radarr APIs

--- a/src/utils/data-dir.ts
+++ b/src/utils/data-dir.ts
@@ -1,4 +1,10 @@
-import { resolve } from 'node:path'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+export const projectRoot = resolve(__dirname, '..', '..')
 
 /**
  * Resolves the Pulsarr data directory based on platform and environment.
@@ -36,7 +42,7 @@ export function resolveDataDir(): string | null {
  * With a data dir: {dataDir}/db
  * Without (Linux/Docker): {projectRoot}/data/db
  */
-export function resolveDbPath(projectRoot: string): string {
+export function resolveDbPath(): string {
   const dataDir = resolveDataDir()
   return dataDir ? resolve(dataDir, 'db') : resolve(projectRoot, 'data', 'db')
 }
@@ -46,7 +52,7 @@ export function resolveDbPath(projectRoot: string): string {
  * With a data dir: {dataDir}/logs
  * Without (Linux/Docker): {projectRoot}/data/logs
  */
-export function resolveLogPath(projectRoot: string): string {
+export function resolveLogPath(): string {
   const dataDir = resolveDataDir()
   return dataDir
     ? resolve(dataDir, 'logs')
@@ -58,7 +64,7 @@ export function resolveLogPath(projectRoot: string): string {
  * With a data dir: {dataDir}/.env
  * Without (Linux/Docker): {projectRoot}/.env
  */
-export function resolveEnvPath(projectRoot: string): string {
+export function resolveEnvPath(): string {
   const dataDir = resolveDataDir()
   return dataDir ? resolve(dataDir, '.env') : resolve(projectRoot, '.env')
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,6 +1,4 @@
 import fs from 'node:fs'
-import { dirname, resolve } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { resolveEnvPath, resolveLogPath } from '@utils/data-dir.js'
 import { config } from 'dotenv'
 import type { FastifyBaseLogger, FastifyRequest } from 'fastify'
@@ -37,14 +35,10 @@ type PulsarrLoggerOptions =
   | FileLoggerOptions
   | MultiStreamLoggerOptions
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-const projectRoot = resolve(__dirname, '..', '..')
-
 // Load .env file early for logger configuration
 // Resolve data directory deterministically from platform (Windows/macOS)
 // or fall back to project-relative paths (Linux/Docker)
-config({ path: resolveEnvPath(projectRoot), quiet: true })
+config({ path: resolveEnvPath(), quiet: true })
 
 /**
  * Creates a custom error serializer that handles both standard errors and custom HttpError objects.
@@ -197,7 +191,7 @@ function filename(time: number | Date | null, index?: number): string {
  * @returns A rotating file stream for logs, or {@link process.stdout} if setup fails.
  */
 function getFileStream(): rfs.RotatingFileStream | NodeJS.WriteStream {
-  const logDirectory = resolveLogPath(projectRoot)
+  const logDirectory = resolveLogPath()
   try {
     if (!fs.existsSync(logDirectory)) {
       fs.mkdirSync(logDirectory, { recursive: true })

--- a/test/unit/utils/data-dir.test.ts
+++ b/test/unit/utils/data-dir.test.ts
@@ -1,12 +1,18 @@
 import { resolve } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  projectRoot,
+  resolveDataDir,
+  resolveDbPath,
+  resolveEnvPath,
+  resolveLogPath,
+} from '@utils/data-dir.js'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 describe('data-dir', () => {
   const originalPlatform = process.platform
   const originalEnv = { ...process.env }
 
   beforeEach(() => {
-    vi.resetModules()
     // Clear relevant env vars
     delete process.env.dataDir
     delete process.env.PROGRAMDATA
@@ -19,99 +25,84 @@ describe('data-dir', () => {
   })
 
   describe('resolveDataDir', () => {
-    it('should return dataDir env var when set', async () => {
+    it('should return dataDir env var when set', () => {
       process.env.dataDir = '/custom/data'
-      const { resolveDataDir } = await import('@utils/data-dir.js')
       expect(resolveDataDir()).toBe('/custom/data')
     })
 
-    it('should return PROGRAMDATA path on win32', async () => {
+    it('should return PROGRAMDATA path on win32', () => {
       Object.defineProperty(process, 'platform', { value: 'win32' })
       process.env.PROGRAMDATA = 'C:\\ProgramData'
-      const { resolveDataDir } = await import('@utils/data-dir.js')
       expect(resolveDataDir()).toBe(resolve('C:\\ProgramData', 'Pulsarr'))
     })
 
-    it('should fall back to ALLUSERSPROFILE on win32 when PROGRAMDATA is missing', async () => {
+    it('should fall back to ALLUSERSPROFILE on win32 when PROGRAMDATA is missing', () => {
       Object.defineProperty(process, 'platform', { value: 'win32' })
       delete process.env.PROGRAMDATA
       process.env.ALLUSERSPROFILE = 'C:\\ProgramData'
-      const { resolveDataDir } = await import('@utils/data-dir.js')
       expect(resolveDataDir()).toBe(resolve('C:\\ProgramData', 'Pulsarr'))
     })
 
-    it('should return null on win32 when no program data env vars', async () => {
+    it('should return null on win32 when no program data env vars', () => {
       Object.defineProperty(process, 'platform', { value: 'win32' })
       delete process.env.PROGRAMDATA
       delete process.env.ALLUSERSPROFILE
-      const { resolveDataDir } = await import('@utils/data-dir.js')
       expect(resolveDataDir()).toBeNull()
     })
 
-    it('should return HOME/.config/Pulsarr on darwin', async () => {
+    it('should return HOME/.config/Pulsarr on darwin', () => {
       Object.defineProperty(process, 'platform', { value: 'darwin' })
       process.env.HOME = '/Users/testuser'
-      const { resolveDataDir } = await import('@utils/data-dir.js')
       expect(resolveDataDir()).toBe(
         resolve('/Users/testuser', '.config', 'Pulsarr'),
       )
     })
 
-    it('should return null on darwin when HOME is missing', async () => {
+    it('should return null on darwin when HOME is missing', () => {
       Object.defineProperty(process, 'platform', { value: 'darwin' })
       delete process.env.HOME
-      const { resolveDataDir } = await import('@utils/data-dir.js')
       expect(resolveDataDir()).toBeNull()
     })
 
-    it('should return null on linux', async () => {
+    it('should return null on linux', () => {
       Object.defineProperty(process, 'platform', { value: 'linux' })
-      const { resolveDataDir } = await import('@utils/data-dir.js')
       expect(resolveDataDir()).toBeNull()
     })
   })
 
   describe('resolveDbPath', () => {
-    it('should use dataDir when available', async () => {
+    it('should use dataDir when available', () => {
       process.env.dataDir = '/custom/data'
-      const { resolveDbPath } = await import('@utils/data-dir.js')
-      expect(resolveDbPath('/project')).toBe(resolve('/custom/data', 'db'))
+      expect(resolveDbPath()).toBe(resolve('/custom/data', 'db'))
     })
 
-    it('should fall back to project-relative path', async () => {
+    it('should fall back to project-relative path', () => {
       Object.defineProperty(process, 'platform', { value: 'linux' })
-      const { resolveDbPath } = await import('@utils/data-dir.js')
-      expect(resolveDbPath('/project')).toBe(resolve('/project', 'data', 'db'))
+      expect(resolveDbPath()).toBe(resolve(projectRoot, 'data', 'db'))
     })
   })
 
   describe('resolveLogPath', () => {
-    it('should use dataDir when available', async () => {
+    it('should use dataDir when available', () => {
       process.env.dataDir = '/custom/data'
-      const { resolveLogPath } = await import('@utils/data-dir.js')
-      expect(resolveLogPath('/project')).toBe(resolve('/custom/data', 'logs'))
+      expect(resolveLogPath()).toBe(resolve('/custom/data', 'logs'))
     })
 
-    it('should fall back to project-relative path', async () => {
+    it('should fall back to project-relative path', () => {
       Object.defineProperty(process, 'platform', { value: 'linux' })
-      const { resolveLogPath } = await import('@utils/data-dir.js')
-      expect(resolveLogPath('/project')).toBe(
-        resolve('/project', 'data', 'logs'),
-      )
+      expect(resolveLogPath()).toBe(resolve(projectRoot, 'data', 'logs'))
     })
   })
 
   describe('resolveEnvPath', () => {
-    it('should use dataDir when available', async () => {
+    it('should use dataDir when available', () => {
       process.env.dataDir = '/custom/data'
-      const { resolveEnvPath } = await import('@utils/data-dir.js')
-      expect(resolveEnvPath('/project')).toBe(resolve('/custom/data', '.env'))
+      expect(resolveEnvPath()).toBe(resolve('/custom/data', '.env'))
     })
 
-    it('should fall back to project-relative path', async () => {
+    it('should fall back to project-relative path', () => {
       Object.defineProperty(process, 'platform', { value: 'linux' })
-      const { resolveEnvPath } = await import('@utils/data-dir.js')
-      expect(resolveEnvPath('/project')).toBe(resolve('/project', '.env'))
+      expect(resolveEnvPath()).toBe(resolve(projectRoot, '.env'))
     })
   })
 })


### PR DESCRIPTION
- Log streaming service was hardcoding project-relative path instead of using resolveLogPath()
- Caused empty log viewer on Windows and macOS native installs
- Centralized projectRoot in data-dir.ts, removed duplicate derivations from logger and tag-migration service
- resolveLogPath/resolveDbPath/resolveEnvPath no longer require a parameter

## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and simplified how the app locates its data, log, and env directories for more consistent behavior across services.
  * Reduced redundant path-resolution logic to improve reliability when reading logs and migration data.

* **Tests**
  * Updated unit tests to use the centralized path helpers, making tests more stable and straightforward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->