### PR TITLE
fix(delete-sync): abort when playlist protection cannot retrieve user…

### DIFF
--- a/src/services/plex-server.service.ts
+++ b/src/services/plex-server.service.ts
@@ -1155,11 +1155,15 @@ export class PlexServerService {
       // Get or create playlists for all users
       const userPlaylists = await this.getOrCreateProtectionPlaylists(true)
 
-      if (userPlaylists.size === 0) {
-        this.log.warn(
-          `No "${playlistName}" playlists found or created for any users`,
+      // Owner always succeeds (admin token) - check that at least
+      // one shared user's playlist was accessible.
+      const nonOwnerPlaylists = [...userPlaylists.keys()].filter(
+        (u) => u !== 'owner',
+      )
+      if (nonOwnerPlaylists.length === 0) {
+        throw new Error(
+          'Plex has removed shared user access tokens - playlist protection cannot function. Delete sync aborted to prevent content loss. Disable playlist protection to resume delete sync.',
         )
-        return protectedGuids
       }
 
       // Process each user's playlist
@@ -1255,7 +1259,8 @@ export class PlexServerService {
         { error },
         'Error getting protected items from user playlists:',
       )
-      return protectedGuids
+      // Rethrow so delete sync aborts rather than proceeding unprotected
+      throw error
     }
   }
 


### PR DESCRIPTION
… tokens

## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure protection playlists include at least one shared user playlist before proceeding.
  * Improved error handling to prevent incomplete delete operations from continuing when validation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->