### PR TITLE
fix(plex): reconnect SSE when server URL or token changes

### DIFF
--- a/src/routes/v1/config/config.ts
+++ b/src/routes/v1/config/config.ts
@@ -166,20 +166,22 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (fastify) => {
           }
         }
 
-        // Handle Plex server URL changes - clear connection cache
+        // Handle Plex server URL changes - clear connection cache and restart SSE
         if (
           'plexServerUrl' in safeConfigUpdate ||
           'plexTokens' in safeConfigUpdate
         ) {
           try {
             fastify.log.info(
-              'Plex server connection settings changed, clearing caches',
+              'Plex server connection settings changed, clearing caches and reconnecting SSE',
             )
             fastify.plexServerService.clearCaches()
+            fastify.plexServerService.disconnectSSE()
+            await fastify.plexServerService.connectSSE()
           } catch (error) {
             fastify.log.error(
               { error },
-              'Failed to clear Plex server caches after config update',
+              'Failed to refresh Plex server caches and SSE after config update',
             )
           }
         }


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of Plex server connections: when server URL or credentials are updated, the app now clears connection caches and fully restarts the live SSE connection to ensure reconnection.
  * Improved logging for reconnection failures to make troubleshooting clearer when refresh/reconnect steps fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->