### PR TITLE
fix(docker): remove unused /app/build-cache volume

### DIFF
--- a/docker-entrypoint.node.sh
+++ b/docker-entrypoint.node.sh
@@ -10,7 +10,7 @@ if [ "$(id -u)" -ne 0 ]; then
     echo "ERROR: /app/data is not writable by uid=$(id -u). Fix volume permissions on the host." >&2
     exit 1
   fi
-  mkdir -p /app/data/db /app/data/logs /app/build-cache
+  mkdir -p /app/data/db /app/data/logs
   echo "Running database migrations..."
   ./node_modules/.bin/tsx migrations/migrate.ts
   echo "Starting application..."
@@ -41,8 +41,8 @@ else
 fi
 
 # Ensure writable directories exist and fix ownership (only files with wrong owner)
-mkdir -p /app/data/db /app/data/logs /app/build-cache
-find /app/data /app/build-cache ! \( -user "$PUID" -group "$PGID" \) -exec chown "$APP_USER:$APP_GROUP" {} + 2>/dev/null || true
+mkdir -p /app/data/db /app/data/logs
+find /app/data ! \( -user "$PUID" -group "$PGID" \) -exec chown "$APP_USER:$APP_GROUP" {} + 2>/dev/null || true
 
 echo "Starting Pulsarr as uid=$PUID, gid=$PGID"
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,7 +10,7 @@ if [ "$(id -u)" -ne 0 ]; then
     echo "ERROR: /app/data is not writable by uid=$(id -u). Fix volume permissions on the host." >&2
     exit 1
   fi
-  mkdir -p /app/data/db /app/data/logs /app/build-cache
+  mkdir -p /app/data/db /app/data/logs
   echo "Running database migrations..."
   bun run --bun migrations/migrate.ts
   echo "Starting application..."
@@ -41,8 +41,8 @@ else
 fi
 
 # Ensure writable directories exist and fix ownership (only files with wrong owner)
-mkdir -p /app/data/db /app/data/logs /app/build-cache
-find /app/data /app/build-cache ! \( -user "$PUID" -group "$PGID" \) -exec chown "$APP_USER:$APP_GROUP" {} + 2>/dev/null || true
+mkdir -p /app/data/db /app/data/logs
+find /app/data ! \( -user "$PUID" -group "$PGID" \) -exec chown "$APP_USER:$APP_GROUP" {} + 2>/dev/null || true
 
 echo "Starting Pulsarr as uid=$PUID, gid=$PGID"
 

--- a/dockerfile
+++ b/dockerfile
@@ -37,8 +37,6 @@ FROM base
 # tini for proper PID 1 zombie reaping, wget for healthcheck, su-exec for privilege drop
 RUN apk add --no-cache tini wget su-exec
 
-ENV CACHE_DIR=/app/build-cache
-
 # Remove bun user from base image (occupies UID 1000) and create pulsarr user
 RUN deluser --remove-home bun && \
     delgroup bun; \
@@ -54,8 +52,7 @@ COPY --from=install /temp/prod/node_modules ./node_modules
 # Create necessary directories with correct ownership
 RUN mkdir -p /app/data/db && \
     mkdir -p /app/data/logs && \
-    mkdir -p ${CACHE_DIR} && \
-    chown -R pulsarr:pulsarr /app/data /app/build-cache
+    chown -R pulsarr:pulsarr /app/data
 
 # Copy build artifacts
 COPY --from=builder /app/dist ./dist
@@ -77,7 +74,6 @@ ENV NODE_ENV=production
 ENV tmdbApiKey=${TMDBAPIKEY}
 
 # Make volumes
-VOLUME ["/app/build-cache"]
 VOLUME ["/app/data"]
 EXPOSE 3003
 

--- a/dockerfile.node
+++ b/dockerfile.node
@@ -3,7 +3,6 @@ FROM node:24.14.1-alpine@sha256:01743339035a5c3c11a373cd7c83aeab6ed1457b55da6a69
 WORKDIR /app
 
 ARG TMDBAPIKEY
-ENV CACHE_DIR=/app/build-cache
 ENV tmdbApiKey=${TMDBAPIKEY}
 
 # Transform package.json for Node.js:
@@ -36,8 +35,7 @@ RUN --mount=type=cache,target=/app/node_modules/.vite \
 RUN npm prune --omit=dev && \
     rm -rf node_modules/vite node_modules/rollup \
            node_modules/@rollup \
-           node_modules/rolldown node_modules/@rolldown && \
-    mkdir -p ${CACHE_DIR}
+           node_modules/rolldown node_modules/@rolldown
 
 # Final runtime image
 FROM node:24.14.1-alpine@sha256:01743339035a5c3c11a373cd7c83aeab6ed1457b55da6a69e014a95ac4e4700b
@@ -45,8 +43,6 @@ WORKDIR /app
 
 # tini for proper PID 1 zombie reaping, wget for healthcheck, su-exec for privilege drop
 RUN apk add --no-cache tini wget su-exec
-
-ENV CACHE_DIR=/app/build-cache
 
 # Remove node user from base image (occupies UID 1000) and create pulsarr user
 RUN deluser --remove-home node && \
@@ -63,8 +59,7 @@ COPY --from=builder /app/node_modules ./node_modules
 # Create necessary directories with correct ownership
 RUN mkdir -p /app/data/db && \
     mkdir -p /app/data/logs && \
-    mkdir -p ${CACHE_DIR} && \
-    chown -R pulsarr:pulsarr /app/data /app/build-cache
+    chown -R pulsarr:pulsarr /app/data
 
 # Copy build artifacts
 COPY --from=builder /app/dist ./dist
@@ -85,7 +80,6 @@ ARG TMDBAPIKEY
 ENV NODE_ENV=production
 ENV tmdbApiKey=${TMDBAPIKEY}
 
-VOLUME ["/app/build-cache"]
 VOLUME ["/app/data"]
 EXPOSE 3003
 


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified Docker container configuration by removing build cache directory management, consolidating persistent storage to application data volumes only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->