### PR TITLE
fix(approvals): clean up watchlist item and caches on pending request…

### DIFF
--- a/src/client/features/approvals/hooks/useApprovalMutations.ts
+++ b/src/client/features/approvals/hooks/useApprovalMutations.ts
@@ -22,6 +22,8 @@ import { approvalKeys } from './useApprovals'
 function invalidateApprovalCaches() {
   queryClient.invalidateQueries({ queryKey: approvalKeys.all })
   queryClient.invalidateQueries({ queryKey: approvalStatsKeys.all })
+  queryClient.invalidateQueries({ queryKey: ['recent-requests'] })
+  queryClient.invalidateQueries({ queryKey: ['dashboard-stats'] })
 }
 
 // ============================================================================

--- a/src/services/approval.service.ts
+++ b/src/services/approval.service.ts
@@ -1033,10 +1033,15 @@ export class ApprovalService {
       const requestToDelete =
         await this.fastify.db.getApprovalRequest(requestId)
 
+      if (requestToDelete?.status === 'pending') {
+        await this.fastify.db.deleteWatchlistItems(requestToDelete.userId, [
+          requestToDelete.contentKey,
+        ])
+      }
+
       const deleted = await this.fastify.db.deleteApprovalRequest(requestId)
 
       if (deleted && requestToDelete) {
-        // Emit SSE event for deleted request
         this.emitApprovalEvent(
           'deleted',
           requestToDelete,


### PR DESCRIPTION
… deletion

- Delete orphaned watchlist_items row when pending approval is deleted
- Invalidate recent-requests and dashboard-stats caches on approval mutations

## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache invalidation so the dashboard and recent requests refresh reliably after approval changes.
  * Ensured deleting pending approval requests also removes related watchlist entries to prevent stale data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->