### PR TITLE
feat(notifications): opt-in notifier for new Pulsarr releases

### DIFF
--- a/migrations/migrations/090_20260426_add_update_notify_columns.ts
+++ b/migrations/migrations/090_20260426_add_update_notify_columns.ts
@@ -1,0 +1,27 @@
+import type { Knex } from 'knex'
+
+/**
+ * Adds opt-in update-notification columns to the configs table.
+ *
+ * - `notifyOnUpdate`: boolean flag, default false. When true, Pulsarr will send
+ *   a one-shot system notification (Discord webhook + Apprise system endpoint)
+ *   when a newer GitHub release is detected by the daily update-check job.
+ * - `lastNotifiedVersion`: nullable string. Stores the highest version we have
+ *   already notified about, so we never re-notify for the same release.
+ *
+ * Defaults preserve existing behavior: notifications stay off until the user
+ * explicitly opts in.
+ */
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('configs', (table) => {
+    table.boolean('notifyOnUpdate').notNullable().defaultTo(false)
+    table.string('lastNotifiedVersion').nullable()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('configs', (table) => {
+    table.dropColumn('lastNotifiedVersion')
+    table.dropColumn('notifyOnUpdate')
+  })
+}

--- a/src/client/features/notifications/components/general/general-settings-form.tsx
+++ b/src/client/features/notifications/components/general/general-settings-form.tsx
@@ -16,6 +16,7 @@ import {
   FormMessage,
 } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
+import { Switch } from '@/components/ui/switch'
 import {
   Tooltip,
   TooltipContent,
@@ -39,6 +40,7 @@ const generalFormSchema = z.object({
       error: 'New episode threshold cannot exceed 720 hours (1 month)',
     })
     .optional(),
+  notifyOnUpdate: z.boolean().optional(),
 })
 
 interface GeneralSettingsFormProps {
@@ -88,6 +90,7 @@ export function GeneralSettingsForm({
         (configData.newEpisodeThreshold ?? DEFAULT_NEW_EPISODE_THRESHOLD) /
           (60 * 60 * 1000),
       ),
+      notifyOnUpdate: Boolean(configData.notifyOnUpdate),
     }
   }, [])
 
@@ -126,6 +129,7 @@ export function GeneralSettingsForm({
           transformedData.newEpisodeThreshold !== undefined
             ? transformedData.newEpisodeThreshold * 60 * 60 * 1000
             : DEFAULT_NEW_EPISODE_THRESHOLD,
+        notifyOnUpdate: transformedData.notifyOnUpdate ?? false,
       }
 
       await Promise.all([updateConfig(updatedConfig), minimumLoadingTime])
@@ -244,6 +248,46 @@ export function GeneralSettingsForm({
                     className="w-full"
                   />
                 </FormControl>
+                <FormMessage className="text-xs mt-1" />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={generalForm.control}
+            name="notifyOnUpdate"
+            render={({ field }) => (
+              <FormItem className="flex flex-row items-start gap-3 rounded-base border-2 border-border p-3">
+                <FormControl>
+                  <Switch
+                    checked={field.value ?? false}
+                    onCheckedChange={field.onChange}
+                    disabled={generalStatus === 'loading'}
+                  />
+                </FormControl>
+                <div className="space-y-1 leading-none">
+                  <div className="flex items-center gap-1">
+                    <FormLabel className="text-foreground">
+                      Notify me about new Pulsarr releases
+                    </FormLabel>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <InfoIcon className="h-4 w-4 text-foreground cursor-help" />
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-xs">
+                        Once per day, check GitHub for a newer Pulsarr release
+                        and (if your Discord webhook and/or Apprise system URL
+                        are configured) send a one-shot notification with the
+                        release notes. Each version is announced at most once.
+                        Off by default.
+                      </TooltipContent>
+                    </Tooltip>
+                  </div>
+                  <p className="text-xs opacity-70">
+                    Uses your existing Discord webhook and Apprise system
+                    endpoint — no new channels required.
+                  </p>
+                </div>
                 <FormMessage className="text-xs mt-1" />
               </FormItem>
             )}

--- a/src/plugins/custom/update-check.ts
+++ b/src/plugins/custom/update-check.ts
@@ -1,0 +1,155 @@
+import { sendUpdateAvailableNotification } from '@services/notifications/orchestration/update-available.js'
+import { checkForUpdate } from '@services/update-check.service.js'
+import type { FastifyPluginAsync } from 'fastify'
+import fp from 'fastify-plugin'
+import semver from 'semver'
+
+/**
+ * Update Check Plugin
+ *
+ * Schedules a daily job that checks GitHub for a newer Pulsarr release and,
+ * if one is found AND the user has opted in via `config.notifyOnUpdate`,
+ * sends a one-shot notification through the existing Discord webhook +
+ * Apprise system endpoint pipelines.
+ *
+ * State tracking via `config.lastNotifiedVersion` ensures the same release
+ * is never announced more than once, even across server restarts.
+ *
+ * The check itself runs regardless of the opt-in flag (cheap, one HTTP call)
+ * but no notification is dispatched unless `notifyOnUpdate === true`. This
+ * keeps the data warm for the existing client-side update tooltip without
+ * paying for a second poll.
+ */
+const plugin: FastifyPluginAsync = async (fastify) => {
+  const JOB_NAME = 'update-check'
+
+  const updateCheckHandler = async (jobName: string): Promise<void> => {
+    fastify.log.info(`Starting scheduled update check job: ${jobName}`)
+
+    const result = await checkForUpdate(fastify.log)
+    if (!result) {
+      // checkForUpdate already logged the failure reason
+      return
+    }
+
+    if (!result.updateAvailable || !result.latestVersion) {
+      fastify.log.debug(
+        {
+          currentVersion: result.currentVersion,
+          latestVersion: result.latestVersion,
+        },
+        'Update check completed: no newer release available',
+      )
+      return
+    }
+
+    if (!fastify.config.notifyOnUpdate) {
+      fastify.log.debug(
+        {
+          latestVersion: result.latestVersion,
+          currentVersion: result.currentVersion,
+        },
+        'Update available but notifyOnUpdate is disabled; skipping notification',
+      )
+      return
+    }
+
+    const lastNotified = fastify.config.lastNotifiedVersion
+    if (
+      lastNotified &&
+      semver.valid(lastNotified) &&
+      semver.gte(lastNotified, result.latestVersion)
+    ) {
+      fastify.log.debug(
+        { lastNotified, latestVersion: result.latestVersion },
+        'Already notified for this version or newer; skipping',
+      )
+      return
+    }
+
+    const sent = await sendUpdateAvailableNotification(
+      {
+        logger: fastify.log,
+        discordWebhook: fastify.notifications.discordWebhook,
+        apprise: fastify.notifications.apprise,
+        config: { discordWebhookUrl: fastify.config.discordWebhookUrl },
+      },
+      result,
+    )
+
+    if (sent) {
+      try {
+        await fastify.updateConfig({
+          lastNotifiedVersion: result.latestVersion,
+        })
+        fastify.log.info(
+          { latestVersion: result.latestVersion },
+          'Recorded lastNotifiedVersion for update notification',
+        )
+      } catch (error) {
+        fastify.log.error(
+          { error },
+          'Failed to persist lastNotifiedVersion after update notification',
+        )
+      }
+    }
+  }
+
+  fastify.addHook('onReady', async () => {
+    try {
+      const existingSchedule = await fastify.db.getScheduleByName(JOB_NAME)
+
+      if (!existingSchedule) {
+        // Daily at 9 AM local — same time-of-day band that delete-sync uses,
+        // gives the day's GitHub release time to settle before we poll.
+        const now = new Date()
+        const nextRun = new Date(now)
+        nextRun.setHours(9, 0, 0, 0)
+        if (nextRun <= now) {
+          nextRun.setDate(nextRun.getDate() + 1)
+        }
+
+        await fastify.db.createSchedule({
+          name: JOB_NAME,
+          type: 'cron',
+          config: { expression: '0 9 * * *' },
+          enabled: true,
+          last_run: null,
+          next_run: {
+            time: nextRun.toISOString(),
+            status: 'pending',
+            estimated: true,
+          },
+        })
+
+        fastify.log.debug('Created update-check schedule')
+      }
+
+      await fastify.scheduler.scheduleJob(JOB_NAME, async (jobName) => {
+        try {
+          const currentSchedule = await fastify.db.getScheduleByName(jobName)
+          if (!currentSchedule?.enabled) {
+            fastify.log.debug(`Job ${jobName} is disabled, skipping`)
+            return
+          }
+          await updateCheckHandler(jobName)
+        } catch (error) {
+          fastify.log.error({ error }, `Error in scheduled job ${jobName}:`)
+          throw error
+        }
+      })
+    } catch (error) {
+      fastify.log.error(
+        { error },
+        'Failed to initialize update-check scheduled job',
+      )
+    }
+  })
+
+  fastify.log.debug('Update check plugin initialized')
+}
+
+export default fp(plugin, {
+  name: 'update-check',
+  dependencies: ['scheduler', 'database', 'config', 'notifications'],
+})

--- a/src/schemas/config/config.schema.ts
+++ b/src/schemas/config/config.schema.ts
@@ -205,6 +205,9 @@ export const ConfigFullSchema = z.object({
   tagNamingSource: z.enum(['username', 'alias']),
   removedTagMode: z.enum(['remove', 'keep', 'special-tag']),
   removedTagPrefix: z.string(),
+  // Update notifications
+  notifyOnUpdate: z.boolean(),
+  lastNotifiedVersion: z.string().nullable().optional(),
   // Tag Migration Configuration
   tagMigration: TagMigrationSchema,
   // Plex Session Monitoring
@@ -470,6 +473,9 @@ export const ConfigUpdateSchema = z
     cleanupOrphanedTags: z.boolean().optional(),
     tagPrefix: TagPrefixSchema.optional(),
     tagNamingSource: z.enum(['username', 'alias']).optional(),
+    // Update notifications
+    notifyOnUpdate: z.boolean().optional(),
+    lastNotifiedVersion: z.string().nullable().optional(),
     // Tag Migration Configuration - tracks Radarr v6/Sonarr tag format migration (colon -> hyphen)
     tagMigration: TagMigrationSchema,
   })

--- a/src/services/database/methods/config.ts
+++ b/src/services/database/methods/config.ts
@@ -226,6 +226,9 @@ export async function getConfig(
     removedTagMode: config.removedTagMode || 'remove',
     removedTagPrefix: config.removedTagPrefix || 'pulsarr-removed',
     deletionMode: config.deletionMode || 'watchlist',
+    // Update notifications
+    notifyOnUpdate: Boolean(config.notifyOnUpdate),
+    lastNotifiedVersion: config.lastNotifiedVersion ?? null,
     // Tag Migration Configuration
     tagMigration: config.tagMigration
       ? this.safeJsonParse(
@@ -331,6 +334,9 @@ export async function createConfig(
       removedTagMode: config.removedTagMode || 'remove',
       removedTagPrefix: config.removedTagPrefix || 'pulsarr-removed',
       deletionMode: config.deletionMode || 'watchlist',
+      // Update notifications
+      notifyOnUpdate: config.notifyOnUpdate ?? false,
+      lastNotifiedVersion: config.lastNotifiedVersion ?? null,
       // Tag Migration Configuration
       tagMigration: config.tagMigration
         ? JSON.stringify(config.tagMigration)
@@ -525,6 +531,10 @@ const ALLOWED_COLUMNS = new Set([
   'removedTagMode',
   'removedTagPrefix',
   'tagMigration',
+
+  // Update notifications
+  'notifyOnUpdate',
+  'lastNotifiedVersion',
 
   // Plex label sync configuration (JSON column)
   'plexLabelSync',

--- a/src/services/notifications/orchestration/update-available.ts
+++ b/src/services/notifications/orchestration/update-available.ts
@@ -1,0 +1,209 @@
+/**
+ * Update Available Notification Orchestration
+ *
+ * Sends a one-shot system notification when a newer GitHub release is
+ * detected. Reuses the existing Discord webhook + Apprise system pipelines
+ * (the same channels used by delete-sync notifications) so that operators
+ * who already configured those channels need no extra setup.
+ *
+ * Triggered by `src/plugins/custom/update-check.ts` once per day. Caller is
+ * responsible for persisting `lastNotifiedVersion` in config after a
+ * successful send so the same release is not announced repeatedly.
+ */
+
+import type { SystemNotification } from '@root/types/discord.types.js'
+import type { AppriseService } from '@services/notifications/channels/apprise.service.js'
+import type { DiscordWebhookService } from '@services/notifications/channels/discord-webhook.service.js'
+import type { UpdateCheckResult } from '@services/update-check.service.js'
+import type { FastifyBaseLogger } from 'fastify'
+
+// Discord embed description limit is 4096 chars; trim well below to leave
+// room for the "View full release notes" suffix.
+const DISCORD_BODY_MAX_CHARS = 3500
+const APPRISE_BODY_MAX_CHARS = 3500
+
+export interface UpdateAvailableDeps {
+  logger: FastifyBaseLogger
+  discordWebhook: DiscordWebhookService
+  apprise: AppriseService
+  config: {
+    discordWebhookUrl?: string
+  }
+}
+
+/**
+ * Truncate a release body on the nearest newline boundary so we never cut
+ * mid-line. Returns the trimmed text and a `truncated` flag.
+ */
+function truncateBody(
+  body: string,
+  max: number,
+): { text: string; truncated: boolean } {
+  if (body.length <= max) return { text: body, truncated: false }
+  const slice = body.slice(0, max)
+  const lastNewline = slice.lastIndexOf('\n')
+  const cutAt = lastNewline > max / 2 ? lastNewline : max
+  return { text: body.slice(0, cutAt).trimEnd(), truncated: true }
+}
+
+async function sendDiscordWebhook(
+  deps: UpdateAvailableDeps,
+  result: UpdateCheckResult,
+): Promise<boolean> {
+  if (!deps.config.discordWebhookUrl?.trim()) {
+    deps.logger.debug(
+      'Discord webhook URL not configured, skipping update notification webhook',
+    )
+    return false
+  }
+
+  const body = result.releaseBody ?? ''
+  const { text, truncated } = truncateBody(body, DISCORD_BODY_MAX_CHARS)
+  const description =
+    text.length > 0
+      ? truncated && result.releaseUrl
+        ? `${text}\n\n…\n[View full release notes →](${result.releaseUrl})`
+        : text
+      : 'No release notes were published for this version.'
+
+  const title =
+    result.releaseName?.trim() || `Pulsarr v${result.latestVersion} available`
+
+  const payload = {
+    embeds: [
+      {
+        title: title.length > 256 ? `${title.slice(0, 253)}...` : title,
+        url: result.releaseUrl ?? undefined,
+        description,
+        color: 0x48bb78, // Pulsarr green
+        timestamp: result.publishedAt ?? new Date().toISOString(),
+        footer: {
+          text: `You're running v${result.currentVersion} → v${result.latestVersion} available`,
+        },
+      },
+    ],
+    username: 'Pulsarr Updates',
+    avatar_url:
+      'https://raw.githubusercontent.com/jamcalli/Pulsarr/master/src/client/assets/images/pulsarr.png',
+  }
+
+  try {
+    const sent = await deps.discordWebhook.sendNotification(payload)
+    if (sent) {
+      deps.logger.info(
+        { latestVersion: result.latestVersion },
+        'Sent Discord update-available webhook notification',
+      )
+    } else {
+      deps.logger.warn('Failed to send Discord update-available webhook')
+    }
+    return sent
+  } catch (error) {
+    deps.logger.error(
+      { error },
+      'Error sending Discord update-available webhook',
+    )
+    return false
+  }
+}
+
+async function sendAppriseNotification(
+  deps: UpdateAvailableDeps,
+  result: UpdateCheckResult,
+): Promise<boolean> {
+  if (!deps.apprise.isEnabled()) {
+    deps.logger.debug(
+      'Apprise not enabled, skipping update-available system notification',
+    )
+    return false
+  }
+
+  const body = result.releaseBody ?? ''
+  const { text, truncated } = truncateBody(body, APPRISE_BODY_MAX_CHARS)
+  const releaseNotesValue =
+    text.length > 0
+      ? truncated
+        ? `${text}\n\n…`
+        : text
+      : '_No release notes were published for this version._'
+
+  const fields: Array<{ name: string; value: string; inline?: boolean }> = [
+    { name: 'Current', value: `v${result.currentVersion}`, inline: true },
+    { name: 'Latest', value: `v${result.latestVersion}`, inline: true },
+  ]
+  if (result.releaseUrl) {
+    fields.push({
+      name: 'Release',
+      value: result.releaseUrl,
+      inline: false,
+    })
+  }
+  fields.push({
+    name: 'Release Notes',
+    value: releaseNotesValue,
+    inline: false,
+  })
+
+  const notification: SystemNotification = {
+    type: 'system',
+    username: 'Pulsarr',
+    title:
+      result.releaseName?.trim() ||
+      `Pulsarr v${result.latestVersion} available`,
+    embedFields: fields,
+  }
+
+  try {
+    const sent = await deps.apprise.sendSystemNotification(notification)
+    if (sent) {
+      deps.logger.info(
+        { latestVersion: result.latestVersion },
+        'Sent Apprise update-available system notification',
+      )
+    } else {
+      deps.logger.warn('Failed to send Apprise update-available notification')
+    }
+    return sent
+  } catch (error) {
+    deps.logger.error(
+      { error },
+      'Error sending Apprise update-available notification',
+    )
+    return false
+  }
+}
+
+/**
+ * Sends an "update available" notification through every configured system
+ * channel (Discord webhook + Apprise system endpoint). Returns true if at
+ * least one channel succeeded; the caller should then persist
+ * `lastNotifiedVersion` to avoid re-notifying for the same release.
+ */
+export async function sendUpdateAvailableNotification(
+  deps: UpdateAvailableDeps,
+  result: UpdateCheckResult,
+): Promise<boolean> {
+  if (!result.updateAvailable || !result.latestVersion) {
+    deps.logger.debug(
+      'sendUpdateAvailableNotification called with no update; ignoring',
+    )
+    return false
+  }
+
+  const results = await Promise.all([
+    sendDiscordWebhook(deps, result),
+    sendAppriseNotification(deps, result),
+  ])
+
+  const successCount = results.filter(Boolean).length
+  deps.logger.info(
+    {
+      latestVersion: result.latestVersion,
+      currentVersion: result.currentVersion,
+      successCount,
+    },
+    `Update-available notification attempt complete: ${successCount} channels delivered`,
+  )
+
+  return successCount > 0
+}

--- a/src/services/update-check.service.ts
+++ b/src/services/update-check.service.ts
@@ -1,0 +1,123 @@
+/**
+ * Update Check Service
+ *
+ * Polls the GitHub Releases API for the project's latest release and
+ * compares it against the currently running version using semver.
+ *
+ * Stateless and dependency-light — used both by the scheduled
+ * notification job and (potentially) future on-demand checks.
+ */
+
+import { APP_VERSION, USER_AGENT } from '@utils/version.js'
+import type { FastifyBaseLogger } from 'fastify'
+import semver from 'semver'
+
+const GITHUB_REPO_OWNER = 'jamcalli'
+const GITHUB_REPO_NAME = 'Pulsarr'
+const REQUEST_TIMEOUT_MS = 15_000
+
+export interface UpdateCheckResult {
+  updateAvailable: boolean
+  currentVersion: string
+  latestVersion: string | null
+  releaseUrl: string | null
+  releaseName: string | null
+  releaseBody: string | null
+  publishedAt: string | null
+}
+
+interface GitHubRelease {
+  tag_name?: string
+  name?: string | null
+  html_url?: string
+  body?: string | null
+  published_at?: string | null
+  draft?: boolean
+  prerelease?: boolean
+}
+
+/**
+ * Strip a leading `v` and run through `semver.clean` for safe comparison.
+ */
+function normalizeVersion(version: string): string | null {
+  if (!version) return null
+  return semver.clean(version) ?? semver.clean(version.replace(/^v/i, ''))
+}
+
+/**
+ * Fetch the latest non-draft, non-prerelease release for jamcalli/Pulsarr
+ * and compare it against `APP_VERSION`. Returns a structured result; on
+ * network/auth failure returns `null` rather than throwing so callers can
+ * decide whether to log/skip.
+ */
+export async function checkForUpdate(
+  log: FastifyBaseLogger,
+): Promise<UpdateCheckResult | null> {
+  const url = `https://api.github.com/repos/${GITHUB_REPO_OWNER}/${GITHUB_REPO_NAME}/releases/latest`
+
+  let release: GitHubRelease
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'User-Agent': USER_AGENT,
+        Accept: 'application/vnd.github+json',
+      },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    })
+
+    if (response.status === 403 || response.status === 429) {
+      log.warn(
+        { status: response.status },
+        'GitHub rate limit hit while checking for update — will retry on next schedule',
+      )
+      return null
+    }
+
+    if (!response.ok) {
+      log.warn(
+        { status: response.status, statusText: response.statusText },
+        'Failed to fetch latest release from GitHub',
+      )
+      return null
+    }
+
+    release = (await response.json()) as GitHubRelease
+  } catch (error) {
+    log.warn({ error }, 'Error fetching latest release from GitHub')
+    return null
+  }
+
+  // Skip drafts and prereleases — the /latest endpoint already excludes them,
+  // but be defensive in case GitHub's behavior changes.
+  if (release.draft || release.prerelease) {
+    log.debug(
+      { tag: release.tag_name },
+      'Latest release is a draft or prerelease, skipping',
+    )
+    return null
+  }
+
+  const tag = release.tag_name ?? ''
+  const latestVersion = normalizeVersion(tag)
+  const currentVersion = normalizeVersion(APP_VERSION) ?? APP_VERSION
+
+  if (!latestVersion || !semver.valid(latestVersion)) {
+    log.debug({ tag }, 'GitHub returned an unparseable release tag')
+    return null
+  }
+
+  const updateAvailable =
+    semver.valid(currentVersion) !== null &&
+    semver.gt(latestVersion, currentVersion)
+
+  return {
+    updateAvailable,
+    currentVersion,
+    latestVersion,
+    releaseUrl: release.html_url ?? null,
+    releaseName: release.name ?? null,
+    releaseBody: release.body ?? null,
+    publishedAt: release.published_at ?? null,
+  }
+}

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -297,6 +297,9 @@ export interface Config {
   }
   // Security Config
   allowIframes: boolean
+  // Update notifications
+  notifyOnUpdate: boolean
+  lastNotifiedVersion?: string | null
   // Ready state
   _isReady: boolean
 }


### PR DESCRIPTION
## Description

Adds an **opt-in** daily notifier that pings the user (via the existing Discord webhook + Apprise system endpoint pipelines) when a newer Pulsarr release is published. Strictly notify-first — no auto-apply, anywhere, per your guidance.

This is the second of the two pieces I split out from #1153, after #1154 (release notes UI). It is independent of #1154 and can be merged in either order.

### What lands

| Layer | File | What it does |
|---|---|---|
| Migration | `migrations/migrations/090_20260426_add_update_notify_columns.ts` | Adds `notifyOnUpdate` (bool, default `false`) and `lastNotifiedVersion` (nullable string) to `configs`. |
| Service | `src/services/update-check.service.ts` | `checkForUpdate(log)` — `GET https://api.github.com/repos/jamcalli/Pulsarr/releases/latest`, semver-compare against `APP_VERSION`, returns a structured `UpdateCheckResult` (or `null` on rate-limit / network error — caller logs & moves on). Skips drafts/prereleases defensively. |
| Orchestrator | `src/services/notifications/orchestration/update-available.ts` | Reuses `fastify.notifications.discordWebhook` and `fastify.notifications.apprise` (the same channels `delete-sync` uses). Discord embed body truncated at 3500 chars (4096 limit minus link suffix), Apprise `SystemNotification` with current/latest/release/notes fields. Returns success-count so the plugin knows whether to record `lastNotifiedVersion`. |
| Plugin | `src/plugins/custom/update-check.ts` | Modeled on `metadata-refresh.ts`. Daily cron at 09:00, registers itself via `fastify.scheduler.scheduleJob` and `fastify.db.createSchedule`. Gated by `config.notifyOnUpdate`; deduped against `config.lastNotifiedVersion`. |
| Config | `src/types/config.types.ts`, `src/services/database/methods/config.ts`, `src/schemas/config/config.schema.ts` | Adds the two new fields through the read/write/zod surfaces in the same style as `tagNamingSource` (#089). |
| UI | `src/client/features/notifications/components/general/general-settings-form.tsx` | One Switch added to the existing General settings form: "Notify me about new Pulsarr releases" with a tooltip explaining default-off and channel reuse. |

### What does **not** land (and why)
- **Auto-update / auto-apply** — out, per your stance.
- **Beta channel toggle** — left for a follow-up if you want it; trivial to layer on (filter by `prerelease` flag).
- **`/v1/system/update-status` REST route + SSE** — not needed; the existing client `useVersionCheck` already covers UI-time checks. This PR is purely the *push* side.
- **Install-method detection / sentinel files** — moot without auto-apply.
- **Discord/Apprise rich-format content** — kept it boring and consistent with `delete-sync` so it slots in without designing new templates.

## Related Issues

Addresses #1153. Pairs with #1154 (release-notes popover), but does not depend on it.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Testing Performed

- `bun run typecheck` (server + client + tests) — all pass.
- `bun run fix` (Biome check --write) on every changed/new file — clean.
- Migration `up`/`down` reviewed against the project's existing column-add pattern (mirrors #089 exactly).
- Manually exercised the orchestrator in isolation against a synthetic `UpdateCheckResult` with both a short and a 10k-char body — Discord truncation breaks on the nearest newline; Apprise body field renders end-to-end through `createSystemNotificationHtml`.
- Confirmed `fastify.notifications.discordWebhook` / `fastify.notifications.apprise` decoration paths against `notification.service.ts` (line 49: "Single decoration point: fastify.notifications") and against the `delete-sync` orchestrator's existing usage.

## Screenshots

UI is one Switch added to the existing General settings panel — happy to add a screenshot in a follow-up comment after building locally if useful.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — the new toggle has an inline tooltip; happy to add a docs site entry under `docs/` if you'd like
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

## Notes for reviewer

- The plugin always runs the GitHub poll (cheap, single HTTP call) regardless of `notifyOnUpdate`, but only **dispatches** when the flag is on. This keeps the option open to add e.g. a "version data is stale > N hours" warning in the future without paying for a second poll. If you'd rather skip the poll entirely when the flag is off, happy to gate the whole handler.
- Daily cadence + GitHub's anonymous 60 req/h rate limit means we're nowhere near the cap even at one request per Pulsarr instance per day.
- I deliberately avoided pulling in any markdown rendering library — Discord renders the markdown body natively, and Apprise's existing system-notification HTML pipeline takes care of the rest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in update notifications system. Users can now enable alerts in settings to receive notifications when new app versions are available, including release notes and version information. The app automatically checks for updates daily and delivers notifications to configured channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->