### PR TITLE
fix(plex): warm connection before opening SSE to avoid stuck CONNECTING

### DIFF
--- a/src/services/plex-server/sse/plex-event-source.ts
+++ b/src/services/plex-server/sse/plex-event-source.ts
@@ -43,6 +43,7 @@ const CONNECTION_TIMEOUT_MS = 30_000
 const MAX_BACKOFF_MS = 30_000
 const INITIAL_BACKOFF_MS = 1_000
 const STABLE_CONNECTION_MS = 60_000
+const HEALTH_PROBE_TIMEOUT_MS = 5_000
 
 // Plex emits 'buffering' between 'playing' frames during scrubs and hiccups.
 export function normalizePlayingNotification(
@@ -92,7 +93,7 @@ export class PlexEventSource {
 
   async connect(): Promise<void> {
     if (this.shutdownRequested) return
-    this.createConnection()
+    await this.createConnection()
   }
 
   disconnect(): void {
@@ -124,8 +125,13 @@ export class PlexEventSource {
 
   // -- Connection lifecycle --
 
-  private createConnection(): void {
+  private async createConnection(): Promise<void> {
     this.cleanup()
+    if (this.shutdownRequested) return
+
+    // Warm a fresh connection first: a stale pooled socket (Plex drops idle
+    // keep-alives) can otherwise leave the SSE fetch hung in CONNECTING.
+    await this.warmConnection()
     if (this.shutdownRequested) return
 
     const url = `${this.serverUrl}/:/eventsource/notifications`
@@ -192,6 +198,23 @@ export class PlexEventSource {
     this.connectedSince = null
   }
 
+  private async warmConnection(): Promise<void> {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), HEALTH_PROBE_TIMEOUT_MS)
+    try {
+      const res = await fetch(`${this.serverUrl}/identity`, {
+        headers: { 'X-Plex-Token': this.token },
+        signal: controller.signal,
+      })
+      // Drain the response so the connection returns to the pool.
+      await res.text()
+    } catch {
+      this.log.debug('SSE pre-connect health probe failed - continuing')
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+
   private resetHeartbeat(): void {
     if (this.heartbeatTimer) {
       clearTimeout(this.heartbeatTimer)
@@ -217,7 +240,7 @@ export class PlexEventSource {
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null
       if (!this.shutdownRequested) {
-        this.createConnection()
+        void this.createConnection()
       }
     }, delay)
 

--- a/src/services/plex-server/sse/plex-event-source.ts
+++ b/src/services/plex-server/sse/plex-event-source.ts
@@ -199,19 +199,15 @@ export class PlexEventSource {
   }
 
   private async warmConnection(): Promise<void> {
-    const controller = new AbortController()
-    const timer = setTimeout(() => controller.abort(), HEALTH_PROBE_TIMEOUT_MS)
     try {
       const res = await fetch(`${this.serverUrl}/identity`, {
         headers: { 'X-Plex-Token': this.token },
-        signal: controller.signal,
+        signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS),
       })
       // Drain the response so the connection returns to the pool.
       await res.text()
     } catch {
       this.log.debug('SSE pre-connect health probe failed - continuing')
-    } finally {
-      clearTimeout(timer)
     }
   }
 


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Plex server connection reliability by performing a pre-connection health probe with a bounded timeout, draining probe responses, and suppressing transient probe failures so normal connections proceed.
  * Made reconnection behavior more resilient by scheduling reconnects in the background to avoid blocking connection setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->