### PR TITLE
fix(watchlist-workflow): carry ratings into full-sync routing

### DIFF
--- a/src/services/watchlist-workflow/orchestration/sync-engine.ts
+++ b/src/services/watchlist-workflow/orchestration/sync-engine.ts
@@ -298,6 +298,10 @@ export async function syncWatchlistItems(
                 genres: parsedGenres,
                 status: 'pending',
                 series_status: 'continuing',
+                imdb: item.ratings?.imdb,
+                rtCritic: item.ratings?.rtCritic,
+                rtAudience: item.ratings?.rtAudience,
+                tmdb: item.ratings?.tmdb,
               }
 
               const result = await routeShow(
@@ -335,6 +339,10 @@ export async function syncWatchlistItems(
                 guids: parsedGuids,
                 type: 'movie',
                 genres: parsedGenres,
+                imdb: item.ratings?.imdb,
+                rtCritic: item.ratings?.rtCritic,
+                rtAudience: item.ratings?.rtAudience,
+                tmdb: item.ratings?.tmdb,
               }
 
               const result = await routeMovie(


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Watchlist synchronization now enriches show and movie items with additional rating information, including IMDb, Rotten Tomatoes (critic and audience scores), and TMDb ratings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jamcalli/Pulsarr/pull/1189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->