### PR TITLE
fix(docker): add tini for proper PID 1 zombie reaping

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -31,8 +31,8 @@ RUN --mount=type=cache,target=/app/node_modules/.vite \
 # Final runtime image
 FROM base
 
-# wget for healthcheck
-RUN apk add --no-cache wget
+# tini for proper PID 1 zombie reaping, wget for healthcheck
+RUN apk add --no-cache tini wget
 
 ENV CACHE_DIR=/app/build-cache
 
@@ -74,4 +74,5 @@ EXPOSE 3003
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
   CMD ./docker-healthcheck.sh
 
+ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["./docker-entrypoint.sh"]

--- a/dockerfile.node
+++ b/dockerfile.node
@@ -48,8 +48,8 @@ RUN npm prune --omit=dev && \
 FROM node:24.14.0-alpine@sha256:7fddd9ddeae8196abf4a3ef2de34e11f7b1a722119f91f28ddf1e99dcafdf114
 WORKDIR /app
 
-# wget for healthcheck
-RUN apk add --no-cache wget
+# tini for proper PID 1 zombie reaping, wget for healthcheck
+RUN apk add --no-cache tini wget
 
 ENV CACHE_DIR=/app/build-cache
 
@@ -88,4 +88,5 @@ EXPOSE 3003
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
   CMD ./docker-healthcheck.sh
 
+ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["./docker-entrypoint.sh"]


### PR DESCRIPTION
- Install tini in both bun and node alpine images
- Set tini as ENTRYPOINT to handle signal forwarding and zombie cleanup

## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image configurations to improve container process management and signal handling for enhanced stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->