### PR TITLE
feat(installer): add linux baseline build for CPUs without AVX2

### DIFF
--- a/scripts/build-native.ts
+++ b/scripts/build-native.ts
@@ -75,6 +75,12 @@ const PLATFORMS: Platform[] = [
     zipSuffix: 'macos-x64',
   },
   {
+    detectName: 'linux-x64-baseline',
+    bunArchive: 'bun-linux-x64-baseline',
+    bunBinary: 'bun',
+    zipSuffix: 'linux-x64-baseline',
+  },
+  {
     detectName: 'windows-x64',
     bunArchive: 'bun-windows-x64',
     bunBinary: 'bun.exe',

--- a/scripts/installers/linux/install.sh
+++ b/scripts/installers/linux/install.sh
@@ -64,7 +64,11 @@ detect_arch() {
     arch=$(uname -m)
     case "$arch" in
         x86_64|amd64)
-            echo "x64"
+            if ! grep -q avx2 /proc/cpuinfo 2>/dev/null; then
+                echo "x64-baseline"
+            else
+                echo "x64"
+            fi
             ;;
         aarch64|arm64)
             echo "arm64"


### PR DESCRIPTION
- Add linux-x64-baseline platform to native build targets
- Auto-detect AVX2 support in Linux installer via /proc/cpuinfo
- Falls back to baseline Bun binary (SSE4.2) when AVX2 is missing

## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added baseline platform support for Linux x64 systems without AVX2 CPU capabilities.
  * Installer now automatically detects CPU features and installs the appropriate binary variant for optimal compatibility on older hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->