### PR TITLE
fix(services): limit bulk tag concurrency and deduplicate SSE cleanup

### DIFF
--- a/src/services/event-emitter.service.ts
+++ b/src/services/event-emitter.service.ts
@@ -35,6 +35,9 @@ export class ProgressService {
   }
 
   removeConnection(id: string) {
+    if (!this.activeConnections.has(id)) {
+      return
+    }
     this.activeConnections.delete(id)
     this.log.debug(`Removing progress connection: ${id}`)
   }

--- a/src/services/log-streaming.service.ts
+++ b/src/services/log-streaming.service.ts
@@ -36,6 +36,7 @@ export class LogStreamingService {
   > = new Map()
   private readonly logFilePath: string
   private _watchTickInFlight = false
+  private _startingFileWatch = false
   private partialLine = ''
   private readonly log: FastifyBaseLogger
 
@@ -74,6 +75,9 @@ export class LogStreamingService {
   }
 
   removeConnection(id: string) {
+    if (!this.activeConnections.has(id)) {
+      return
+    }
     this.activeConnections.delete(id)
     this.log.debug({ connectionId: id }, 'Removing log streaming connection')
 
@@ -101,6 +105,7 @@ export class LogStreamingService {
     this.activeConnections.clear()
     this.eventEmitter.removeAllListeners()
     this.partialLine = ''
+    this._startingFileWatch = false
   }
 
   async getTailLines(lines: number, filter?: string): Promise<LogEntry[]> {
@@ -202,64 +207,71 @@ export class LogStreamingService {
   }
 
   private async startFileWatching() {
-    if (this.watchedFiles.has(this.logFilePath)) {
+    if (this.watchedFiles.has(this.logFilePath) || this._startingFileWatch) {
       return
     }
+    this._startingFileWatch = true
 
-    // Initialize entry and start interval regardless of file existence
-    let initialSize = 0
     try {
-      const stats = await stat(this.logFilePath)
-      initialSize = stats.size
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-        this.log.debug(
-          {
-            file: this.logFilePath,
-          },
-          'Log file not found at startup, will watch for creation',
-        )
-      } else {
-        // Unexpected error, abort
-        this.log.warn(
-          {
-            error,
-            file: this.logFilePath,
-          },
-          'Failed to start watching log file',
-        )
+      let initialSize = 0
+      try {
+        const stats = await stat(this.logFilePath)
+        initialSize = stats.size
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          this.log.debug(
+            {
+              file: this.logFilePath,
+            },
+            'Log file not found at startup, will watch for creation',
+          )
+        } else {
+          this.log.warn(
+            {
+              error,
+              file: this.logFilePath,
+            },
+            'Failed to start watching log file',
+          )
+          return
+        }
+      }
+
+      // All connections may have closed while awaiting stat
+      if (this.activeConnections.size === 0) {
         return
       }
-    }
 
-    this.watchedFiles.set(this.logFilePath, { size: initialSize })
+      this.watchedFiles.set(this.logFilePath, { size: initialSize })
 
-    // Always start the polling interval
-    const interval = setInterval(async () => {
-      if (this._watchTickInFlight) return
-      this._watchTickInFlight = true
-      try {
-        await this.checkFileChanges()
-      } finally {
-        this._watchTickInFlight = false
+      const interval = setInterval(async () => {
+        if (this._watchTickInFlight) return
+        this._watchTickInFlight = true
+        try {
+          await this.checkFileChanges()
+        } finally {
+          this._watchTickInFlight = false
+        }
+      }, 1000)
+
+      const fileInfo = this.watchedFiles.get(this.logFilePath)
+      if (fileInfo) {
+        fileInfo.interval = interval
       }
-    }, 1000)
 
-    const fileInfo = this.watchedFiles.get(this.logFilePath)
-    if (fileInfo) {
-      fileInfo.interval = interval
+      this.log.debug({ file: this.logFilePath }, 'Started watching log file')
+    } finally {
+      this._startingFileWatch = false
     }
-
-    this.log.debug({ file: this.logFilePath }, 'Started watching log file')
   }
 
   private stopFileWatching() {
     const fileInfo = this.watchedFiles.get(this.logFilePath)
     if (fileInfo?.interval) {
       clearInterval(fileInfo.interval)
-      this.watchedFiles.delete(this.logFilePath)
-      this.log.debug({ file: this.logFilePath }, 'Stopped watching log file')
     }
+    this.watchedFiles.delete(this.logFilePath)
+    this.log.debug({ file: this.logFilePath }, 'Stopped watching log file')
   }
 
   private async checkFileChanges() {

--- a/src/services/radarr.service.ts
+++ b/src/services/radarr.service.ts
@@ -31,10 +31,14 @@ import {
 import { createServiceLogger } from '@utils/logger.js'
 import { normalizeBasePath } from '@utils/url.js'
 import type { FastifyBaseLogger, FastifyInstance } from 'fastify'
+import pLimit from 'p-limit'
 
 // HTTP timeout constants
 const RADARR_API_TIMEOUT = 300000 // 300 seconds for API operations
 const RADARR_CONNECTION_TEST_TIMEOUT = 10000 // 10 seconds for connection tests
+
+// Bulk tag update concurrency limit
+const BULK_TAG_CONCURRENCY = 4
 
 // Custom error class to include HTTP status
 class HttpError extends Error {
@@ -1593,26 +1597,28 @@ export class RadarrService {
         tagGroups.get(tagKey)?.push(update.movieId)
       }
 
-      // Process each tag group as a bulk operation
+      // Process each tag group as a bulk operation with concurrency limit
+      const limit = pLimit(BULK_TAG_CONCURRENCY)
       const promises = Array.from(tagGroups.entries()).map(
-        async ([tagKey, movieIds]) => {
-          const tagIds =
-            tagKey === ''
-              ? []
-              : tagKey.split(',').map((id) => Number.parseInt(id, 10))
+        ([tagKey, movieIds]) =>
+          limit(async () => {
+            const tagIds =
+              tagKey === ''
+                ? []
+                : tagKey.split(',').map((id) => Number.parseInt(id, 10))
 
-          const payload = {
-            movieIds: movieIds,
-            tags: tagIds,
-            applyTags,
-          }
+            const payload = {
+              movieIds: movieIds,
+              tags: tagIds,
+              applyTags,
+            }
 
-          await this.putToRadarr('movie/editor', payload)
+            await this.putToRadarr('movie/editor', payload)
 
-          this.log.debug(
-            `Bulk updated ${movieIds.length} movies with tags [${tagIds.join(', ')}] (mode: ${applyTags})`,
-          )
-        },
+            this.log.debug(
+              `Bulk updated ${movieIds.length} movies with tags [${tagIds.join(', ')}] (mode: ${applyTags})`,
+            )
+          }),
       )
 
       await Promise.all(promises)

--- a/src/services/sonarr.service.ts
+++ b/src/services/sonarr.service.ts
@@ -30,10 +30,14 @@ import {
 import { createServiceLogger } from '@utils/logger.js'
 import { normalizeBasePath } from '@utils/url.js'
 import type { FastifyBaseLogger, FastifyInstance } from 'fastify'
+import pLimit from 'p-limit'
 
 // HTTP timeout constants
 const SONARR_API_TIMEOUT = 300000 // 300 seconds for API operations
 const SONARR_CONNECTION_TEST_TIMEOUT = 10000 // 10 seconds for connection tests
+
+// Bulk tag update concurrency limit
+const BULK_TAG_CONCURRENCY = 4
 
 // Custom error class to include HTTP status
 class HttpError extends Error {
@@ -1543,26 +1547,28 @@ export class SonarrService {
         tagGroups.get(tagKey)?.push(update.seriesId)
       }
 
-      // Process each tag group as a bulk operation
+      // Process each tag group as a bulk operation with concurrency limit
+      const limit = pLimit(BULK_TAG_CONCURRENCY)
       const promises = Array.from(tagGroups.entries()).map(
-        async ([tagKey, seriesIds]) => {
-          const tagIds =
-            tagKey === ''
-              ? []
-              : tagKey.split(',').map((id) => Number.parseInt(id, 10))
+        ([tagKey, seriesIds]) =>
+          limit(async () => {
+            const tagIds =
+              tagKey === ''
+                ? []
+                : tagKey.split(',').map((id) => Number.parseInt(id, 10))
 
-          const payload = {
-            seriesIds: seriesIds,
-            tags: tagIds,
-            applyTags,
-          }
+            const payload = {
+              seriesIds: seriesIds,
+              tags: tagIds,
+              applyTags,
+            }
 
-          await this.putToSonarr('series/editor', payload)
+            await this.putToSonarr('series/editor', payload)
 
-          this.log.debug(
-            `Bulk updated ${seriesIds.length} series with tags [${tagIds.join(', ')}] (mode: ${applyTags})`,
-          )
-        },
+            this.log.debug(
+              `Bulk updated ${seriesIds.length} series with tags [${tagIds.join(', ')}] (mode: ${applyTags})`,
+            )
+          }),
       )
 
       await Promise.all(promises)


### PR DESCRIPTION
- Add pLimit(4) to bulk tag updates in radarr/sonarr services
- Fix file watcher race condition in log streaming service
- Make SSE removeConnection idempotent for log and progress routes

## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Added concurrency limiting for bulk tag updates to reduce resource contention.

* **Bug Fixes**
  * Prevented unnecessary removal attempts by guarding connection removal.
  * Improved file-watcher startup/shutdown coordination to avoid duplicate watchers and ensure clean startup/teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->