### PR TITLE
fix(migration): match backtick-quoted table names in FK dependency parser

### DIFF
--- a/migrations/scripts/sqlite-to-postgresql.ts
+++ b/migrations/scripts/sqlite-to-postgresql.ts
@@ -202,15 +202,6 @@ class SQLiteToPostgresMigration {
         } else {
           transformed[key] = JSON.stringify(value)
         }
-      } else if (
-        typeof value === 'string' &&
-        (value.startsWith('{') || value.startsWith('['))
-      ) {
-        try {
-          JSON.parse(value)
-        } catch {
-          // Not valid JSON, leave as-is
-        }
       }
     }
 


### PR DESCRIPTION
- Clean up redundant comments

#1099 

## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Removed outdated top-level and inline documentation comments from migration tooling.

* **Chores**
  * Removed implicit environment-variable loading at startup.
  * Improved migration logic to recognize backtick-quoted table/column references.
  * Simplified JSON-like string handling during data transformation (no user-visible behavior changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->