### PR TITLE
fix(schemas): stop Zod defaults clobbering untouched fields on update

### DIFF
--- a/src/routes/v1/content-router/content-router-management.ts
+++ b/src/routes/v1/content-router/content-router-management.ts
@@ -300,8 +300,8 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (fastify) => {
           search_on_add: ruleData.search_on_add,
           season_monitoring: ruleData.season_monitoring,
           series_type: ruleData.series_type,
-          always_require_approval: ruleData.always_require_approval,
-          bypass_user_quotas: ruleData.bypass_user_quotas,
+          always_require_approval: ruleData.always_require_approval ?? false,
+          bypass_user_quotas: ruleData.bypass_user_quotas ?? false,
           approval_reason: ruleData.approval_reason,
         })
 
@@ -323,8 +323,8 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (fastify) => {
           search_on_add: ruleData.search_on_add,
           season_monitoring: ruleData.season_monitoring,
           series_type: ruleData.series_type,
-          always_require_approval: ruleData.always_require_approval,
-          bypass_user_quotas: ruleData.bypass_user_quotas,
+          always_require_approval: ruleData.always_require_approval ?? false,
+          bypass_user_quotas: ruleData.bypass_user_quotas ?? false,
           approval_reason: ruleData.approval_reason,
         }
 

--- a/src/schemas/content-router/content-router.schema.ts
+++ b/src/schemas/content-router/content-router.schema.ts
@@ -259,9 +259,9 @@ export const BaseRouterRuleSchema = z.object({
   condition: z.union([ConditionSchema, ConditionGroupSchema]).optional(),
   root_folder: z.string().optional(),
   quality_profile: z.union([z.number(), z.string()]).optional(),
-  tags: z.array(z.string()).optional().default([]),
+  tags: z.array(z.string()).optional(),
   order: z.number().optional(),
-  enabled: z.boolean().optional().default(true),
+  enabled: z.boolean().optional(),
   search_on_add: z.boolean().nullable().optional(),
   // For Sonarr only - sending this with Radarr rules will be rejected by the API
   // Additional validation happens in the route handlers
@@ -272,9 +272,8 @@ export const BaseRouterRuleSchema = z.object({
     .enum(['movieOnly', 'movieAndCollection', 'none'])
     .nullable()
     .optional(),
-  // Actions - approval behavior
-  always_require_approval: z.boolean().optional().default(false),
-  bypass_user_quotas: z.boolean().optional().default(false),
+  always_require_approval: z.boolean().optional(),
+  bypass_user_quotas: z.boolean().optional(),
   approval_reason: z.string().optional(),
 })
 

--- a/src/schemas/quota/quota.schema.ts
+++ b/src/schemas/quota/quota.schema.ts
@@ -38,7 +38,7 @@ export const UpdateSpecificQuotaSchema = QuotaFieldsSchema.extend({
 export const UpdateSeparateQuotasSchema = z.object({
   movieQuota: EnabledQuotaSchema.optional(),
   showQuota: EnabledQuotaSchema.optional(),
-  autoApproveHeld: z.boolean().optional().default(false),
+  autoApproveHeld: z.boolean().optional(),
 })
 
 export const UserQuotaResponseSchema = z.object({

--- a/src/schemas/users/users.schema.ts
+++ b/src/schemas/users/users.schema.ts
@@ -7,12 +7,12 @@ export const CreateUserSchema = z.object({
   apprise: z.string().nullable(),
   alias: z.string().min(3).max(255).nullable(),
   discord_id: z.string().nullable(),
-  notify_apprise: z.boolean().default(false),
-  notify_discord: z.boolean().default(false),
-  notify_discord_mention: z.boolean().default(true),
-  notify_plex_mobile: z.boolean().default(false),
-  can_sync: z.boolean().default(true),
-  requires_approval: z.boolean().default(false),
+  notify_apprise: z.boolean(),
+  notify_discord: z.boolean(),
+  notify_discord_mention: z.boolean(),
+  notify_plex_mobile: z.boolean(),
+  can_sync: z.boolean(),
+  requires_approval: z.boolean(),
 })
 
 export const UserResponseSchema = z.object({

--- a/test/unit/schemas/update-schemas-no-default-leakage.test.ts
+++ b/test/unit/schemas/update-schemas-no-default-leakage.test.ts
@@ -1,0 +1,53 @@
+/// <reference types="vite/client" />
+import { describe, expect, it } from 'vitest'
+import type { z } from 'zod'
+
+// Zod's .partial() makes fields optional but does not strip .default() values,
+// so a PATCH that omits a field gets the schema default silently injected and
+// persisted, overwriting whatever was on the row.
+
+type AnySchema = z.ZodType<unknown>
+
+// Glob (not explicit imports) so any new Update*Schema is auto-covered.
+const modules = import.meta.glob<Record<string, unknown>>(
+  '../../../src/schemas/**/*.ts',
+  { eager: true },
+)
+
+const isZodSchema = (value: unknown): value is AnySchema =>
+  typeof value === 'object' &&
+  value !== null &&
+  'safeParse' in value &&
+  typeof (value as { safeParse: unknown }).safeParse === 'function'
+
+// Response schemas are output shapes, not request bodies; leakage doesn't apply.
+const isUpdateSchemaName = (name: string): boolean =>
+  /Update/.test(name) && /Schema$/.test(name) && !/Response/.test(name)
+
+const updateSchemas: Array<{ name: string; file: string; schema: AnySchema }> =
+  Object.entries(modules).flatMap(([file, mod]) =>
+    Object.entries(mod)
+      .filter(([name, value]) => isUpdateSchemaName(name) && isZodSchema(value))
+      .map(([name, value]) => ({
+        name,
+        file: file.replace('../../../src/schemas/', ''),
+        schema: value as AnySchema,
+      })),
+  )
+
+describe('Update schemas: no default leakage on partial input', () => {
+  it('discovers at least one update schema', () => {
+    expect(updateSchemas.length).toBeGreaterThan(0)
+  })
+
+  it.each(
+    updateSchemas,
+  )('$name ($file) parse({}) returns no auto-injected keys', ({ schema }) => {
+    const result = schema.safeParse({})
+    if (result.success) {
+      expect(result.data).toEqual({})
+    } else {
+      expect(result.error).toBeDefined()
+    }
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -35,6 +35,14 @@ export default defineConfig({
       // Clear with: npx vitest --clearCache
       fsModuleCache: true,
     },
+    // Zod 4's `import * as z; export { z }` index resolves the named `z`
+    // export to undefined under Vitest's SSR fast-path; inlining runs the
+    // full Vite transform.
+    server: {
+      deps: {
+        inline: ['zod'],
+      },
+    },
   },
   resolve: {
     alias: [


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated API schema validation to remove automatic default values for optional fields in router rules, quota updates, and user creation, requiring more explicit inputs to ensure predictable behavior.

* **Tests**
  * Added validation tests to prevent default value inconsistencies in future schema updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->