### PR TITLE
fix(content-router): stop storing rule targets as synced instances

### DIFF
--- a/src/client/features/approvals/components/approval-radarr-routing-card.tsx
+++ b/src/client/features/approvals/components/approval-radarr-routing-card.tsx
@@ -115,11 +115,7 @@ export function ApprovalRadarrRoutingCard({
   const targetInstance = instances.find((i) => i.id === instanceId)
   const instanceName = targetInstance?.name || `Radarr Instance ${instanceId}`
 
-  // Determine if this is the default instance
-  // Check both the instance property and if the routing has syncedInstances (only default instances can have these)
-  const isDefaultInstance =
-    targetInstance?.isDefault ||
-    (routing.syncedInstances && routing.syncedInstances.length > 0)
+  const isDefaultInstance = Boolean(targetInstance?.isDefault)
 
   const form = useForm<ApprovalRoutingFormData>({
     resolver: zodResolver(approvalRoutingSchema),

--- a/src/client/features/approvals/components/approval-sonarr-routing-card.tsx
+++ b/src/client/features/approvals/components/approval-sonarr-routing-card.tsx
@@ -122,11 +122,7 @@ export function ApprovalSonarrRoutingCard({
   const targetInstance = instances.find((i) => i.id === instanceId)
   const instanceName = targetInstance?.name || `Sonarr Instance ${instanceId}`
 
-  // Determine if this is the default instance
-  // Check both the instance property and if the routing has syncedInstances (only default instances can have these)
-  const isDefaultInstance =
-    targetInstance?.isDefault ||
-    (routing.syncedInstances && routing.syncedInstances.length > 0)
+  const isDefaultInstance = Boolean(targetInstance?.isDefault)
 
   const form = useForm<ApprovalRoutingFormData>({
     resolver: zodResolver(approvalRoutingSchema),

--- a/src/services/content-router.service.ts
+++ b/src/services/content-router.service.ts
@@ -408,8 +408,9 @@ export class ContentRouterService {
                   triggeredBy: approvalResult.trigger || 'manual_flag',
                   data: approvalResult.data || {},
                   proposedRouting: await this.createProposedRoutingDecision(
-                    defaultRoutingDecisions,
+                    defaultRoutingDecisions[0],
                     contentType,
+                    defaultRoutingDecisions.slice(1).map((d) => d.instanceId),
                   ),
                 },
               },
@@ -500,6 +501,7 @@ export class ContentRouterService {
                 bypassRoutedInstances,
                 [],
                 bypassActualRouting,
+                bypassRoutedInstances.slice(1),
               )
             }
 
@@ -537,8 +539,9 @@ export class ContentRouterService {
                     quotaLimit: quotaResult.quotaLimit,
                   },
                   proposedRouting: await this.createProposedRoutingDecision(
-                    defaultRoutingDecisions,
+                    defaultRoutingDecisions[0],
                     contentType,
+                    defaultRoutingDecisions.slice(1).map((d) => d.instanceId),
                   ),
                 },
               },
@@ -599,6 +602,7 @@ export class ContentRouterService {
           defaultRoutedInstances,
           [],
           defaultActualRouting,
+          defaultRoutedInstances.slice(1),
         )
       }
 
@@ -812,8 +816,11 @@ export class ContentRouterService {
                       triggeredBy: approvalResult.trigger || 'manual_flag',
                       data: approvalResult.data || {},
                       proposedRouting: await this.createProposedRoutingDecision(
-                        defaultRoutingDecisions,
+                        defaultRoutingDecisions[0],
                         contentType,
+                        defaultRoutingDecisions
+                          .slice(1)
+                          .map((d) => d.instanceId),
                       ),
                     },
                   },
@@ -893,8 +900,11 @@ export class ContentRouterService {
                           },
                           proposedRouting:
                             await this.createProposedRoutingDecision(
-                              defaultRoutingDecisions,
+                              defaultRoutingDecisions[0],
                               contentType,
+                              defaultRoutingDecisions
+                                .slice(1)
+                                .map((d) => d.instanceId),
                             ),
                         },
                       },
@@ -968,6 +978,7 @@ export class ContentRouterService {
             defaultRoutedInstances,
             [],
             fallbackActualRouting,
+            defaultRoutedInstances.slice(1),
           )
         }
         return {
@@ -1468,12 +1479,15 @@ export class ContentRouterService {
 
     // Create auto-approval record for tracking all successful content additions
     if (routedInstances.length > 0) {
+      // Rule-matched routing has no sync expansion - the tail is independent
+      // rule decisions, not sync targets.
       await this.createAutoApprovalRecord(
         enrichedItem,
         context,
         routedInstances,
         allDecisions,
-        allActualRoutings[0], // Pass first routing for auto-approval record
+        allActualRoutings[0],
+        undefined,
       )
     }
 
@@ -2259,23 +2273,18 @@ export class ContentRouterService {
   }
 
   /**
-   * Creates a proposed routing decision that includes primary instance and synced instances
+   * Builds the proposedRouting field for an approval record. Only pass
+   * syncedInstances when the tail is true sync expansion from default,
+   * not independent rule decisions.
    */
   private async createProposedRoutingDecision(
-    routingDecisions: RoutingDecision[],
+    primaryDecision: RoutingDecision | undefined,
     contentType: 'movie' | 'show',
+    syncedInstances?: number[],
   ): Promise<NonNullable<RouterDecision['approval']>['proposedRouting']> {
-    if (routingDecisions.length === 0) {
+    if (!primaryDecision) {
       return undefined
     }
-
-    // Use the primary routing decision (first one) as the base
-    const primaryDecision = routingDecisions[0]
-
-    // Extract synced instance IDs from the routing decisions (skip the first one which is primary)
-    const syncedInstances = routingDecisions
-      .slice(1)
-      .map((decision) => decision.instanceId)
 
     return {
       instanceId: primaryDecision.instanceId,
@@ -2289,7 +2298,10 @@ export class ContentRouterService {
       seriesType: primaryDecision.seriesType,
       minimumAvailability: primaryDecision.minimumAvailability,
       monitor: primaryDecision.monitor,
-      syncedInstances: syncedInstances.length > 0 ? syncedInstances : undefined,
+      syncedInstances:
+        syncedInstances && syncedInstances.length > 0
+          ? syncedInstances
+          : undefined,
     }
   }
 
@@ -2315,6 +2327,7 @@ export class ContentRouterService {
       seriesType?: string | null
       monitor?: 'movieOnly' | 'movieAndCollection' | 'none' | null
     },
+    syncedInstances?: number[],
   ): Promise<void> {
     try {
       // Skip if this is a sync operation
@@ -2347,7 +2360,10 @@ export class ContentRouterService {
 
       // Use actual routing that was executed, not proposed routing
       let proposedRouting: RouterDecision['routing'] | undefined
-      const syncedInstances = routedInstances.slice(1) // All instances except the first
+      const normalizedSyncedInstances =
+        syncedInstances && syncedInstances.length > 0
+          ? syncedInstances
+          : undefined
 
       if (actualRouting) {
         // Use the ACTUAL routing parameters that were sent to Radarr/Sonarr
@@ -2376,8 +2392,7 @@ export class ContentRouterService {
             | 'movieAndCollection'
             | 'none'
             | undefined,
-          syncedInstances:
-            syncedInstances.length > 0 ? syncedInstances : undefined,
+          syncedInstances: normalizedSyncedInstances,
         }
       } else if (routingDecisions.length > 0) {
         // Fall back to proposed routing from decisions if no actual routing captured
@@ -2395,8 +2410,7 @@ export class ContentRouterService {
           seriesType: primaryDecision.seriesType,
           minimumAvailability: primaryDecision.minimumAvailability,
           monitor: primaryDecision.monitor,
-          syncedInstances:
-            syncedInstances.length > 0 ? syncedInstances : undefined,
+          syncedInstances: normalizedSyncedInstances,
         }
       } else {
         // Default routing case - use instance information from routed instances
@@ -2410,8 +2424,7 @@ export class ContentRouterService {
           tags: [],
           priority: 50,
           searchOnAdd: null,
-          syncedInstances:
-            syncedInstances.length > 0 ? syncedInstances : undefined,
+          syncedInstances: normalizedSyncedInstances,
         }
       }
 


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected how default instances are identified in approval routing workflows—now uses explicit configuration instead of inferring from synced instance presence.
  * Updated display logic for synced instances sections in routing cards to align with instance configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamcalli/Pulsarr/pull/1184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->