### PR TITLE
fix(docker): handle pre-existing GID/UID in entrypoint

### DIFF
--- a/docker-entrypoint.node.sh
+++ b/docker-entrypoint.node.sh
@@ -6,20 +6,34 @@ set -eu
 PUID=${PUID:-1000}
 PGID=${PGID:-1000}
 
-# Recreate pulsarr user/group with requested IDs
 deluser pulsarr 2>/dev/null || true
 delgroup pulsarr 2>/dev/null || true
-addgroup -g "$PGID" -S pulsarr
-adduser -u "$PUID" -G pulsarr -D -H -s /sbin/nologin pulsarr
+
+# Some GIDs are pre-allocated in Alpine (e.g. 100 is "users")
+EXISTING_GROUP=$(getent group "$PGID" 2>/dev/null | cut -d: -f1 || true)
+if [ -n "$EXISTING_GROUP" ]; then
+  APP_GROUP="$EXISTING_GROUP"
+else
+  addgroup -g "$PGID" -S pulsarr
+  APP_GROUP="pulsarr"
+fi
+
+EXISTING_USER=$(getent passwd "$PUID" 2>/dev/null | cut -d: -f1 || true)
+if [ -n "$EXISTING_USER" ]; then
+  APP_USER="$EXISTING_USER"
+else
+  adduser -u "$PUID" -G "$APP_GROUP" -D -H -s /sbin/nologin pulsarr
+  APP_USER="pulsarr"
+fi
 
 # Ensure writable directories exist and fix ownership (only files with wrong owner)
 mkdir -p /app/data/db /app/data/logs /app/build-cache
-find /app/data /app/build-cache ! \( -user "$PUID" -group "$PGID" \) -exec chown pulsarr:pulsarr {} + 2>/dev/null || true
+find /app/data /app/build-cache ! \( -user "$PUID" -group "$PGID" \) -exec chown "$APP_USER:$APP_GROUP" {} + 2>/dev/null || true
 
 echo "Starting Pulsarr as uid=$PUID, gid=$PGID"
 
 echo "Running database migrations..."
-su-exec pulsarr ./node_modules/.bin/tsx migrations/migrate.ts
+su-exec "$APP_USER:$APP_GROUP" ./node_modules/.bin/tsx migrations/migrate.ts
 
 echo "Starting application..."
-exec su-exec pulsarr node dist/server.js "$@"
+exec su-exec "$APP_USER:$APP_GROUP" node dist/server.js "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,20 +6,34 @@ set -eu
 PUID=${PUID:-1000}
 PGID=${PGID:-1000}
 
-# Recreate pulsarr user/group with requested IDs
 deluser pulsarr 2>/dev/null || true
 delgroup pulsarr 2>/dev/null || true
-addgroup -g "$PGID" -S pulsarr
-adduser -u "$PUID" -G pulsarr -D -H -s /sbin/nologin pulsarr
+
+# Some GIDs are pre-allocated in Alpine (e.g. 100 is "users")
+EXISTING_GROUP=$(getent group "$PGID" 2>/dev/null | cut -d: -f1 || true)
+if [ -n "$EXISTING_GROUP" ]; then
+  APP_GROUP="$EXISTING_GROUP"
+else
+  addgroup -g "$PGID" -S pulsarr
+  APP_GROUP="pulsarr"
+fi
+
+EXISTING_USER=$(getent passwd "$PUID" 2>/dev/null | cut -d: -f1 || true)
+if [ -n "$EXISTING_USER" ]; then
+  APP_USER="$EXISTING_USER"
+else
+  adduser -u "$PUID" -G "$APP_GROUP" -D -H -s /sbin/nologin pulsarr
+  APP_USER="pulsarr"
+fi
 
 # Ensure writable directories exist and fix ownership (only files with wrong owner)
 mkdir -p /app/data/db /app/data/logs /app/build-cache
-find /app/data /app/build-cache ! \( -user "$PUID" -group "$PGID" \) -exec chown pulsarr:pulsarr {} + 2>/dev/null || true
+find /app/data /app/build-cache ! \( -user "$PUID" -group "$PGID" \) -exec chown "$APP_USER:$APP_GROUP" {} + 2>/dev/null || true
 
 echo "Starting Pulsarr as uid=$PUID, gid=$PGID"
 
 echo "Running database migrations..."
-su-exec pulsarr bun run --bun migrations/migrate.ts
+su-exec "$APP_USER:$APP_GROUP" bun run --bun migrations/migrate.ts
 
 echo "Starting application..."
-exec su-exec pulsarr bun run --bun dist/server.js "$@"
+exec su-exec "$APP_USER:$APP_GROUP" bun run --bun dist/server.js "$@"


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Docker startup now reuses matching existing system users/groups when given UIDs/GIDs, avoiding unnecessary account creation.
  * Container file ownership adjustments now apply to the actual runtime user/group, preventing permission issues for data and cache directories.
  * Database migrations and the server now run under the selected user/group; startup still reports the configured UID/GID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->