### PR TITLE
fix(plex): filter unreachable connections during server discovery

### DIFF
--- a/src/client/features/utilities/hooks/usePlexServerDiscovery.ts
+++ b/src/client/features/utilities/hooks/usePlexServerDiscovery.ts
@@ -33,7 +33,7 @@ export function usePlexServerDiscovery() {
 
     // Set up a timeout for the request
     const controller = new AbortController()
-    const timeoutId = setTimeout(() => controller.abort(), 5000) // 5-second timeout
+    const timeoutId = setTimeout(() => controller.abort(), 15000)
 
     try {
       const response = await fetch(api('/v1/plex/discover-servers'), {

--- a/src/routes/v1/plex/discover-servers.ts
+++ b/src/routes/v1/plex/discover-servers.ts
@@ -3,6 +3,10 @@ import {
   PlexServerResponseSchema,
   PlexTokenSchema,
 } from '@schemas/plex/discover-servers.schema.js'
+import {
+  type ConnectionCandidate,
+  testConnectionReachability,
+} from '@services/plex-server/existence-check/index.js'
 import { logRouteError } from '@utils/route-errors.js'
 import {
   PLEX_CLIENT_IDENTIFIER,
@@ -109,14 +113,39 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (fastify) => {
             r.owned,
         )
 
+        const candidates: ConnectionCandidate[] = serverResources.flatMap(
+          (server) =>
+            (server.connections || [])
+              .filter((c) => c.uri)
+              .map((c) => ({
+                uri: c.uri,
+                local: c.local || false,
+                relay: false,
+              })),
+        )
+
+        const reachable = await testConnectionReachability(
+          candidates,
+          plexToken,
+          fastify.log,
+          3000,
+        )
+        const reachableUris = new Set(reachable.map((r) => r.uri))
+        const hasReachable = reachableUris.size > 0
+
+        if (!hasReachable && candidates.length > 0) {
+          fastify.log.warn(
+            'No Plex connections passed reachability test - returning all as fallback',
+          )
+        }
+
         for (const server of serverResources) {
-          // For each server, add all viable connection options
           for (const connection of server.connections || []) {
             if (!connection.uri) continue
+            if (hasReachable && !reachableUris.has(connection.uri)) continue
 
             try {
               const url = new URL(connection.uri)
-              const _isSecure = url.protocol === 'https:'
 
               // Add option with direct Plex URL (secure)
               if (url.hostname) {

--- a/src/services/notifications/channels/plex-mobile.service.ts
+++ b/src/services/notifications/channels/plex-mobile.service.ts
@@ -175,12 +175,18 @@ export class PlexMobileService {
     )
 
     if (resolved) {
-      return this.sendResolved(
+      const sent = await this.sendResolved(
         notification,
         resolved,
         [plexUserId],
         isBulkRelease,
       )
+      if (sent) {
+        this.log.info(
+          `Plex mobile notification sent successfully to ${user.name} for "${notification.title}"`,
+        )
+      }
+      return sent
     }
 
     // Not found yet — queue for retry

--- a/src/services/plex-server.service.ts
+++ b/src/services/plex-server.service.ts
@@ -31,9 +31,11 @@ import {
   buildUniqueServerList,
   type CachedConnection,
   type CachedContentAvailability,
+  type ConnectionCandidate,
   checkContentOnServer,
   clearContentCacheForReconciliation,
   getBestServerConnection,
+  testConnectionReachability,
 } from './plex-server/existence-check/index.js'
 import {
   getCurrentLabels,
@@ -353,14 +355,41 @@ export class PlexServerService {
         })
       }
 
-      // Sort connections by priority: local first, then non-relay, then relay
+      // Sort connections by priority: non-relay first, then local first
       connections.sort((a, b) => {
-        if (a.local && !b.local) return -1
-        if (!a.local && b.local) return 1
         if (!a.relay && b.relay) return -1
         if (a.relay && !b.relay) return 1
+        if (a.local && !b.local) return -1
+        if (!a.local && b.local) return 1
         return 0
       })
+
+      if (!(configUrl && configUrl !== defaultUrl) && connections.length > 0) {
+        const candidates: ConnectionCandidate[] = connections.map((c) => ({
+          uri: c.url,
+          local: c.local,
+          relay: c.relay,
+        }))
+
+        const reachable = await testConnectionReachability(
+          candidates,
+          adminToken,
+          this.log,
+        )
+
+        if (reachable.length > 0) {
+          const reachableUris = new Set(reachable.map((r) => r.uri))
+          const filtered = connections.filter((c) => reachableUris.has(c.url))
+          connections.splice(0, connections.length, ...filtered)
+          this.log.info(
+            `Filtered to ${connections.length} reachable connections (${candidates.length - connections.length} unreachable)`,
+          )
+        } else {
+          this.log.warn(
+            'All connection tests failed - keeping full list as fallback',
+          )
+        }
+      }
 
       // Mark the first one as default
       if (connections.length > 0) {

--- a/src/services/plex-server/existence-check/connection-cache.ts
+++ b/src/services/plex-server/existence-check/connection-cache.ts
@@ -76,17 +76,19 @@ export function getCachedConnection(
 
 /**
  * Tests connections in parallel using lightweight /identity endpoint.
- * Returns working connections sorted by preference (non-local, non-relay first).
+ * Returns only reachable connections in their original order.
  *
  * @param connections - Array of connections to test
  * @param accessToken - Token for authentication
  * @param logger - Logger instance
- * @returns Array of working connections sorted by preference
+ * @param timeoutMs - Per-connection timeout in milliseconds (default 2000)
+ * @returns Array of reachable connections
  */
-async function testConnections(
+export async function testConnectionReachability(
   connections: ConnectionCandidate[],
   accessToken: string,
   logger: FastifyBaseLogger,
+  timeoutMs = 2000,
 ): Promise<ConnectionCandidate[]> {
   const connectionTests = connections.map(async (conn) => {
     try {
@@ -95,7 +97,7 @@ async function testConnections(
           'X-Plex-Token': accessToken,
           'X-Plex-Client-Identifier': PLEX_CLIENT_IDENTIFIER,
         },
-        signal: AbortSignal.timeout(2000), // 2s timeout for connection test
+        signal: AbortSignal.timeout(timeoutMs),
       })
 
       if (response.ok) {
@@ -113,22 +115,41 @@ async function testConnections(
 
   const results = await Promise.allSettled(connectionTests)
 
-  // Filter successful connections and sort by preference
   return results
     .filter(
       (r): r is PromiseFulfilledResult<ConnectionCandidate> =>
         r.status === 'fulfilled' && r.value !== null,
     )
     .map((r) => r.value)
-    .sort((a, b) => {
-      // Prefer non-local over local (local = friend's LAN, unreachable)
-      if (!a.local && b.local) return -1
-      if (a.local && !b.local) return 1
-      // Then prefer non-relay over relay
-      if (!a.relay && b.relay) return -1
-      if (a.relay && !b.relay) return 1
-      return 0
-    })
+}
+
+/**
+ * Tests connections in parallel using lightweight /identity endpoint.
+ * Returns working connections sorted by preference (non-local, non-relay first).
+ *
+ * @param connections - Array of connections to test
+ * @param accessToken - Token for authentication
+ * @param logger - Logger instance
+ * @returns Array of working connections sorted by preference
+ */
+async function testConnections(
+  connections: ConnectionCandidate[],
+  accessToken: string,
+  logger: FastifyBaseLogger,
+): Promise<ConnectionCandidate[]> {
+  const reachable = await testConnectionReachability(
+    connections,
+    accessToken,
+    logger,
+  )
+
+  return reachable.sort((a, b) => {
+    if (!a.local && b.local) return -1
+    if (a.local && !b.local) return 1
+    if (!a.relay && b.relay) return -1
+    if (a.relay && !b.relay) return 1
+    return 0
+  })
 }
 
 /**

--- a/src/services/plex-server/existence-check/index.ts
+++ b/src/services/plex-server/existence-check/index.ts
@@ -15,6 +15,7 @@ export {
   getCachedConnection,
   invalidateServerConnection,
   isServerInBackoff,
+  testConnectionReachability,
 } from './connection-cache.js'
 
 // Content cache exports


### PR DESCRIPTION
- Reachability test connections via /identity before presenting results
- Fix connection sort to prefer local for admin server
- Bump client timeout to 15s, add plex mobile success logging

## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server reachability detection to optimize connection routing and prioritize accessible connections.

* **Improvements**
  * Increased server discovery timeout for improved connectivity in slower network environments.
  * Enhanced connection prioritization logic for better server selection.
  * Improved fallback behavior when direct connections are unavailable.
  * Enhanced logging for connection diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->