### PR TITLE
docs(readme): standardize ElfHosted links and update sponsor wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ See the [configuration documentation](https://jamcalli.github.io/Pulsarr/docs/in
 
 ## Hosted Deployment Options
 
-[ElfHosted](https://store.elfhosted.com/elf/jamcalli/) offers managed Pulsarr hosting with pre-configured media server bundles.
+[ElfHosted](https://store.elfhosted.com/product/pulsarr/elf/jamcalli/?utm_source=github&utm_medium=readme&utm_campaign=pulsarr-readme) offers managed Pulsarr hosting with pre-configured media server bundles. 33% of every Pulsarr subscription supports the project.
 
 ## ✨ Key Features
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pulsarr",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "Plex watchlist tracker and notification center that integrates with the Arr stack",
   "main": "build/server.js",
   "type": "module",


### PR DESCRIPTION
Just a minor UTM update for the ElfHosted links in the README (trying to improve our internal attribution reports!)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated hosted deployment options link and added note that 33% of each Pulsarr subscription supports the project.
* **Chores**
  * Bumped package version from 0.15.2 to 0.15.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->