### PR TITLE
refactor(base-path): simplify to native <base> tag approach

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -58,7 +58,7 @@ async function serviceApp(
       dev: process.argv.includes('--dev'),
       spa: true,
       distDir: 'dist',
-      prefix: opts.prefix,
+      prefix: opts.prefix || '/',
     })
 
     await fastify.vite.ready()

--- a/src/client/lib/api.ts
+++ b/src/client/lib/api.ts
@@ -1,21 +1,11 @@
+import { BASE_PATH } from '@/lib/basePath.js'
+
 /**
- * Get the appropriate API path with base path support
- * Prepends the configured base path to API routes
- * Uses runtime configuration set by the server
+ * Get the appropriate API path with base path support.
+ * Prepends the base path (read from the <base> tag) to API routes.
  */
 export function api(path: string): string {
-  const basePath = window.__BASE_PATH__ || '/'
-
-  // Remove trailing slash from base path if present
-  const normalizedBase =
-    basePath.endsWith('/') && basePath !== '/'
-      ? basePath.slice(0, -1)
-      : basePath
-
-  // Ensure path starts with /
   const normalizedPath = path.startsWith('/') ? path : `/${path}`
 
-  return normalizedBase === '/'
-    ? normalizedPath
-    : `${normalizedBase}${normalizedPath}`
+  return BASE_PATH === '/' ? normalizedPath : `${BASE_PATH}${normalizedPath}`
 }

--- a/src/client/lib/basePath.ts
+++ b/src/client/lib/basePath.ts
@@ -1,0 +1,13 @@
+/**
+ * Resolves the base path from the <base> tag injected by the server.
+ * Returns '/' for root deployments or '/pulsarr' for subfolder deployments.
+ */
+function resolveBasePath(): string {
+  const baseEl = document.querySelector('base')
+  if (baseEl) {
+    return new URL(baseEl.href).pathname.replace(/\/+$/, '') || '/'
+  }
+  return '/'
+}
+
+export const BASE_PATH = resolveBasePath()

--- a/src/client/router/router.tsx
+++ b/src/client/router/router.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense } from 'react'
 import { createBrowserRouter, Navigate, Outlet } from 'react-router-dom'
 import AuthenticatedLayout from '@/layouts/authenticated'
 import RootLayout from '@/layouts/root'
+import { BASE_PATH } from '@/lib/basePath.js'
 
 const LoginPage = lazy(() => import('@/features/auth'))
 const CreateUserPage = lazy(() => import('@/features/create-user'))
@@ -55,19 +56,11 @@ const NotFoundPage = lazy(() => import('@/features/not-found'))
 const LoadingFallback = () => null
 
 /**
- * Get the configured base path for the router
- * Uses runtime configuration set by the server
+ * Get the configured base path for the router.
+ * Reads from the <base> tag injected by the server.
  */
 function getBasename(): string {
-  const basePath = window.__BASE_PATH__ || '/'
-
-  // Return empty string for root
-  if (basePath === '/') {
-    return ''
-  }
-
-  // Remove trailing slash if present (React Router basename must not end with /)
-  return basePath.endsWith('/') ? basePath.slice(0, -1) : basePath
+  return BASE_PATH === '/' ? '' : BASE_PATH
 }
 
 export const router = createBrowserRouter(

--- a/src/client/types/globals.d.ts
+++ b/src/client/types/globals.d.ts
@@ -2,10 +2,6 @@
 
 declare global {
   const __APP_VERSION__: string
-
-  interface Window {
-    __BASE_PATH__: string
-  }
 }
 
 export {}

--- a/src/plugins/custom/base-path-injection.ts
+++ b/src/plugins/custom/base-path-injection.ts
@@ -3,61 +3,25 @@ import type { FastifyInstance } from 'fastify'
 import fp from 'fastify-plugin'
 
 /**
- * Escapes characters that are unsafe in inline script contexts.
- * JSON.stringify handles quotes but not HTML/script-breaking characters.
- */
-function escapeForScriptTag(str: string): string {
-  return str
-    .replace(/</g, '\\u003C')
-    .replace(/>/g, '\\u003E')
-    .replace(/\u2028/g, '\\u2028')
-    .replace(/\u2029/g, '\\u2029')
-}
-
-/**
- * Injects runtime base path into HTML responses for SPA.
- * Rewrites asset paths to include basePath for reverse proxy compatibility.
+ * Injects a <base> tag into HTML responses for SPA.
+ * The <base> tag handles relative asset URL resolution natively (./assets/...),
+ * and client JS reads it to derive the base path for API calls and routing.
  */
 async function basePathInjection(fastify: FastifyInstance) {
-  fastify.addHook('onSend', async (_request, reply, payload) => {
+  const normalizedBasePath = normalizeBasePath(fastify.config.basePath)
+  const baseHref = normalizedBasePath === '/' ? '/' : `${normalizedBasePath}/`
+
+  fastify.addHook('onSend', async (request, reply, payload) => {
     const contentType = reply.getHeader('content-type')
 
-    // Only modify HTML responses for the SPA
     if (
       typeof contentType === 'string' &&
       contentType.includes('text/html') &&
-      typeof payload === 'string'
+      typeof payload === 'string' &&
+      payload.includes('<div id="app">') &&
+      !request.url.includes('/api/docs')
     ) {
-      // Get normalized base path from config
-      const normalizedBasePath = normalizeBasePath(fastify.config.basePath)
-
-      // Inject base path and asset helper for runtime URL resolution
-      const safeBasePath = escapeForScriptTag(
-        JSON.stringify(normalizedBasePath),
-      )
-      const safeAssetBase = escapeForScriptTag(
-        JSON.stringify(normalizedBasePath === '/' ? '' : normalizedBasePath),
-      )
-      const injectedScript = `<script>window.__BASE_PATH__ = ${safeBasePath};window.__assetBase = function(f) { return ${safeAssetBase} + '/' + f; };</script>`
-      let modifiedPayload = payload.replace('<head>', `<head>${injectedScript}`)
-
-      // Rewrite asset paths in HTML to include basePath for reverse proxy compatibility
-      if (normalizedBasePath !== '/') {
-        modifiedPayload = modifiedPayload.replace(
-          /src="\/assets\//g,
-          `src="${normalizedBasePath}/assets/`,
-        )
-        modifiedPayload = modifiedPayload.replace(
-          /href="\/assets\//g,
-          `href="${normalizedBasePath}/assets/`,
-        )
-        modifiedPayload = modifiedPayload.replace(
-          /href="\/favicon\./g,
-          `href="${normalizedBasePath}/favicon.`,
-        )
-      }
-
-      return modifiedPayload
+      return payload.replace('<head>', `<head><base href="${baseHref}">`)
     }
     return payload
   })

--- a/src/plugins/external/swagger.ts
+++ b/src/plugins/external/swagger.ts
@@ -56,7 +56,7 @@ function buildWebhooksSpec(): Record<string, unknown> {
   return webhooks
 }
 
-const createOpenapiConfig = (fastify: FastifyInstance) => {
+const createOpenapiConfig = (fastify: FastifyInstance, pathSuffix: string) => {
   const urlObject = new URL(fastify.config.baseUrl)
 
   fastify.log.debug(
@@ -74,7 +74,7 @@ const createOpenapiConfig = (fastify: FastifyInstance) => {
       },
       servers: [
         {
-          url: '{protocol}://{host}:{port}',
+          url: `{protocol}://{host}:{port}${pathSuffix}`,
           description: 'Custom Server',
           variables: {
             protocol: {
@@ -93,15 +93,15 @@ const createOpenapiConfig = (fastify: FastifyInstance) => {
           },
         },
         {
-          url: fastify.config.baseUrl,
+          url: `${fastify.config.baseUrl}${pathSuffix}`,
           description: 'Primary Server',
         },
         {
-          url: `${urlObject.protocol}//${urlObject.hostname}:${fastify.config.port}`,
+          url: `${urlObject.protocol}//${urlObject.hostname}:${fastify.config.port}${pathSuffix}`,
           description: 'Direct Server Access (with port)',
         },
         {
-          url: `http://localhost:${fastify.config.port}`,
+          url: `http://localhost:${fastify.config.port}${pathSuffix}`,
           description: 'Localhost Access (with port)',
         },
       ],
@@ -257,6 +257,9 @@ const createOpenapiConfig = (fastify: FastifyInstance) => {
 
 export default fp(
   async (fastify: FastifyInstance) => {
+    const basePath = normalizeBasePath(fastify.config.basePath)
+    const pathSuffix = basePath === '/' ? '' : basePath
+
     // Register the zod-openapi plugin (required for schema transformation)
     await fastify.register(fastifyZodOpenApiPlugin)
 
@@ -264,17 +267,19 @@ export default fp(
      * Register Swagger with combined config
      * @see {@link https://github.com/fastify/fastify-swagger}
      */
-    await fastify.register(fastifySwagger, createOpenapiConfig(fastify))
+    await fastify.register(
+      fastifySwagger,
+      createOpenapiConfig(fastify, pathSuffix),
+    )
 
     /**
      * Register Swagger UI
+     * routePrefix must include basePath because this plugin is fp()-wrapped,
+     * which registers on the root scope (bypassing the Fastify prefix).
      * @see {@link https://github.com/fastify/fastify-swagger-ui}
      */
-    const normalizedBasePath = normalizeBasePath(fastify.config.basePath)
     const swaggerRoute =
-      normalizedBasePath === '/'
-        ? '/api/docs'
-        : (`${normalizedBasePath}/api/docs` as `/${string}`)
+      basePath === '/' ? '/api/docs' : (`${basePath}/api/docs` as `/${string}`)
     await fastify.register(apiReference, {
       routePrefix: swaggerRoute,
     })

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,16 +7,9 @@ const packageJson = JSON.parse(
   readFileSync(new URL('./package.json', import.meta.url), 'utf8'),
 )
 
-const renderBuiltUrl = (filename, { hostType }) => {
-  if (hostType === 'js') {
-    return { runtime: `window.__assetBase(${JSON.stringify(filename)})` }
-  }
-  return { relative: true }
-}
-
 /** @type {import('vite').UserConfig} */
 export default {
-  base: '/',
+  base: './',
   root: resolve(import.meta.dirname, 'src/client'),
   plugins: [viteReact(), viteFastify({ spa: true, useRelativePaths: true })],
   build: {
@@ -35,9 +28,6 @@ export default {
         },
       },
     },
-  },
-  experimental: {
-    renderBuiltUrl,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
- Replace window.__BASE_PATH__, renderBuiltUrl, and regex rewriting with <base href> injection
- Switch Vite base to './' with prefix fallback for @fastify/vite compatibility
- Fix OpenAPI server URLs to include basePath

## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * App base path is now derived from the page's base setting with a safe '/' fallback, improving subfolder deployments.

* **Routing & APIs**
  * Client routing, API endpoints, and the API docs UI consistently honor the configured base path.

* **Build**
  * Build output now uses relative asset paths for more reliable hosting in nested paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->