### PR TITLE
fix(session-monitor): stop unmonitoring seasons other users still need

### DIFF
--- a/src/services/plex-server/sse/plex-event-source.ts
+++ b/src/services/plex-server/sse/plex-event-source.ts
@@ -44,6 +44,16 @@ const MAX_BACKOFF_MS = 30_000
 const INITIAL_BACKOFF_MS = 1_000
 const STABLE_CONNECTION_MS = 60_000
 
+// Plex emits 'buffering' between 'playing' frames during scrubs and hiccups.
+export function normalizePlayingNotification(
+  notification: PlexPlaySessionNotification,
+): PlexPlaySessionNotification {
+  if (notification.state !== 'buffering') {
+    return notification
+  }
+  return { ...notification, state: 'playing' }
+}
+
 export interface PlexEventSourceConfig {
   serverUrl: string
   token: string
@@ -283,7 +293,9 @@ export class PlexEventSource {
       const data = JSON.parse(String(evt.data)) as {
         PlaySessionStateNotification: PlexPlaySessionNotification
       }
-      this.emitter.emit('playing', [data.PlaySessionStateNotification])
+      this.emitter.emit('playing', [
+        normalizePlayingNotification(data.PlaySessionStateNotification),
+      ])
     } catch {
       this.log.debug('Failed to parse SSE playing event data')
     }
@@ -303,7 +315,12 @@ export class PlexEventSource {
     container: NotificationContainer['NotificationContainer'],
   ): void {
     if (container.PlaySessionStateNotification) {
-      this.emitter.emit('playing', container.PlaySessionStateNotification)
+      this.emitter.emit(
+        'playing',
+        container.PlaySessionStateNotification.map(
+          normalizePlayingNotification,
+        ),
+      )
     }
     if (container.TimelineEntry) {
       this.emitter.emit('timeline', container.TimelineEntry)

--- a/src/services/plex-session-monitor.service.ts
+++ b/src/services/plex-session-monitor.service.ts
@@ -13,6 +13,10 @@ import type {
 } from '@root/types/plex-session.types.js'
 import type { SonarrSeries } from '@root/types/sonarr.types.js'
 import {
+  collectSeasonsEligibleForCleanup,
+  userNeedsSeason,
+} from '@services/plex-session-monitor/cleanup-predicates.js'
+import {
   extractPlexKey,
   extractTvdbId,
   normalizeGuid,
@@ -255,6 +259,11 @@ export class PlexSessionMonitorService {
     const currentSeason = session.parentIndex
     const currentEpisode = session.index
 
+    // rollingShow was read pre-write, so last_watched_* are the prior values.
+    const positionUnchanged =
+      rollingShow.last_watched_season === currentSeason &&
+      rollingShow.last_watched_episode === currentEpisode
+
     // Always update progress tracking (regardless of user filtering)
     await this.updateRollingShowProgress(
       rollingShow.id,
@@ -271,7 +280,7 @@ export class PlexSessionMonitorService {
       return
     }
 
-    // allSeasonPilotRolling: watching any season's pilot expands that season
+    // Above the positionUnchanged gate so a transient failure retries on repeated E01.
     if (
       rollingShow.monitoring_type === 'allSeasonPilotRolling' &&
       currentEpisode === 1
@@ -297,6 +306,10 @@ export class PlexSessionMonitorService {
 
     // allSeasonPilotRolling only expands via pilot watch, not end-of-season threshold
     if (rollingShow.monitoring_type === 'allSeasonPilotRolling') return
+
+    // The next-season check below hits Sonarr getAllSeries (uncached full
+    // library dump), so skip it on no-progress events.
+    if (positionUnchanged) return
 
     // Check if we need to expand monitoring using Sonarr data
     const currentSeasonData = await this.getSonarrSeriesData(session)
@@ -577,9 +590,8 @@ export class PlexSessionMonitorService {
     }
   }
 
-  /**
-   * Update rolling show progress
-   */
+  // Cleanup is gated on season advancement because Plex emits 'playing'
+  // every ~10s plus extras on each scrub/pause/resume.
   private async updateRollingShowProgress(
     showId: number,
     season: number,
@@ -587,14 +599,17 @@ export class PlexSessionMonitorService {
     canTriggerActions = true,
   ): Promise<void> {
     try {
+      const priorRow = await this.db.getRollingMonitoredShowById(showId)
+      const priorSeason = priorRow?.last_watched_season ?? 0
+
       await this.db.updateRollingShowProgress(showId, season, episode)
 
-      // Check if progressive cleanup is enabled and trigger cleanup if needed
-      // Only trigger for users allowed to perform monitoring actions
-      if (
+      const shouldRunCleanup =
         this.config.plexSessionMonitoring?.enableProgressiveCleanup &&
-        canTriggerActions
-      ) {
+        canTriggerActions &&
+        season > priorSeason
+
+      if (shouldRunCleanup) {
         const rollingShow = await this.db.getRollingMonitoredShowById(showId)
         if (rollingShow) {
           await this.checkAndPerformProgressiveCleanup(rollingShow, season)
@@ -1081,29 +1096,6 @@ export class PlexSessionMonitorService {
   }
 
   /**
-   * Collect seasons eligible for progressive cleanup by checking user activity.
-   * A season is safe to clean only if no active filtered user is still watching it.
-   */
-  private collectSeasonsEligibleForCleanup(
-    startSeason: number,
-    maxSeasonExclusive: number,
-    activeUsers: RollingMonitoredShow[],
-  ): number[] {
-    const seasons: number[] = []
-    for (let season = startSeason; season < maxSeasonExclusive; season++) {
-      const anyUserWatchingSeason = activeUsers.some((show) => {
-        const last = show.last_watched_season ?? 0
-        const monitored = show.current_monitored_season ?? 0
-        return last <= season && monitored >= season
-      })
-      if (!anyUserWatchingSeason) {
-        seasons.push(season)
-      }
-    }
-    return seasons
-  }
-
-  /**
    * Progressive cleanup for rolling monitored shows
    * Removes previous seasons when a user progresses to the next season,
    * but only if no filtered users (including current user) have watched those
@@ -1148,6 +1140,13 @@ export class PlexSessionMonitorService {
       )
 
       this.log.debug(
+        {
+          users: allUsersWatchingShow.map((u) => ({
+            user: u.plex_username,
+            last_watched_season: u.last_watched_season,
+            last_watched_episode: u.last_watched_episode,
+          })),
+        },
         `Progressive cleanup safety check: found ${allUsersWatchingShow.length} active filtered users for ${rollingShow.show_title}`,
       )
 
@@ -1170,7 +1169,7 @@ export class PlexSessionMonitorService {
       )
 
       seasonsToCleanup.push(
-        ...this.collectSeasonsEligibleForCleanup(
+        ...collectSeasonsEligibleForCleanup(
           startSeason,
           maxSeasonToCheck,
           allUsersWatchingShow,
@@ -1179,9 +1178,8 @@ export class PlexSessionMonitorService {
 
       // pilotRolling: also check if Season 1 needs reset back to pilot-only (when watching S2+)
       if (rollingShow.monitoring_type === 'pilotRolling' && currentSeason > 1) {
-        const anyUserWatchingSeason1 = allUsersWatchingShow.some(
-          (show) =>
-            show.last_watched_season <= 1 && show.current_monitored_season >= 1,
+        const anyUserWatchingSeason1 = allUsersWatchingShow.some((show) =>
+          userNeedsSeason(show, 1),
         )
         this.log.debug(
           `Season 1 pilot reset check - any filtered user watching S1: ${anyUserWatchingSeason1}, currentSeason: ${currentSeason}`,

--- a/src/services/plex-session-monitor/cleanup-predicates.ts
+++ b/src/services/plex-session-monitor/cleanup-predicates.ts
@@ -1,0 +1,31 @@
+import type { RollingMonitoredShow } from '@root/types/plex-session.types.js'
+
+/**
+ * A season is protected if it is the current or next season for the given user.
+ *
+ * current_monitored_season is deliberately not consulted - it is a high-water-mark
+ * that only advances when expandMonitoringToNextSeason fires near end-of-season,
+ * so a user on S01E03 would otherwise have S02 (their next) wrongly unmonitored
+ * when another user pushes ahead in the same series.
+ */
+export function userNeedsSeason(
+  show: RollingMonitoredShow,
+  season: number,
+): boolean {
+  const last = show.last_watched_season ?? 0
+  return season >= last && season <= last + 1
+}
+
+export function collectSeasonsEligibleForCleanup(
+  startSeason: number,
+  maxSeasonExclusive: number,
+  activeUsers: RollingMonitoredShow[],
+): number[] {
+  const seasons: number[] = []
+  for (let season = startSeason; season < maxSeasonExclusive; season++) {
+    if (!activeUsers.some((show) => userNeedsSeason(show, season))) {
+      seasons.push(season)
+    }
+  }
+  return seasons
+}

--- a/test/integration/services/plex-session-monitor/progressive-cleanup-workflow.test.ts
+++ b/test/integration/services/plex-session-monitor/progressive-cleanup-workflow.test.ts
@@ -1,0 +1,1379 @@
+/**
+ * Integration tests for progressive cleanup multi-user safety
+ *
+ * Exercises monitorSessions end-to-end with real Fastify and real database.
+ * Plex and Sonarr boundaries are stubbed so the test asserts on the actual
+ * cleanup decisions the orchestration emits (which seasons get unmonitored,
+ * which files get deleted) for each monitoring type.
+ */
+
+import type {
+  PlexSession,
+  RollingMonitoredShow,
+} from '@root/types/plex-session.types.js'
+import type { SonarrEpisode, SonarrSeries } from '@root/types/sonarr.types.js'
+import type { FastifyInstance } from 'fastify'
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+import { build } from '../../../helpers/app.js'
+import { getTestDatabase, resetDatabase } from '../../../helpers/database.js'
+import { seedAll } from '../../../helpers/seeds/index.js'
+
+async function insertRollingShow(
+  knex: ReturnType<typeof getTestDatabase>,
+  overrides: Partial<RollingMonitoredShow> & {
+    show_title: string
+    monitoring_type: RollingMonitoredShow['monitoring_type']
+    sonarr_series_id: number
+    sonarr_instance_id: number
+    tvdb_id: string
+  },
+): Promise<number> {
+  const now = new Date().toISOString()
+  const [result] = await knex('rolling_monitored_shows')
+    .insert({
+      current_monitored_season: 1,
+      last_watched_season: 0,
+      last_watched_episode: 0,
+      last_session_date: now,
+      created_at: now,
+      updated_at: now,
+      last_updated_at: now,
+      ...overrides,
+    })
+    .returning('id')
+  return typeof result === 'object' ? result.id : (result as number)
+}
+
+describe('Progressive Cleanup → Multi-User Safety Integration', () => {
+  let app: FastifyInstance
+
+  beforeAll(async () => {
+    app = await build()
+    await app.ready()
+  })
+
+  afterAll(async () => {
+    await app.close()
+  })
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    await resetDatabase()
+    await seedAll(getTestDatabase())
+  })
+
+  describe('Multi-user safety (firstSeasonRolling)', () => {
+    it('should leave seasons protected by other active users (Stella bug scenario)', async () => {
+      const knex = getTestDatabase()
+
+      await app.updateConfig({
+        plexSessionMonitoring: {
+          enabled: true,
+          filterUsers: [],
+          enableAutoReset: false,
+          remainingEpisodes: 2,
+          inactivityResetDays: 7,
+          autoResetIntervalHours: 24,
+          pollingIntervalMinutes: 15,
+          enableProgressiveCleanup: true,
+        },
+      })
+
+      const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+
+      await insertRollingShow(knex, {
+        show_title: 'Stella',
+        monitoring_type: 'firstSeasonRolling',
+        sonarr_series_id: 1566,
+        sonarr_instance_id: 1,
+        tvdb_id: '90210',
+        current_monitored_season: 1,
+      })
+      await insertRollingShow(knex, {
+        show_title: 'Stella',
+        monitoring_type: 'firstSeasonRolling',
+        sonarr_series_id: 1566,
+        sonarr_instance_id: 1,
+        tvdb_id: '90210',
+        plex_user_id: 'u_nicole',
+        plex_username: 'nicole3876',
+        last_watched_season: 3,
+        last_watched_episode: 7,
+        current_monitored_season: 5,
+        last_session_date: yesterday,
+      })
+      await insertRollingShow(knex, {
+        show_title: 'Stella',
+        monitoring_type: 'firstSeasonRolling',
+        sonarr_series_id: 1566,
+        sonarr_instance_id: 1,
+        tvdb_id: '90210',
+        plex_user_id: 'u_storm',
+        plex_username: 'stormshaker',
+        last_watched_season: 1,
+        last_watched_episode: 3,
+        current_monitored_season: 1,
+        last_session_date: yesterday,
+      })
+
+      const mockGetActiveSessions = vi
+        .fn()
+        .mockResolvedValue([makeEpisodeSession({ season: 4, episode: 7 })])
+      const mockGetShowMetadata = vi
+        .fn()
+        .mockResolvedValue(makeShowMetadata('90210'))
+
+      app.plexServerService.getActiveSessions = mockGetActiveSessions
+      app.plexServerService.getShowMetadata = mockGetShowMetadata
+
+      const mockUpdateSeasonMonitoring = vi.fn().mockResolvedValue(true)
+      const mockGetEpisodes = vi
+        .fn()
+        .mockResolvedValue(makeEpisodesWithFiles([2, 3], 1566))
+
+      const fakeSonarr = {
+        getAllSeries: vi.fn().mockResolvedValue([makeSonarrSeries(1566, 5)]),
+        getEpisodes: mockGetEpisodes,
+        updateSeasonMonitoring: mockUpdateSeasonMonitoring,
+        updateEpisodesMonitoring: vi.fn().mockResolvedValue(true),
+        deleteEpisodeFiles: vi.fn().mockResolvedValue(true),
+        searchSeason: vi.fn().mockResolvedValue(true),
+      }
+
+      app.sonarrManager.getAllInstances = vi
+        .fn()
+        .mockResolvedValue([
+          { id: 1, name: 'Test Sonarr', baseUrl: 'http://x', apiKey: 'k' },
+        ])
+      app.sonarrManager.getSonarrService = vi
+        .fn()
+        .mockReturnValue(
+          fakeSonarr as unknown as ReturnType<
+            typeof app.sonarrManager.getSonarrService
+          >,
+        )
+
+      await app.plexSessionMonitor.monitorSessions()
+
+      const unmonitoredSeasons = mockUpdateSeasonMonitoring.mock.calls
+        .filter((call) => call[2] === false)
+        .map((call) => call[1])
+
+      expect([...unmonitoredSeasons].sort((a, b) => a - b)).toEqual([3])
+    })
+
+    it('should clean seasons when other user is past inactivity cutoff', async () => {
+      const knex = getTestDatabase()
+
+      await app.updateConfig({
+        plexSessionMonitoring: {
+          enabled: true,
+          filterUsers: [],
+          enableAutoReset: false,
+          remainingEpisodes: 2,
+          inactivityResetDays: 7,
+          autoResetIntervalHours: 24,
+          pollingIntervalMinutes: 15,
+          enableProgressiveCleanup: true,
+        },
+      })
+
+      const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+      const longAgo = new Date(
+        Date.now() - 30 * 24 * 60 * 60 * 1000,
+      ).toISOString()
+
+      await insertRollingShow(knex, {
+        show_title: 'Stella',
+        monitoring_type: 'firstSeasonRolling',
+        sonarr_series_id: 1566,
+        sonarr_instance_id: 1,
+        tvdb_id: '90210',
+      })
+      await insertRollingShow(knex, {
+        show_title: 'Stella',
+        monitoring_type: 'firstSeasonRolling',
+        sonarr_series_id: 1566,
+        sonarr_instance_id: 1,
+        tvdb_id: '90210',
+        plex_user_id: 'u_nicole',
+        plex_username: 'nicole3876',
+        last_watched_season: 3,
+        last_watched_episode: 7,
+        current_monitored_season: 5,
+        last_session_date: yesterday,
+      })
+      await insertRollingShow(knex, {
+        show_title: 'Stella',
+        monitoring_type: 'firstSeasonRolling',
+        sonarr_series_id: 1566,
+        sonarr_instance_id: 1,
+        tvdb_id: '90210',
+        plex_user_id: 'u_storm',
+        plex_username: 'stormshaker',
+        last_watched_season: 1,
+        last_watched_episode: 3,
+        current_monitored_season: 1,
+        last_session_date: longAgo,
+      })
+
+      app.plexServerService.getActiveSessions = vi
+        .fn()
+        .mockResolvedValue([makeEpisodeSession({ season: 4, episode: 7 })])
+      app.plexServerService.getShowMetadata = vi
+        .fn()
+        .mockResolvedValue(makeShowMetadata('90210'))
+
+      const mockUpdateSeasonMonitoring = vi.fn().mockResolvedValue(true)
+      const fakeSonarr = {
+        getAllSeries: vi.fn().mockResolvedValue([makeSonarrSeries(1566, 5)]),
+        getEpisodes: vi
+          .fn()
+          .mockResolvedValue(makeEpisodesWithFiles([2, 3], 1566)),
+        updateSeasonMonitoring: mockUpdateSeasonMonitoring,
+        updateEpisodesMonitoring: vi.fn().mockResolvedValue(true),
+        deleteEpisodeFiles: vi.fn().mockResolvedValue(true),
+        searchSeason: vi.fn().mockResolvedValue(true),
+      }
+
+      app.sonarrManager.getAllInstances = vi
+        .fn()
+        .mockResolvedValue([
+          { id: 1, name: 'Test Sonarr', baseUrl: 'http://x', apiKey: 'k' },
+        ])
+      app.sonarrManager.getSonarrService = vi
+        .fn()
+        .mockReturnValue(
+          fakeSonarr as unknown as ReturnType<
+            typeof app.sonarrManager.getSonarrService
+          >,
+        )
+
+      await app.plexSessionMonitor.monitorSessions()
+
+      const unmonitoredSeasons = mockUpdateSeasonMonitoring.mock.calls
+        .filter((call) => call[2] === false)
+        .map((call) => call[1])
+
+      expect([...unmonitoredSeasons].sort((a, b) => a - b)).toEqual([2, 3])
+    })
+
+    it('should record progress for triggering user even when cleanup yields no seasons', async () => {
+      const knex = getTestDatabase()
+
+      await app.updateConfig({
+        plexSessionMonitoring: {
+          enabled: true,
+          filterUsers: [],
+          enableAutoReset: false,
+          remainingEpisodes: 2,
+          inactivityResetDays: 7,
+          autoResetIntervalHours: 24,
+          pollingIntervalMinutes: 15,
+          enableProgressiveCleanup: true,
+        },
+      })
+
+      const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+
+      await insertRollingShow(knex, {
+        show_title: 'Stella',
+        monitoring_type: 'firstSeasonRolling',
+        sonarr_series_id: 1566,
+        sonarr_instance_id: 1,
+        tvdb_id: '90210',
+      })
+      const nicoleId = await insertRollingShow(knex, {
+        show_title: 'Stella',
+        monitoring_type: 'firstSeasonRolling',
+        sonarr_series_id: 1566,
+        sonarr_instance_id: 1,
+        tvdb_id: '90210',
+        plex_user_id: 'u_nicole',
+        plex_username: 'nicole3876',
+        last_watched_season: 3,
+        last_watched_episode: 5,
+        current_monitored_season: 5,
+        last_session_date: yesterday,
+      })
+      await insertRollingShow(knex, {
+        show_title: 'Stella',
+        monitoring_type: 'firstSeasonRolling',
+        sonarr_series_id: 1566,
+        sonarr_instance_id: 1,
+        tvdb_id: '90210',
+        plex_user_id: 'u_storm',
+        plex_username: 'stormshaker',
+        last_watched_season: 2,
+        last_watched_episode: 9,
+        current_monitored_season: 2,
+        last_session_date: yesterday,
+      })
+
+      app.plexServerService.getActiveSessions = vi
+        .fn()
+        .mockResolvedValue([makeEpisodeSession({ season: 4, episode: 7 })])
+      app.plexServerService.getShowMetadata = vi
+        .fn()
+        .mockResolvedValue(makeShowMetadata('90210'))
+
+      const mockUpdateSeasonMonitoring = vi.fn().mockResolvedValue(true)
+      const fakeSonarr = {
+        getAllSeries: vi.fn().mockResolvedValue([makeSonarrSeries(1566, 5)]),
+        getEpisodes: vi
+          .fn()
+          .mockResolvedValue(makeEpisodesWithFiles([2, 3], 1566)),
+        updateSeasonMonitoring: mockUpdateSeasonMonitoring,
+        updateEpisodesMonitoring: vi.fn().mockResolvedValue(true),
+        deleteEpisodeFiles: vi.fn().mockResolvedValue(true),
+        searchSeason: vi.fn().mockResolvedValue(true),
+      }
+
+      app.sonarrManager.getAllInstances = vi
+        .fn()
+        .mockResolvedValue([
+          { id: 1, name: 'Test Sonarr', baseUrl: 'http://x', apiKey: 'k' },
+        ])
+      app.sonarrManager.getSonarrService = vi
+        .fn()
+        .mockReturnValue(
+          fakeSonarr as unknown as ReturnType<
+            typeof app.sonarrManager.getSonarrService
+          >,
+        )
+
+      await app.plexSessionMonitor.monitorSessions()
+
+      const nicoleRow = await knex('rolling_monitored_shows')
+        .where({ id: nicoleId })
+        .first()
+      expect(nicoleRow.last_watched_season).toBe(4)
+      expect(nicoleRow.last_watched_episode).toBe(7)
+
+      const unmonitorCalls = mockUpdateSeasonMonitoring.mock.calls.filter(
+        (call) => call[2] === false,
+      )
+      expect(unmonitorCalls).toEqual([])
+    })
+
+    it('should clean middle seasons left unprotected by a gap between two active users', async () => {
+      const knex = getTestDatabase()
+
+      await app.updateConfig({
+        plexSessionMonitoring: {
+          enabled: true,
+          filterUsers: [],
+          enableAutoReset: false,
+          remainingEpisodes: 2,
+          inactivityResetDays: 7,
+          autoResetIntervalHours: 24,
+          pollingIntervalMinutes: 15,
+          enableProgressiveCleanup: true,
+        },
+      })
+
+      const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+
+      await insertRollingShow(knex, {
+        show_title: 'Stella',
+        monitoring_type: 'firstSeasonRolling',
+        sonarr_series_id: 1566,
+        sonarr_instance_id: 1,
+        tvdb_id: '90210',
+      })
+      await insertRollingShow(knex, {
+        show_title: 'Stella',
+        monitoring_type: 'firstSeasonRolling',
+        sonarr_series_id: 1566,
+        sonarr_instance_id: 1,
+        tvdb_id: '90210',
+        plex_user_id: 'u_nicole',
+        plex_username: 'nicole3876',
+        last_watched_season: 5,
+        last_watched_episode: 3,
+        current_monitored_season: 7,
+        last_session_date: yesterday,
+      })
+      await insertRollingShow(knex, {
+        show_title: 'Stella',
+        monitoring_type: 'firstSeasonRolling',
+        sonarr_series_id: 1566,
+        sonarr_instance_id: 1,
+        tvdb_id: '90210',
+        plex_user_id: 'u_storm',
+        plex_username: 'stormshaker',
+        last_watched_season: 2,
+        last_watched_episode: 4,
+        current_monitored_season: 2,
+        last_session_date: yesterday,
+      })
+
+      app.plexServerService.getActiveSessions = vi
+        .fn()
+        .mockResolvedValue([makeEpisodeSession({ season: 6, episode: 3 })])
+      app.plexServerService.getShowMetadata = vi
+        .fn()
+        .mockResolvedValue(makeShowMetadata('90210'))
+
+      const mockUpdateSeasonMonitoring = vi.fn().mockResolvedValue(true)
+      const fakeSonarr = {
+        getAllSeries: vi.fn().mockResolvedValue([makeSonarrSeries(1566, 7)]),
+        getEpisodes: vi
+          .fn()
+          .mockResolvedValue(makeEpisodesWithFiles([2, 3, 4, 5], 1566)),
+        updateSeasonMonitoring: mockUpdateSeasonMonitoring,
+        updateEpisodesMonitoring: vi.fn().mockResolvedValue(true),
+        deleteEpisodeFiles: vi.fn().mockResolvedValue(true),
+        searchSeason: vi.fn().mockResolvedValue(true),
+      }
+
+      app.sonarrManager.getAllInstances = vi
+        .fn()
+        .mockResolvedValue([
+          { id: 1, name: 'Test Sonarr', baseUrl: 'http://x', apiKey: 'k' },
+        ])
+      app.sonarrManager.getSonarrService = vi
+        .fn()
+        .mockReturnValue(
+          fakeSonarr as unknown as ReturnType<
+            typeof app.sonarrManager.getSonarrService
+          >,
+        )
+
+      await app.plexSessionMonitor.monitorSessions()
+
+      const unmonitoredSeasons = mockUpdateSeasonMonitoring.mock.calls
+        .filter((call) => call[2] === false)
+        .map((call) => call[1])
+
+      expect([...unmonitoredSeasons].sort((a, b) => a - b)).toEqual([4, 5])
+    })
+
+    it('should not protect seasons when only the master record exists for other users', async () => {
+      const knex = getTestDatabase()
+
+      await app.updateConfig({
+        plexSessionMonitoring: {
+          enabled: true,
+          filterUsers: [],
+          enableAutoReset: false,
+          remainingEpisodes: 2,
+          inactivityResetDays: 7,
+          autoResetIntervalHours: 24,
+          pollingIntervalMinutes: 15,
+          enableProgressiveCleanup: true,
+        },
+      })
+
+      const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+
+      await insertRollingShow(knex, {
+        show_title: 'Stella',
+        monitoring_type: 'firstSeasonRolling',
+        sonarr_series_id: 1566,
+        sonarr_instance_id: 1,
+        tvdb_id: '90210',
+        last_watched_season: 1,
+        current_monitored_season: 1,
+      })
+      await insertRollingShow(knex, {
+        show_title: 'Stella',
+        monitoring_type: 'firstSeasonRolling',
+        sonarr_series_id: 1566,
+        sonarr_instance_id: 1,
+        tvdb_id: '90210',
+        plex_user_id: 'u_nicole',
+        plex_username: 'nicole3876',
+        last_watched_season: 3,
+        last_watched_episode: 7,
+        current_monitored_season: 5,
+        last_session_date: yesterday,
+      })
+
+      app.plexServerService.getActiveSessions = vi
+        .fn()
+        .mockResolvedValue([makeEpisodeSession({ season: 4, episode: 7 })])
+      app.plexServerService.getShowMetadata = vi
+        .fn()
+        .mockResolvedValue(makeShowMetadata('90210'))
+
+      const mockUpdateSeasonMonitoring = vi.fn().mockResolvedValue(true)
+      const fakeSonarr = {
+        getAllSeries: vi.fn().mockResolvedValue([makeSonarrSeries(1566, 5)]),
+        getEpisodes: vi
+          .fn()
+          .mockResolvedValue(makeEpisodesWithFiles([2, 3], 1566)),
+        updateSeasonMonitoring: mockUpdateSeasonMonitoring,
+        updateEpisodesMonitoring: vi.fn().mockResolvedValue(true),
+        deleteEpisodeFiles: vi.fn().mockResolvedValue(true),
+        searchSeason: vi.fn().mockResolvedValue(true),
+      }
+
+      app.sonarrManager.getAllInstances = vi
+        .fn()
+        .mockResolvedValue([
+          { id: 1, name: 'Test Sonarr', baseUrl: 'http://x', apiKey: 'k' },
+        ])
+      app.sonarrManager.getSonarrService = vi
+        .fn()
+        .mockReturnValue(
+          fakeSonarr as unknown as ReturnType<
+            typeof app.sonarrManager.getSonarrService
+          >,
+        )
+
+      await app.plexSessionMonitor.monitorSessions()
+
+      const unmonitoredSeasons = mockUpdateSeasonMonitoring.mock.calls
+        .filter((call) => call[2] === false)
+        .map((call) => call[1])
+
+      expect([...unmonitoredSeasons].sort((a, b) => a - b)).toEqual([2, 3])
+    })
+  })
+
+  describe('pilotRolling Season 1 reset', () => {
+    it('should not reset Season 1 to pilot when another user is still on Season 1', async () => {
+      const knex = getTestDatabase()
+
+      await app.updateConfig({
+        plexSessionMonitoring: {
+          enabled: true,
+          filterUsers: [],
+          enableAutoReset: false,
+          remainingEpisodes: 2,
+          inactivityResetDays: 7,
+          autoResetIntervalHours: 24,
+          pollingIntervalMinutes: 15,
+          enableProgressiveCleanup: true,
+        },
+      })
+
+      const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+
+      await insertRollingShow(knex, {
+        show_title: 'Stella',
+        monitoring_type: 'pilotRolling',
+        sonarr_series_id: 1566,
+        sonarr_instance_id: 1,
+        tvdb_id: '90210',
+      })
+      await insertRollingShow(knex, {
+        show_title: 'Stella',
+        monitoring_type: 'pilotRolling',
+        sonarr_series_id: 1566,
+        sonarr_instance_id: 1,
+        tvdb_id: '90210',
+        plex_user_id: 'u_nicole',
+        plex_username: 'nicole3876',
+        last_watched_season: 3,
+        last_watched_episode: 7,
+        current_monitored_season: 5,
+        last_session_date: yesterday,
+      })
+      await insertRollingShow(knex, {
+        show_title: 'Stella',
+        monitoring_type: 'pilotRolling',
+        sonarr_series_id: 1566,
+        sonarr_instance_id: 1,
+        tvdb_id: '90210',
+        plex_user_id: 'u_storm',
+        plex_username: 'stormshaker',
+        last_watched_season: 1,
+        last_watched_episode: 3,
+        current_monitored_season: 1,
+        last_session_date: yesterday,
+      })
+
+      app.plexServerService.getActiveSessions = vi
+        .fn()
+        .mockResolvedValue([makeEpisodeSession({ season: 4, episode: 7 })])
+      app.plexServerService.getShowMetadata = vi
+        .fn()
+        .mockResolvedValue(makeShowMetadata('90210'))
+
+      const mockUpdateEpisodesMonitoring = vi.fn().mockResolvedValue(true)
+      const mockDeleteEpisodeFiles = vi.fn().mockResolvedValue(true)
+      const fakeSonarr = {
+        getAllSeries: vi.fn().mockResolvedValue([makeSonarrSeries(1566, 5)]),
+        getEpisodes: vi
+          .fn()
+          .mockResolvedValue(makeEpisodesWithFiles([1, 2, 3], 1566)),
+        updateSeasonMonitoring: vi.fn().mockResolvedValue(true),
+        updateEpisodesMonitoring: mockUpdateEpisodesMonitoring,
+        deleteEpisodeFiles: mockDeleteEpisodeFiles,
+        searchSeason: vi.fn().mockResolvedValue(true),
+      }
+
+      app.sonarrManager.getAllInstances = vi
+        .fn()
+        .mockResolvedValue([
+          { id: 1, name: 'Test Sonarr', baseUrl: 'http://x', apiKey: 'k' },
+        ])
+      app.sonarrManager.getSonarrService = vi
+        .fn()
+        .mockReturnValue(
+          fakeSonarr as unknown as ReturnType<
+            typeof app.sonarrManager.getSonarrService
+          >,
+        )
+
+      await app.plexSessionMonitor.monitorSessions()
+
+      const deletedFileIds = mockDeleteEpisodeFiles.mock.calls.flatMap(
+        (call) => call[0] as number[],
+      )
+      const season1FileIds = deletedFileIds.filter(
+        (id) => id >= 1000 && id < 2000,
+      )
+      expect(season1FileIds).toEqual([])
+
+      const unmonitoredEpisodeIds = mockUpdateEpisodesMonitoring.mock.calls
+        .flatMap((call) => call[0] as Array<{ id: number; monitored: boolean }>)
+        .filter((ep) => ep.monitored === false && ep.id >= 100 && ep.id < 200)
+        .map((ep) => ep.id)
+      expect(unmonitoredEpisodeIds).toEqual([])
+    })
+
+    it('should reset Season 1 to pilot when no active user is on Season 1', async () => {
+      const knex = getTestDatabase()
+
+      await app.updateConfig({
+        plexSessionMonitoring: {
+          enabled: true,
+          filterUsers: [],
+          enableAutoReset: false,
+          remainingEpisodes: 2,
+          inactivityResetDays: 7,
+          autoResetIntervalHours: 24,
+          pollingIntervalMinutes: 15,
+          enableProgressiveCleanup: true,
+        },
+      })
+
+      const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+
+      await insertRollingShow(knex, {
+        show_title: 'Stella',
+        monitoring_type: 'pilotRolling',
+        sonarr_series_id: 1566,
+        sonarr_instance_id: 1,
+        tvdb_id: '90210',
+      })
+      await insertRollingShow(knex, {
+        show_title: 'Stella',
+        monitoring_type: 'pilotRolling',
+        sonarr_series_id: 1566,
+        sonarr_instance_id: 1,
+        tvdb_id: '90210',
+        plex_user_id: 'u_nicole',
+        plex_username: 'nicole3876',
+        last_watched_season: 3,
+        last_watched_episode: 7,
+        current_monitored_season: 5,
+        last_session_date: yesterday,
+      })
+
+      app.plexServerService.getActiveSessions = vi
+        .fn()
+        .mockResolvedValue([makeEpisodeSession({ season: 4, episode: 7 })])
+      app.plexServerService.getShowMetadata = vi
+        .fn()
+        .mockResolvedValue(makeShowMetadata('90210'))
+
+      const mockUpdateEpisodesMonitoring = vi.fn().mockResolvedValue(true)
+      const mockDeleteEpisodeFiles = vi.fn().mockResolvedValue(true)
+      const fakeSonarr = {
+        getAllSeries: vi.fn().mockResolvedValue([makeSonarrSeries(1566, 5)]),
+        getEpisodes: vi
+          .fn()
+          .mockResolvedValue(makeEpisodesWithFiles([1, 2, 3], 1566)),
+        updateSeasonMonitoring: vi.fn().mockResolvedValue(true),
+        updateEpisodesMonitoring: mockUpdateEpisodesMonitoring,
+        deleteEpisodeFiles: mockDeleteEpisodeFiles,
+        searchSeason: vi.fn().mockResolvedValue(true),
+      }
+
+      app.sonarrManager.getAllInstances = vi
+        .fn()
+        .mockResolvedValue([
+          { id: 1, name: 'Test Sonarr', baseUrl: 'http://x', apiKey: 'k' },
+        ])
+      app.sonarrManager.getSonarrService = vi
+        .fn()
+        .mockReturnValue(
+          fakeSonarr as unknown as ReturnType<
+            typeof app.sonarrManager.getSonarrService
+          >,
+        )
+
+      await app.plexSessionMonitor.monitorSessions()
+
+      const deletedFileIds = mockDeleteEpisodeFiles.mock.calls.flatMap(
+        (call) => call[0] as number[],
+      )
+      const season1FilesDeleted = deletedFileIds
+        .filter((id) => id >= 1000 && id < 2000)
+        .sort((a, b) => a - b)
+      expect(season1FilesDeleted).toEqual([
+        1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009, 1010,
+      ])
+
+      const unmonitoredS1 = mockUpdateEpisodesMonitoring.mock.calls
+        .flatMap((call) => call[0] as Array<{ id: number; monitored: boolean }>)
+        .filter((ep) => ep.monitored === false && ep.id >= 100 && ep.id < 200)
+        .map((ep) => ep.id)
+        .sort((a, b) => a - b)
+      expect(unmonitoredS1).toEqual([
+        102, 103, 104, 105, 106, 107, 108, 109, 110,
+      ])
+    })
+  })
+
+  describe('allSeasonPilotRolling', () => {
+    it('should preserve pilot episodes while cleaning earlier seasons', async () => {
+      const knex = getTestDatabase()
+
+      await app.updateConfig({
+        plexSessionMonitoring: {
+          enabled: true,
+          filterUsers: [],
+          enableAutoReset: false,
+          remainingEpisodes: 2,
+          inactivityResetDays: 7,
+          autoResetIntervalHours: 24,
+          pollingIntervalMinutes: 15,
+          enableProgressiveCleanup: true,
+        },
+      })
+
+      const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+
+      await insertRollingShow(knex, {
+        show_title: 'Stella',
+        monitoring_type: 'allSeasonPilotRolling',
+        sonarr_series_id: 1566,
+        sonarr_instance_id: 1,
+        tvdb_id: '90210',
+      })
+      await insertRollingShow(knex, {
+        show_title: 'Stella',
+        monitoring_type: 'allSeasonPilotRolling',
+        sonarr_series_id: 1566,
+        sonarr_instance_id: 1,
+        tvdb_id: '90210',
+        plex_user_id: 'u_nicole',
+        plex_username: 'nicole3876',
+        last_watched_season: 3,
+        last_watched_episode: 7,
+        current_monitored_season: 5,
+        last_session_date: yesterday,
+      })
+
+      app.plexServerService.getActiveSessions = vi
+        .fn()
+        .mockResolvedValue([makeEpisodeSession({ season: 4, episode: 7 })])
+      app.plexServerService.getShowMetadata = vi
+        .fn()
+        .mockResolvedValue(makeShowMetadata('90210'))
+
+      const mockDeleteEpisodeFiles = vi.fn().mockResolvedValue(true)
+      const mockUpdateEpisodesMonitoring = vi.fn().mockResolvedValue(true)
+      const fakeSonarr = {
+        getAllSeries: vi.fn().mockResolvedValue([makeSonarrSeries(1566, 5)]),
+        getEpisodes: vi
+          .fn()
+          .mockResolvedValue(makeEpisodesWithFiles([1, 2, 3], 1566)),
+        updateSeasonMonitoring: vi.fn().mockResolvedValue(true),
+        updateEpisodesMonitoring: mockUpdateEpisodesMonitoring,
+        deleteEpisodeFiles: mockDeleteEpisodeFiles,
+        searchSeason: vi.fn().mockResolvedValue(true),
+      }
+
+      app.sonarrManager.getAllInstances = vi
+        .fn()
+        .mockResolvedValue([
+          { id: 1, name: 'Test Sonarr', baseUrl: 'http://x', apiKey: 'k' },
+        ])
+      app.sonarrManager.getSonarrService = vi
+        .fn()
+        .mockReturnValue(
+          fakeSonarr as unknown as ReturnType<
+            typeof app.sonarrManager.getSonarrService
+          >,
+        )
+
+      await app.plexSessionMonitor.monitorSessions()
+
+      const deletedFileIds = [
+        ...mockDeleteEpisodeFiles.mock.calls.flatMap(
+          (call) => call[0] as number[],
+        ),
+      ].sort((a, b) => a - b)
+
+      // E02-E10 of S1, S2, S3 - pilots (1001, 2001, 3001) preserved.
+      expect(deletedFileIds).toEqual([
+        1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009, 1010, 2002, 2003, 2004,
+        2005, 2006, 2007, 2008, 2009, 2010, 3002, 3003, 3004, 3005, 3006, 3007,
+        3008, 3009, 3010,
+      ])
+
+      const unmonitoredPilots = mockUpdateEpisodesMonitoring.mock.calls
+        .flatMap((call) => call[0] as Array<{ id: number; monitored: boolean }>)
+        .filter(
+          (ep) =>
+            ep.monitored === false &&
+            (ep.id === 101 || ep.id === 201 || ep.id === 301),
+        )
+      expect(unmonitoredPilots).toEqual([])
+    })
+
+    it('should leave a season intact when another user still needs it', async () => {
+      const knex = getTestDatabase()
+
+      await app.updateConfig({
+        plexSessionMonitoring: {
+          enabled: true,
+          filterUsers: [],
+          enableAutoReset: false,
+          remainingEpisodes: 2,
+          inactivityResetDays: 7,
+          autoResetIntervalHours: 24,
+          pollingIntervalMinutes: 15,
+          enableProgressiveCleanup: true,
+        },
+      })
+
+      const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+
+      await insertRollingShow(knex, {
+        show_title: 'Stella',
+        monitoring_type: 'allSeasonPilotRolling',
+        sonarr_series_id: 1566,
+        sonarr_instance_id: 1,
+        tvdb_id: '90210',
+      })
+      await insertRollingShow(knex, {
+        show_title: 'Stella',
+        monitoring_type: 'allSeasonPilotRolling',
+        sonarr_series_id: 1566,
+        sonarr_instance_id: 1,
+        tvdb_id: '90210',
+        plex_user_id: 'u_nicole',
+        plex_username: 'nicole3876',
+        last_watched_season: 3,
+        last_watched_episode: 7,
+        current_monitored_season: 5,
+        last_session_date: yesterday,
+      })
+      await insertRollingShow(knex, {
+        show_title: 'Stella',
+        monitoring_type: 'allSeasonPilotRolling',
+        sonarr_series_id: 1566,
+        sonarr_instance_id: 1,
+        tvdb_id: '90210',
+        plex_user_id: 'u_storm',
+        plex_username: 'stormshaker',
+        last_watched_season: 2,
+        last_watched_episode: 4,
+        current_monitored_season: 2,
+        last_session_date: yesterday,
+      })
+
+      app.plexServerService.getActiveSessions = vi
+        .fn()
+        .mockResolvedValue([makeEpisodeSession({ season: 4, episode: 7 })])
+      app.plexServerService.getShowMetadata = vi
+        .fn()
+        .mockResolvedValue(makeShowMetadata('90210'))
+
+      const mockDeleteEpisodeFiles = vi.fn().mockResolvedValue(true)
+      const fakeSonarr = {
+        getAllSeries: vi.fn().mockResolvedValue([makeSonarrSeries(1566, 5)]),
+        getEpisodes: vi
+          .fn()
+          .mockResolvedValue(makeEpisodesWithFiles([1, 2, 3], 1566)),
+        updateSeasonMonitoring: vi.fn().mockResolvedValue(true),
+        updateEpisodesMonitoring: vi.fn().mockResolvedValue(true),
+        deleteEpisodeFiles: mockDeleteEpisodeFiles,
+        searchSeason: vi.fn().mockResolvedValue(true),
+      }
+
+      app.sonarrManager.getAllInstances = vi
+        .fn()
+        .mockResolvedValue([
+          { id: 1, name: 'Test Sonarr', baseUrl: 'http://x', apiKey: 'k' },
+        ])
+      app.sonarrManager.getSonarrService = vi
+        .fn()
+        .mockReturnValue(
+          fakeSonarr as unknown as ReturnType<
+            typeof app.sonarrManager.getSonarrService
+          >,
+        )
+
+      await app.plexSessionMonitor.monitorSessions()
+
+      const deletedFileIds = [
+        ...mockDeleteEpisodeFiles.mock.calls.flatMap(
+          (call) => call[0] as number[],
+        ),
+      ].sort((a, b) => a - b)
+
+      // stormshaker on S2 protects S2-S3; only S1 non-pilots are cleanable.
+      expect(deletedFileIds).toEqual([
+        1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009, 1010,
+      ])
+    })
+  })
+
+  describe('Cleanup trigger gating', () => {
+    it('should not call Sonarr cleanup when the user has not advanced into a new season', async () => {
+      const knex = getTestDatabase()
+
+      await app.updateConfig({
+        plexSessionMonitoring: {
+          enabled: true,
+          filterUsers: [],
+          enableAutoReset: false,
+          remainingEpisodes: 2,
+          inactivityResetDays: 7,
+          autoResetIntervalHours: 24,
+          pollingIntervalMinutes: 15,
+          enableProgressiveCleanup: true,
+        },
+      })
+
+      const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+
+      await insertRollingShow(knex, {
+        show_title: 'Stella',
+        monitoring_type: 'firstSeasonRolling',
+        sonarr_series_id: 1566,
+        sonarr_instance_id: 1,
+        tvdb_id: '90210',
+      })
+      await insertRollingShow(knex, {
+        show_title: 'Stella',
+        monitoring_type: 'firstSeasonRolling',
+        sonarr_series_id: 1566,
+        sonarr_instance_id: 1,
+        tvdb_id: '90210',
+        plex_user_id: 'u_nicole',
+        plex_username: 'nicole3876',
+        last_watched_season: 4,
+        last_watched_episode: 7,
+        current_monitored_season: 5,
+        last_session_date: yesterday,
+      })
+
+      app.plexServerService.getActiveSessions = vi
+        .fn()
+        .mockResolvedValue([makeEpisodeSession({ season: 4, episode: 7 })])
+      app.plexServerService.getShowMetadata = vi
+        .fn()
+        .mockResolvedValue(makeShowMetadata('90210'))
+
+      const mockUpdateSeasonMonitoring = vi.fn().mockResolvedValue(true)
+      const mockDeleteEpisodeFiles = vi.fn().mockResolvedValue(true)
+      const mockGetEpisodes = vi
+        .fn()
+        .mockResolvedValue(makeEpisodesWithFiles([2, 3], 1566))
+
+      const mockGetAllSeries = vi
+        .fn()
+        .mockResolvedValue([makeSonarrSeries(1566, 5)])
+      const fakeSonarr = {
+        getAllSeries: mockGetAllSeries,
+        getEpisodes: mockGetEpisodes,
+        updateSeasonMonitoring: mockUpdateSeasonMonitoring,
+        updateEpisodesMonitoring: vi.fn().mockResolvedValue(true),
+        deleteEpisodeFiles: mockDeleteEpisodeFiles,
+        searchSeason: vi.fn().mockResolvedValue(true),
+      }
+
+      app.sonarrManager.getAllInstances = vi
+        .fn()
+        .mockResolvedValue([
+          { id: 1, name: 'Test Sonarr', baseUrl: 'http://x', apiKey: 'k' },
+        ])
+      app.sonarrManager.getSonarrService = vi
+        .fn()
+        .mockReturnValue(
+          fakeSonarr as unknown as ReturnType<
+            typeof app.sonarrManager.getSonarrService
+          >,
+        )
+
+      await app.plexSessionMonitor.monitorSessions()
+
+      expect(mockUpdateSeasonMonitoring).not.toHaveBeenCalled()
+      expect(mockDeleteEpisodeFiles).not.toHaveBeenCalled()
+      expect(mockGetAllSeries).not.toHaveBeenCalled()
+      expect(mockGetEpisodes).not.toHaveBeenCalled()
+    })
+
+    it('should still run the expansion check when the user advances to a new episode within the same season', async () => {
+      const knex = getTestDatabase()
+
+      await app.updateConfig({
+        plexSessionMonitoring: {
+          enabled: true,
+          filterUsers: [],
+          enableAutoReset: false,
+          remainingEpisodes: 2,
+          inactivityResetDays: 7,
+          autoResetIntervalHours: 24,
+          pollingIntervalMinutes: 15,
+          enableProgressiveCleanup: true,
+        },
+      })
+
+      const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+
+      await insertRollingShow(knex, {
+        show_title: 'Stella',
+        monitoring_type: 'firstSeasonRolling',
+        sonarr_series_id: 1566,
+        sonarr_instance_id: 1,
+        tvdb_id: '90210',
+      })
+      await insertRollingShow(knex, {
+        show_title: 'Stella',
+        monitoring_type: 'firstSeasonRolling',
+        sonarr_series_id: 1566,
+        sonarr_instance_id: 1,
+        tvdb_id: '90210',
+        plex_user_id: 'u_nicole',
+        plex_username: 'nicole3876',
+        last_watched_season: 4,
+        last_watched_episode: 6,
+        current_monitored_season: 5,
+        last_session_date: yesterday,
+      })
+
+      app.plexServerService.getActiveSessions = vi
+        .fn()
+        .mockResolvedValue([makeEpisodeSession({ season: 4, episode: 7 })])
+      app.plexServerService.getShowMetadata = vi
+        .fn()
+        .mockResolvedValue(makeShowMetadata('90210'))
+
+      const mockGetAllSeries = vi
+        .fn()
+        .mockResolvedValue([makeSonarrSeries(1566, 5)])
+      const fakeSonarr = {
+        getAllSeries: mockGetAllSeries,
+        getEpisodes: vi
+          .fn()
+          .mockResolvedValue(makeEpisodesWithFiles([2, 3], 1566)),
+        updateSeasonMonitoring: vi.fn().mockResolvedValue(true),
+        updateEpisodesMonitoring: vi.fn().mockResolvedValue(true),
+        deleteEpisodeFiles: vi.fn().mockResolvedValue(true),
+        searchSeason: vi.fn().mockResolvedValue(true),
+      }
+
+      app.sonarrManager.getAllInstances = vi
+        .fn()
+        .mockResolvedValue([
+          { id: 1, name: 'Test Sonarr', baseUrl: 'http://x', apiKey: 'k' },
+        ])
+      app.sonarrManager.getSonarrService = vi
+        .fn()
+        .mockReturnValue(
+          fakeSonarr as unknown as ReturnType<
+            typeof app.sonarrManager.getSonarrService
+          >,
+        )
+
+      await app.plexSessionMonitor.monitorSessions()
+
+      // Without this the end-of-season expansion would never trigger.
+      expect(mockGetAllSeries).toHaveBeenCalled()
+    })
+
+    it('should fire cleanup exactly once when the same session is processed twice without progress', async () => {
+      const knex = getTestDatabase()
+
+      await app.updateConfig({
+        plexSessionMonitoring: {
+          enabled: true,
+          filterUsers: [],
+          enableAutoReset: false,
+          remainingEpisodes: 2,
+          inactivityResetDays: 7,
+          autoResetIntervalHours: 24,
+          pollingIntervalMinutes: 15,
+          enableProgressiveCleanup: true,
+        },
+      })
+
+      const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+
+      await insertRollingShow(knex, {
+        show_title: 'Stella',
+        monitoring_type: 'firstSeasonRolling',
+        sonarr_series_id: 1566,
+        sonarr_instance_id: 1,
+        tvdb_id: '90210',
+      })
+      await insertRollingShow(knex, {
+        show_title: 'Stella',
+        monitoring_type: 'firstSeasonRolling',
+        sonarr_series_id: 1566,
+        sonarr_instance_id: 1,
+        tvdb_id: '90210',
+        plex_user_id: 'u_nicole',
+        plex_username: 'nicole3876',
+        last_watched_season: 3,
+        last_watched_episode: 7,
+        current_monitored_season: 5,
+        last_session_date: yesterday,
+      })
+
+      app.plexServerService.getActiveSessions = vi
+        .fn()
+        .mockResolvedValue([makeEpisodeSession({ season: 4, episode: 7 })])
+      app.plexServerService.getShowMetadata = vi
+        .fn()
+        .mockResolvedValue(makeShowMetadata('90210'))
+
+      const mockUpdateSeasonMonitoring = vi.fn().mockResolvedValue(true)
+      const fakeSonarr = {
+        getAllSeries: vi.fn().mockResolvedValue([makeSonarrSeries(1566, 5)]),
+        getEpisodes: vi
+          .fn()
+          .mockResolvedValue(makeEpisodesWithFiles([2, 3], 1566)),
+        updateSeasonMonitoring: mockUpdateSeasonMonitoring,
+        updateEpisodesMonitoring: vi.fn().mockResolvedValue(true),
+        deleteEpisodeFiles: vi.fn().mockResolvedValue(true),
+        searchSeason: vi.fn().mockResolvedValue(true),
+      }
+
+      app.sonarrManager.getAllInstances = vi
+        .fn()
+        .mockResolvedValue([
+          { id: 1, name: 'Test Sonarr', baseUrl: 'http://x', apiKey: 'k' },
+        ])
+      app.sonarrManager.getSonarrService = vi
+        .fn()
+        .mockReturnValue(
+          fakeSonarr as unknown as ReturnType<
+            typeof app.sonarrManager.getSonarrService
+          >,
+        )
+
+      await app.plexSessionMonitor.monitorSessions()
+      const callsAfterFirst = mockUpdateSeasonMonitoring.mock.calls.length
+      await app.plexSessionMonitor.monitorSessions()
+      const callsAfterSecond = mockUpdateSeasonMonitoring.mock.calls.length
+
+      // First run crosses 3 to 4 and cleans; second run sees prior at 4 and no-ops.
+      expect(callsAfterFirst).toBeGreaterThan(0)
+      expect(callsAfterSecond).toBe(callsAfterFirst)
+
+      const unmonitoredSeasons = mockUpdateSeasonMonitoring.mock.calls
+        .filter((call) => call[2] === false)
+        .map((call) => call[1])
+        .sort((a, b) => a - b)
+      expect(unmonitoredSeasons).toEqual([2, 3])
+    })
+
+    it('should still attempt pilot expansion on repeated E01 events so transient failures retry', async () => {
+      const knex = getTestDatabase()
+
+      await app.updateConfig({
+        plexSessionMonitoring: {
+          enabled: true,
+          filterUsers: [],
+          enableAutoReset: false,
+          remainingEpisodes: 2,
+          inactivityResetDays: 7,
+          autoResetIntervalHours: 24,
+          pollingIntervalMinutes: 15,
+          enableProgressiveCleanup: true,
+        },
+      })
+
+      const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+
+      await insertRollingShow(knex, {
+        show_title: 'Stella',
+        monitoring_type: 'pilotRolling',
+        sonarr_series_id: 1566,
+        sonarr_instance_id: 1,
+        tvdb_id: '90210',
+      })
+      await insertRollingShow(knex, {
+        show_title: 'Stella',
+        monitoring_type: 'pilotRolling',
+        sonarr_series_id: 1566,
+        sonarr_instance_id: 1,
+        tvdb_id: '90210',
+        plex_user_id: 'u_nicole',
+        plex_username: 'nicole3876',
+        last_watched_season: 1,
+        last_watched_episode: 1,
+        current_monitored_season: 1,
+        last_session_date: yesterday,
+      })
+
+      app.plexServerService.getActiveSessions = vi
+        .fn()
+        .mockResolvedValue([makeEpisodeSession({ season: 1, episode: 1 })])
+      app.plexServerService.getShowMetadata = vi
+        .fn()
+        .mockResolvedValue(makeShowMetadata('90210'))
+
+      // Episodes for S1 with E02-E10 unmonitored so the expand path runs each call.
+      const s1Episodes: SonarrEpisode[] = []
+      for (let n = 1; n <= 10; n++) {
+        s1Episodes.push({
+          id: 100 + n,
+          seriesId: 1566,
+          episodeFileId: 1000 + n,
+          seasonNumber: 1,
+          episodeNumber: n,
+          title: `S01E${n}`,
+          hasFile: n === 1,
+          monitored: n === 1,
+          unverifiedSceneNumbering: false,
+          grabbed: false,
+        })
+      }
+      const mockGetEpisodes = vi.fn().mockResolvedValue(s1Episodes)
+      const mockUpdateSeasonMonitoring = vi.fn().mockResolvedValue(true)
+      const fakeSonarr = {
+        getAllSeries: vi.fn().mockResolvedValue([makeSonarrSeries(1566, 5)]),
+        getEpisodes: mockGetEpisodes,
+        updateSeasonMonitoring: mockUpdateSeasonMonitoring,
+        updateEpisodesMonitoring: vi.fn().mockResolvedValue(true),
+        deleteEpisodeFiles: vi.fn().mockResolvedValue(true),
+        searchSeason: vi.fn().mockResolvedValue(true),
+      }
+
+      app.sonarrManager.getAllInstances = vi
+        .fn()
+        .mockResolvedValue([
+          { id: 1, name: 'Test Sonarr', baseUrl: 'http://x', apiKey: 'k' },
+        ])
+      app.sonarrManager.getSonarrService = vi
+        .fn()
+        .mockReturnValue(
+          fakeSonarr as unknown as ReturnType<
+            typeof app.sonarrManager.getSonarrService
+          >,
+        )
+
+      // Prior position already matches the session - positionUnchanged is true.
+      // Pilot expansion must still fire so a previously-failed expansion retries.
+      await app.plexSessionMonitor.monitorSessions()
+
+      expect(mockGetEpisodes).toHaveBeenCalled()
+      expect(mockUpdateSeasonMonitoring).toHaveBeenCalledWith(1566, 1, true)
+    })
+  })
+})
+
+function makeEpisodeSession({
+  season,
+  episode,
+}: {
+  season: number
+  episode: number
+}): PlexSession {
+  return {
+    type: 'episode',
+    sessionKey: 'sess-nicole',
+    ratingKey: '106942',
+    key: '/library/metadata/106942',
+    guid: 'plex://episode/abc',
+    title: 'Episode',
+    parentRatingKey: '106941',
+    parentKey: '/library/metadata/106941',
+    parentIndex: season,
+    parentTitle: `Season ${season}`,
+    parentGuid: 'plex://season/abc',
+    grandparentRatingKey: '106940',
+    grandparentKey: '/library/metadata/106940',
+    grandparentTitle: 'Stella',
+    grandparentGuid: 'plex://show/abc',
+    index: episode,
+    viewOffset: 0,
+    duration: 1_200_000,
+    User: { id: 'u_nicole', title: 'nicole3876' },
+    Session: { id: 'session', bandwidth: 0, location: 'lan' },
+    librarySectionTitle: 'TV Shows',
+    librarySectionID: '2',
+  }
+}
+
+function makeShowMetadata(tvdbId: string) {
+  return {
+    MediaContainer: {
+      Metadata: [
+        {
+          ratingKey: '106940',
+          guid: 'plex://show/abc',
+          Guid: [{ id: `tvdb://${tvdbId}` }, { id: 'imdb://tt12345' }],
+        },
+      ],
+    },
+  }
+}
+
+function makeSonarrSeries(
+  seriesId: number,
+  totalSeasons: number,
+): SonarrSeries {
+  const seasons = []
+  for (let n = 1; n <= totalSeasons; n++) {
+    seasons.push({
+      seasonNumber: n,
+      monitored: true,
+      statistics: { totalEpisodeCount: 16 },
+    })
+  }
+  return {
+    title: 'Stella',
+    tvdbId: 90210,
+    id: seriesId,
+    seasons,
+  } as unknown as SonarrSeries
+}
+
+// Builds episodes for the given seasons with files. Episode IDs are
+// seasonNumber*100 + episodeNumber (e.g. S2E3 = 203). File IDs are
+// seasonNumber*1000 + episodeNumber (e.g. S2E3 = 2003). E01 of each
+// season is the pilot, E02-E10 are the rest.
+function makeEpisodesWithFiles(
+  seasons: number[],
+  seriesId: number,
+): SonarrEpisode[] {
+  const episodes: SonarrEpisode[] = []
+  for (const seasonNumber of seasons) {
+    for (let n = 1; n <= 10; n++) {
+      episodes.push({
+        id: seasonNumber * 100 + n,
+        seriesId,
+        episodeFileId: seasonNumber * 1000 + n,
+        seasonNumber,
+        episodeNumber: n,
+        title: `S${seasonNumber}E${n}`,
+        hasFile: true,
+        monitored: true,
+        unverifiedSceneNumbering: false,
+        grabbed: false,
+      })
+    }
+  }
+  return episodes
+}

--- a/test/unit/services/plex-server/sse/plex-event-source.test.ts
+++ b/test/unit/services/plex-server/sse/plex-event-source.test.ts
@@ -1,0 +1,58 @@
+import type { PlexPlaySessionNotification } from '@root/types/plex-session.types.js'
+import { normalizePlayingNotification } from '@services/plex-server/sse/plex-event-source.js'
+import { describe, expect, it } from 'vitest'
+
+function makeNotification(
+  overrides: Partial<PlexPlaySessionNotification> = {},
+): PlexPlaySessionNotification {
+  return {
+    sessionKey: '322',
+    clientIdentifier: 'zmupu10q',
+    guid: 'plex://episode/abc',
+    ratingKey: '109498',
+    url: '',
+    key: '/library/metadata/109498',
+    viewOffset: 1_234_000,
+    playQueueItemID: 169073,
+    state: 'playing',
+    ...overrides,
+  }
+}
+
+describe('normalizePlayingNotification', () => {
+  it('rewrites buffering to playing', () => {
+    const input = makeNotification({ state: 'buffering' })
+    const out = normalizePlayingNotification(input)
+    expect(out.state).toBe('playing')
+  })
+
+  it('preserves every other field when rewriting buffering', () => {
+    const input = makeNotification({
+      state: 'buffering',
+      sessionKey: '999',
+      viewOffset: 42,
+    })
+    const out = normalizePlayingNotification(input)
+    expect(out).toEqual({ ...input, state: 'playing' })
+  })
+
+  it('does not mutate the input when rewriting', () => {
+    const input = makeNotification({ state: 'buffering' })
+    normalizePlayingNotification(input)
+    expect(input.state).toBe('buffering')
+  })
+
+  it('passes playing through unchanged', () => {
+    const input = makeNotification({ state: 'playing' })
+    expect(normalizePlayingNotification(input)).toBe(input)
+  })
+
+  it.each([
+    'paused',
+    'stopped',
+    'error',
+  ] as const)('passes %s through unchanged', (state) => {
+    const input = makeNotification({ state })
+    expect(normalizePlayingNotification(input)).toBe(input)
+  })
+})

--- a/test/unit/services/plex-session-monitor/cleanup-predicates.test.ts
+++ b/test/unit/services/plex-session-monitor/cleanup-predicates.test.ts
@@ -1,0 +1,170 @@
+import type { RollingMonitoredShow } from '@root/types/plex-session.types.js'
+import {
+  collectSeasonsEligibleForCleanup,
+  userNeedsSeason,
+} from '@services/plex-session-monitor/cleanup-predicates.js'
+import { describe, expect, it } from 'vitest'
+
+function makeUser(
+  overrides: Partial<RollingMonitoredShow> & {
+    plex_username: string
+    last_watched_season: number
+  },
+): RollingMonitoredShow {
+  return {
+    id: 1,
+    sonarr_series_id: 1566,
+    show_title: 'Stella',
+    monitoring_type: 'firstSeasonRolling',
+    current_monitored_season: 1,
+    last_watched_episode: 1,
+    last_session_date: '2026-05-23T00:00:00Z',
+    sonarr_instance_id: 1,
+    plex_user_id: 'u1',
+    created_at: '2026-05-22T00:00:00Z',
+    updated_at: '2026-05-23T00:00:00Z',
+    last_updated_at: '2026-05-23T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('userNeedsSeason', () => {
+  it('protects the user current season', () => {
+    const user = makeUser({ plex_username: 'a', last_watched_season: 3 })
+    expect(userNeedsSeason(user, 3)).toBe(true)
+  })
+
+  it('protects the next season after the user current position', () => {
+    const user = makeUser({ plex_username: 'a', last_watched_season: 3 })
+    expect(userNeedsSeason(user, 4)).toBe(true)
+  })
+
+  it('does not protect seasons before the user current position', () => {
+    const user = makeUser({ plex_username: 'a', last_watched_season: 3 })
+    expect(userNeedsSeason(user, 2)).toBe(false)
+  })
+
+  it('does not protect seasons more than one ahead of the user', () => {
+    const user = makeUser({ plex_username: 'a', last_watched_season: 3 })
+    expect(userNeedsSeason(user, 5)).toBe(false)
+  })
+
+  it('ignores current_monitored_season - relies only on last_watched_season', () => {
+    // current_monitored_season only advances at end-of-season; a user on
+    // S01E03 still needs S02 as their next, but current_monitored_season=1
+    // would falsely allow S02 to be cleaned if the predicate consulted it.
+    const user = makeUser({
+      plex_username: 'a',
+      last_watched_season: 1,
+      current_monitored_season: 1,
+    })
+    expect(userNeedsSeason(user, 2)).toBe(true)
+  })
+
+  it('protects S1 for a fresh entry with last_watched_season 0', () => {
+    const user = makeUser({
+      plex_username: 'a',
+      last_watched_season: 0,
+    })
+    expect(userNeedsSeason(user, 1)).toBe(true)
+    expect(userNeedsSeason(user, 2)).toBe(false)
+  })
+})
+
+describe('collectSeasonsEligibleForCleanup', () => {
+  it('returns empty when range is empty', () => {
+    const users = [makeUser({ plex_username: 'a', last_watched_season: 5 })]
+    expect(collectSeasonsEligibleForCleanup(2, 2, users)).toEqual([])
+  })
+
+  it('returns the full range when there are no active users to protect any season', () => {
+    expect(collectSeasonsEligibleForCleanup(2, 5, [])).toEqual([2, 3, 4])
+  })
+
+  describe('multi-user scenarios', () => {
+    it('Stella bug scenario: two users at S1 and S4, only S3 is cleanable', () => {
+      // firstSeasonRolling, cleanup range is [2, 4) since the triggering
+      // user (nicole) is on S4. stormshaker on S01E03 must protect S2.
+      const users = [
+        makeUser({ plex_username: 'stormshaker', last_watched_season: 1 }),
+        makeUser({ plex_username: 'nicole3876', last_watched_season: 4 }),
+      ]
+      expect(collectSeasonsEligibleForCleanup(2, 4, users)).toEqual([3])
+    })
+
+    it('leaves middle season cleanable when a gap exists between users', () => {
+      // Users on S2 and S6 mean S4 is needed by nobody.
+      const users = [
+        makeUser({ plex_username: 'a', last_watched_season: 2 }),
+        makeUser({ plex_username: 'b', last_watched_season: 6 }),
+      ]
+      // a protects {2,3}, b protects {6,7}. Range [2,6) cleans {4,5}.
+      expect(collectSeasonsEligibleForCleanup(2, 6, users)).toEqual([4, 5])
+    })
+
+    it('single user advancing leaves earlier seasons cleanable', () => {
+      const users = [makeUser({ plex_username: 'a', last_watched_season: 5 })]
+      expect(collectSeasonsEligibleForCleanup(2, 5, users)).toEqual([2, 3, 4])
+    })
+  })
+
+  describe('monitoring type ranges', () => {
+    it('firstSeasonRolling: range starts at 2', () => {
+      const users = [makeUser({ plex_username: 'a', last_watched_season: 1 })]
+      // S1 is never in the cleanup range, even though it is "current" for a.
+      expect(collectSeasonsEligibleForCleanup(2, 4, users)).toEqual([3])
+    })
+
+    it('pilotRolling: range starts at 2 (S1 handled by separate reset path)', () => {
+      const users = [
+        makeUser({
+          plex_username: 'a',
+          monitoring_type: 'pilotRolling',
+          last_watched_season: 1,
+        }),
+      ]
+      expect(collectSeasonsEligibleForCleanup(2, 4, users)).toEqual([3])
+    })
+
+    it('allSeasonPilotRolling: range starts at 1', () => {
+      const users = [
+        makeUser({
+          plex_username: 'a',
+          monitoring_type: 'allSeasonPilotRolling',
+          last_watched_season: 3,
+        }),
+      ]
+      // a protects {3,4}. Range [1,5) cleans {1,2} (E02+ removed, pilots kept).
+      expect(collectSeasonsEligibleForCleanup(1, 5, users)).toEqual([1, 2])
+    })
+  })
+
+  describe('pilotRolling S1 reset predicate (userNeedsSeason with season=1)', () => {
+    it('protects S1 when a user is on S1', () => {
+      const user = makeUser({
+        plex_username: 'a',
+        monitoring_type: 'pilotRolling',
+        last_watched_season: 1,
+      })
+      expect(userNeedsSeason(user, 1)).toBe(true)
+    })
+
+    it('protects S1 for a fresh entry with last_watched_season 0', () => {
+      const user = makeUser({
+        plex_username: 'a',
+        monitoring_type: 'pilotRolling',
+        last_watched_season: 0,
+      })
+      expect(userNeedsSeason(user, 1)).toBe(true)
+    })
+
+    it('allows S1 reset when all active users have moved past S2', () => {
+      const user = makeUser({
+        plex_username: 'a',
+        monitoring_type: 'pilotRolling',
+        last_watched_season: 3,
+      })
+      expect(userNeedsSeason(user, 1)).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Playback notifications with transient "buffering" are normalized to "playing" so downstream events never report buffering.

* **Improvements**
  * Smarter multi-user progressive cleanup: skips redundant work when a session hasn't progressed, respects other users' watched positions, gates cleanup to enabled/allowed cases, and adds safer Season‑1 pilot‑reset handling and expanded debug context.

* **Tests**
  * New integration and unit tests covering progressive‑cleanup workflows and playback‑notification normalization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamcalli/Pulsarr/pull/1186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->