### PR TITLE
fix(apprise): replace blind sleep with HTTP readiness probe

### DIFF
--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -1,10 +1,3 @@
-/**
- * Notification Service
- *
- * Thin orchestrator that owns notification channels.
- * Owns Discord (bot + webhook), Plex Mobile, Apprise, and future channels.
- */
-
 import {
   buildRoutingPayload,
   type WebhookPayloadMap,
@@ -42,12 +35,6 @@ import {
   type WatchlistItemInfo,
 } from './notifications/orchestration/index.js'
 
-/**
- * Notification Service
- *
- * Owns all notification channels and provides lifecycle management.
- * Single decoration point: fastify.notifications
- */
 export class NotificationService {
   private readonly log: FastifyBaseLogger
   private readonly _discordBot: DiscordBotService
@@ -62,67 +49,38 @@ export class NotificationService {
     this.log = createServiceLogger(baseLog, 'NOTIFICATIONS')
     this.log.debug('Initializing notification service')
 
-    // Create Discord services
     this._discordBot = new DiscordBotService(this.log, this.fastify)
     this._discordWebhook = new DiscordWebhookService(this.log, this.fastify)
-
-    // Create Plex Mobile service
     this._plexMobile = new PlexMobileService(this.log, this.fastify)
-
-    // Create Apprise service
     this._apprise = new AppriseService(this.log, this.fastify)
   }
 
-  /**
-   * Discord bot accessor for bot lifecycle and DMs.
-   */
   get discordBot(): DiscordBotService {
     return this._discordBot
   }
 
-  /**
-   * Discord webhook accessor for stateless webhook operations.
-   */
   get discordWebhook(): DiscordWebhookService {
     return this._discordWebhook
   }
 
-  /**
-   * Plex Mobile service accessor for mobile push notifications.
-   */
   get plexMobile(): PlexMobileService {
     return this._plexMobile
   }
 
-  /**
-   * Apprise service accessor for Apprise notifications.
-   */
   get apprise(): AppriseService {
     return this._apprise
   }
 
-  /**
-   * Get Discord bot status.
-   * Convenience method for status emission.
-   */
   getBotStatus(): BotStatus {
     return this._discordBot.getBotStatus()
   }
 
-  /**
-   * Check if Discord bot config is present.
-   */
   get hasBotConfig(): boolean {
     const required = ['discordBotToken', 'discordClientId'] as const
     return required.every((key) => Boolean(this.fastify.config[key]))
   }
 
-  /**
-   * Initialize all notification channels.
-   * Called from plugin onReady hook.
-   */
   async initialize(): Promise<void> {
-    // Initialize Discord bot if configured
     if (this.hasBotConfig) {
       this.log.info('Discord bot configuration found, attempting auto-start')
       try {
@@ -139,44 +97,28 @@ export class NotificationService {
       )
     }
 
-    // Initialize Plex Mobile if configured
     try {
       await this._plexMobile.initialize()
     } catch (error) {
       this.log.error({ error }, 'Failed to initialize Plex Mobile service')
     }
 
-    // Initialize Apprise (fire-and-forget to avoid blocking startup)
-    // The initialization includes a 5-second delay to allow Apprise container to fully start
+    // Fire-and-forget to avoid blocking startup; callers fired during boot
+    // should await fastify.notifications.apprise.whenReady().
     this._apprise.initialize().catch((error) => {
       this.log.error({ error }, 'Unexpected error in Apprise initialization')
     })
   }
 
-  /**
-   * Shutdown all notification channels.
-   * Called from plugin onClose hook.
-   */
   async shutdown(): Promise<void> {
-    // Shutdown Discord bot
     if (this._discordBot.getBotStatus() === 'running') {
       this.log.info('Stopping Discord bot during shutdown')
       await this._discordBot.stopBot()
     }
 
-    // Shutdown Plex Mobile
     this._plexMobile.shutdown()
   }
 
-  /**
-   * Sends a delete sync notification via webhook, DM, and/or Apprise.
-   * Orchestration method that coordinates all channels based on configuration.
-   *
-   * @param results - Delete sync operation results
-   * @param dryRun - Whether this was a dry run
-   * @param notifyOption - Override for notification setting (uses config default if not provided)
-   * @returns Promise resolving to boolean indicating if any notifications were sent
-   */
   async sendDeleteSyncNotification(
     results: DeleteSyncResult,
     dryRun: boolean,
@@ -202,15 +144,6 @@ export class NotificationService {
     )
   }
 
-  /**
-   * Sends watchlist addition notifications to admin channels.
-   * Notifies admins via Discord webhook and/or Apprise when a user adds content.
-   *
-   * @param user - User who added the item
-   * @param item - Watchlist item details
-   * @param routingDetails - Optional routing information from the content router
-   * @returns Promise resolving to boolean indicating if any notifications were sent
-   */
   async sendWatchlistAdded(
     user: Friend & { userId: number },
     item: WatchlistItemInfo,
@@ -242,14 +175,6 @@ export class NotificationService {
     )
   }
 
-  /**
-   * Sends approval batch notifications to configured channels.
-   * Called by ApprovalService after its debounce timer fires.
-   *
-   * @param queuedRequests - Approval requests to notify about
-   * @param totalPending - Total pending approval count
-   * @returns Promise resolving to number of channels that sent successfully
-   */
   async sendApprovalBatch(
     queuedRequests: ApprovalRequestNotification[],
     totalPending: number,
@@ -270,12 +195,7 @@ export class NotificationService {
     )
   }
 
-  /**
-   * Queues a watchlist cap notification with trailing-edge debounce.
-   * Each call resets the timer; notification fires after quiet period.
-   *
-   * @param event - The watchlist cap event details
-   */
+  // Trailing-edge debounce: each call resets the timer; fires after quiet period.
   sendWatchlistCapReached(event: WatchlistCapEvent): void {
     sendWatchlistCapNotification(
       {
@@ -294,20 +214,6 @@ export class NotificationService {
     )
   }
 
-  /**
-   * Sends media available notifications to all relevant users and public channels.
-   *
-   * Orchestration method that:
-   * 1. Looks up all users who watchlisted this content
-   * 2. Checks each user's notification preferences
-   * 3. Creates notification records in the database
-   * 4. Dispatches to all enabled channels (Discord, Apprise, Plex Mobile)
-   * 5. Handles public channel notifications if configured
-   *
-   * @param mediaInfo - Information about the available media
-   * @param options - Processing options
-   * @returns Promise resolving to matched count
-   */
   async sendMediaAvailable(
     mediaInfo: {
       type: 'movie' | 'show'
@@ -337,17 +243,6 @@ export class NotificationService {
     )
   }
 
-  /**
-   * Dispatches a native webhook event to all configured endpoints.
-   *
-   * This is a fire-and-forget method - errors are logged but not thrown.
-   * Use this for events that should trigger external webhooks without
-   * blocking the main operation.
-   *
-   * @param eventType - The type of event being dispatched
-   * @param data - The event payload data (must match WebhookPayloadMap[eventType])
-   * @returns Promise resolving to dispatch result with statistics
-   */
   async sendNativeWebhook<T extends WebhookEventType>(
     eventType: T,
     data: WebhookPayloadMap[T],
@@ -358,19 +253,6 @@ export class NotificationService {
     })
   }
 
-  // ==========================================================================
-  // New Event Methods (Native Webhook Only for Now)
-  // ==========================================================================
-
-  /**
-   * Sends approval resolved notification when an admin approves or rejects a request.
-   *
-   * @param request - The approval request that was resolved
-   * @param resolution - Whether it was approved or denied
-   * @param resolvedBy - User ID of the admin who resolved it
-   * @param notes - Optional notes from the admin
-   * @returns Promise resolving to boolean indicating if notification was sent
-   */
   async sendApprovalResolved(
     request: ApprovalRequest,
     resolution: 'approved' | 'denied',
@@ -387,7 +269,6 @@ export class NotificationService {
     const status =
       resolution === 'denied' ? ('rejected' as const) : ('approved' as const)
 
-    // Build routing with discriminated union based on instanceType
     const routing = proposedRouting
       ? buildRoutingPayload(proposedRouting)
       : undefined
@@ -420,7 +301,6 @@ export class NotificationService {
       log: this.log,
     })
 
-    // Create notification record
     if (result.succeeded > 0) {
       try {
         await this.fastify.db.createNotificationRecord({
@@ -444,15 +324,6 @@ export class NotificationService {
     return result.succeeded > 0
   }
 
-  /**
-   * Sends auto-approval notification when content is auto-approved.
-   * Called from ContentRouterService.createAutoApprovalRecord() with full routing context.
-   *
-   * @param request - The approval request that was auto-approved
-   * @param routing - The routing configuration that was applied
-   * @param reason - Reason for auto-approval
-   * @returns Promise resolving to boolean indicating if notification was sent
-   */
   async sendApprovalAuto(
     request: ApprovalRequest,
     routing: {
@@ -491,7 +362,6 @@ export class NotificationService {
       log: this.log,
     })
 
-    // Create notification record
     if (result.succeeded > 0) {
       try {
         await this.fastify.db.createNotificationRecord({
@@ -515,14 +385,6 @@ export class NotificationService {
     return result.succeeded > 0
   }
 
-  /**
-   * Sends watchlist removed notification when a user removes content from their watchlist.
-   *
-   * @param userId - The user who removed the item
-   * @param username - The username of the user
-   * @param item - The watchlist item that was removed
-   * @returns Promise resolving to boolean indicating if notification was sent
-   */
   async sendWatchlistRemoved(
     userId: number,
     username: string,
@@ -554,7 +416,6 @@ export class NotificationService {
       log: this.log,
     })
 
-    // Create notification record
     if (result.succeeded > 0) {
       try {
         await this.fastify.db.createNotificationRecord({
@@ -578,12 +439,6 @@ export class NotificationService {
     return result.succeeded > 0
   }
 
-  /**
-   * Sends user created notification when a new user is added.
-   *
-   * @param user - The user that was created
-   * @returns Promise resolving to boolean indicating if notification was sent
-   */
   async sendUserCreated(user: User): Promise<boolean> {
     const payload = {
       user: {
@@ -601,7 +456,6 @@ export class NotificationService {
       log: this.log,
     })
 
-    // Create notification record
     if (result.succeeded > 0) {
       try {
         await this.fastify.db.createNotificationRecord({

--- a/src/services/notifications/channels/apprise.service.ts
+++ b/src/services/notifications/channels/apprise.service.ts
@@ -1,10 +1,3 @@
-/**
- * Apprise Service
- *
- * Thin wrapper exposing stateless Apprise functions.
- * Constructs deps internally, delegates to pure functions.
- */
-
 import type { AppriseSchemaFormatMap } from '@root/types/apprise.types.js'
 import type { NotificationUser } from '@root/types/config.types.js'
 import type { DeleteSyncResult } from '@root/types/delete-sync.types.js'
@@ -30,25 +23,24 @@ import { fetchSchemaFormats } from './apprise-format-cache.js'
 
 export type AppriseStatus = 'enabled' | 'disabled' | 'not_configured'
 
-/**
- * Apprise Service
- *
- * Thin wrapper for Apprise notification operations.
- * Follows the deps getter pattern - constructs deps from constructor args,
- * delegates to pure functions in apprise.ts.
- */
+const READY_PROBE_DEADLINE_MS = 30_000
+const READY_PROBE_INTERVAL_MS = 1_000
+
 export class AppriseService {
   private schemaFormatCache: AppriseSchemaFormatMap = new Map()
+  private readyValue = false
+  private readonly readyPromise: Promise<boolean>
+  private resolveReady!: (value: boolean) => void
 
   constructor(
     private readonly log: FastifyBaseLogger,
     private readonly fastify: FastifyInstance,
-  ) {}
+  ) {
+    this.readyPromise = new Promise<boolean>((resolve) => {
+      this.resolveReady = resolve
+    })
+  }
 
-  /**
-   * Constructs deps from instance state.
-   * Following plex-label-sync pattern for deps getters.
-   */
   private get appriseDeps(): AppriseDeps {
     return {
       log: this.log,
@@ -62,25 +54,16 @@ export class AppriseService {
     }
   }
 
-  /**
-   * Checks if Apprise is enabled in configuration.
-   */
   isEnabled(): boolean {
     return checkAppriseEnabled(this.appriseDeps)
   }
 
-  /**
-   * Send public content notification to shared Apprise endpoints.
-   */
   async sendPublicNotification(
     notification: MediaNotification,
   ): Promise<boolean> {
     return sendPublic(notification, this.appriseDeps)
   }
 
-  /**
-   * Sends a media notification to a user via their configured Apprise URL.
-   */
   async sendMediaNotification(
     user: NotificationUser,
     notification: MediaNotification,
@@ -88,18 +71,12 @@ export class AppriseService {
     return sendMedia(user, notification, this.appriseDeps)
   }
 
-  /**
-   * Send a system notification to the configured system endpoint.
-   */
   async sendSystemNotification(
     notification: SystemNotification,
   ): Promise<boolean> {
     return sendSystem(notification, this.appriseDeps)
   }
 
-  /**
-   * Send a delete sync result notification to the admin.
-   */
   async sendDeleteSyncNotification(
     results: DeleteSyncResult,
     dryRun: boolean,
@@ -107,9 +84,6 @@ export class AppriseService {
     return sendDeleteSync(results, dryRun, this.appriseDeps)
   }
 
-  /**
-   * Send a watchlist addition notification.
-   */
   async sendWatchlistAdditionNotification(item: {
     title: string
     type: string
@@ -123,9 +97,6 @@ export class AppriseService {
     return sendWatchlistAddition(item, this.appriseDeps)
   }
 
-  /**
-   * Send a watchlist cap notification to the admin system endpoint.
-   */
   async sendWatchlistCapNotification(event: {
     userName: string
     contentType: string
@@ -135,9 +106,6 @@ export class AppriseService {
     return sendWatchlistCap(event, this.appriseDeps)
   }
 
-  /**
-   * Send a watchlist cap notification to a specific user's Apprise URL.
-   */
   async sendUserWatchlistCapNotification(
     user: NotificationUser,
     event: {
@@ -150,16 +118,10 @@ export class AppriseService {
     return sendUserWatchlistCap(user, event, this.appriseDeps)
   }
 
-  /**
-   * Send a test notification to verify Apprise configuration.
-   */
   async sendTestNotification(targetUrl: string): Promise<boolean> {
     return sendTest(targetUrl, this.appriseDeps)
   }
 
-  /**
-   * Get current Apprise status for UI display.
-   */
   getStatus(): AppriseStatus {
     const appriseUrl = this.fastify.config.appriseUrl
     if (!appriseUrl) {
@@ -168,48 +130,62 @@ export class AppriseService {
     return this.fastify.config.enableApprise ? 'enabled' : 'disabled'
   }
 
-  /**
-   * Initialize Apprise service by checking connectivity.
-   * Updates config.enableApprise based on whether the server is reachable.
-   */
-  async initialize(): Promise<void> {
-    const appriseUrl = this.fastify.config.appriseUrl || ''
+  whenReady(): Promise<boolean> {
+    return this.readyPromise
+  }
 
-    if (!appriseUrl) {
-      this.log.info(
-        'No Apprise URL configured, Apprise notifications will be disabled',
-      )
-      await this.fastify.updateConfig({ enableApprise: false })
-      return
+  isReady(): boolean {
+    return this.readyValue
+  }
+
+  private async probeUntilReachable(appriseUrl: string): Promise<boolean> {
+    const deadline = Date.now() + READY_PROBE_DEADLINE_MS
+    let attempt = 0
+    while (Date.now() < deadline) {
+      attempt++
+      if (await pingAppriseServer(appriseUrl)) {
+        this.log.debug({ attempt }, 'Apprise reachable')
+        return true
+      }
+      if (Date.now() + READY_PROBE_INTERVAL_MS >= deadline) break
+      await new Promise((r) => setTimeout(r, READY_PROBE_INTERVAL_MS))
     }
+    this.log.warn(
+      { attempts: attempt },
+      'Apprise did not become reachable within probe deadline',
+    )
+    return false
+  }
 
-    this.log.debug('Found Apprise URL in configuration')
-
-    // Delay before checking to allow Apprise to fully initialize
-    this.log.debug('Waiting 5 seconds for Apprise to initialize...')
-    await new Promise((resolve) => setTimeout(resolve, 5000))
-
+  async initialize(): Promise<void> {
     try {
-      this.log.debug('Pinging Apprise server to verify it is reachable')
-      const isReachable = await pingAppriseServer(appriseUrl)
+      const appriseUrl = this.fastify.config.appriseUrl || ''
+
+      if (!appriseUrl) {
+        this.log.info(
+          'No Apprise URL configured, Apprise notifications will be disabled',
+        )
+        await this.fastify.updateConfig({ enableApprise: false })
+        return
+      }
+
+      this.log.debug('Probing Apprise server for readiness')
+      const isReachable = await this.probeUntilReachable(appriseUrl)
 
       if (isReachable) {
-        this.log.info('Successfully connected to Apprise container')
-        await this.fastify.updateConfig({ enableApprise: true })
-
-        // Fetch and cache schema formats for format-aware notifications
         this.schemaFormatCache = await fetchSchemaFormats(appriseUrl, this.log)
-
+        await this.fastify.updateConfig({ enableApprise: true })
+        this.readyValue = true
         this.log.info('Apprise notification service is configured and enabled')
       } else {
-        this.log.warn(
-          'Could not connect to Apprise container, notifications will be disabled',
-        )
         await this.fastify.updateConfig({ enableApprise: false })
       }
     } catch (error) {
       this.log.error({ error }, 'Error connecting to Apprise container')
+      this.readyValue = false
       await this.fastify.updateConfig({ enableApprise: false })
+    } finally {
+      this.resolveReady(this.readyValue)
     }
   }
 }

--- a/src/services/webhook-queue.service.ts
+++ b/src/services/webhook-queue.service.ts
@@ -1,10 +1,3 @@
-/**
- * Webhook Queue Service
- *
- * Orchestrates webhook batching and processing for Sonarr/Radarr notifications.
- * Consolidates queue state management, episode detection, and pending webhook handling.
- */
-
 import type {
   RadarrPayload,
   SonarrPayload,
@@ -77,10 +70,6 @@ export class WebhookQueueService {
     }
   }
 
-  // ============================================================================
-  // Getters
-  // ============================================================================
-
   get queue(): WebhookQueue {
     return this._queue
   }
@@ -88,10 +77,6 @@ export class WebhookQueueService {
   get config(): WebhookQueueConfig {
     return this._config
   }
-
-  // ============================================================================
-  // Dependencies
-  // ============================================================================
 
   private get queueManagerDeps(): QueueManagerDeps {
     return { logger: this.log }
@@ -196,10 +181,6 @@ export class WebhookQueueService {
     }
   }
 
-  // ============================================================================
-  // Public Methods - Delegating to Submodules
-  // ============================================================================
-
   isEpisodeAlreadyQueued(
     tvdbId: string,
     seasonNumber: number,
@@ -243,10 +224,6 @@ export class WebhookQueueService {
     return isSeasonComplete(tvdbId, seasonNumber, this.seasonCompletionDeps)
   }
 
-  // ============================================================================
-  // Webhook Handlers
-  // ============================================================================
-
   async handleMovieWebhook(
     body: RadarrPayload,
     instance: RadarrInstance | null,
@@ -255,7 +232,6 @@ export class WebhookQueueService {
     const matchingItems =
       await this.fastify.db.getWatchlistItemsByGuid(tmdbGuid)
 
-    // No matches - queue for later
     if (matchingItems.length === 0) {
       this.log.info(
         {
@@ -276,7 +252,6 @@ export class WebhookQueueService {
       return
     }
 
-    // Check sync status suppression
     if (instance) {
       const suppressed = await shouldSuppressRadarrNotification(
         matchingItems,
@@ -339,7 +314,6 @@ export class WebhookQueueService {
         rollingShow?.monitoring_type === 'allSeasonPilotRolling'
     }
 
-    // Single episode path
     if ('episodeFile' in body && !('episodeFiles' in body)) {
       await this.handleSingleEpisode(
         body,
@@ -351,7 +325,6 @@ export class WebhookQueueService {
       return
     }
 
-    // Bulk episode path
     if ('episodeFiles' in body) {
       await this.handleBulkEpisodes(
         body,
@@ -385,10 +358,6 @@ export class WebhookQueueService {
       })
     })
   }
-
-  // ============================================================================
-  // Private Handlers
-  // ============================================================================
 
   private async handleSingleEpisode(
     body: SonarrPayload,
@@ -440,7 +409,6 @@ export class WebhookQueueService {
       return
     }
 
-    // Recent episode - notify immediately
     if (this.isRecentEpisode(episode.airDateUtc)) {
       await notifyOrQueueShow(
         tvdbId,
@@ -452,7 +420,6 @@ export class WebhookQueueService {
       return
     }
 
-    // Non-recent - add to queue for batching
     await addEpisodeToQueue(
       tvdbId,
       seasonNumber,
@@ -478,7 +445,6 @@ export class WebhookQueueService {
     )
     this._queue[tvdbId].isPilotRolling = isPilotRolling
 
-    // Split recent vs non-recent
     const recentEpisodes = body.episodes.filter((ep) =>
       this.isRecentEpisode(ep.airDateUtc),
     )
@@ -486,7 +452,6 @@ export class WebhookQueueService {
       (ep) => !this.isRecentEpisode(ep.airDateUtc),
     )
 
-    // Recent episodes - notify immediately
     if (recentEpisodes.length > 0) {
       this.log.debug(
         {
@@ -506,7 +471,6 @@ export class WebhookQueueService {
       )
     }
 
-    // Non-recent - add to queue
     if (nonRecentEpisodes.length > 0) {
       this.log.debug(
         {
@@ -526,10 +490,6 @@ export class WebhookQueueService {
       )
     }
   }
-
-  // ============================================================================
-  // Lifecycle
-  // ============================================================================
 
   async initialize(): Promise<void> {
     await this.fastify.scheduler.scheduleJob(
@@ -566,7 +526,12 @@ export class WebhookQueueService {
 
     this._isRunning = true
 
-    await this.processRetryWebhooks()
+    void this.fastify.notifications.apprise
+      .whenReady()
+      .then(() => this.processRetryWebhooks())
+      .catch((error) => {
+        this.log.error({ error }, 'Boot-time pending webhook retry failed')
+      })
   }
 
   private async processRetryWebhooks(): Promise<number> {


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  - Improved notification initialization and readiness tracking for third‑party channels; startup now uses retry/backoff and better error handling.
  - Webhook retry processing now waits for notification readiness before running and is triggered asynchronously at boot.

* **Reliability**
  - Apprise now auto‑disables when not configured or unreachable, caches formats on success, and exposes readiness checks for more reliable delivery and logging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamcalli/Pulsarr/pull/1188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->