### PR TITLE
revert(plex): drop verbatim SSE url and warm-connection, keep connect…

### DIFF
--- a/src/services/plex-server.service.ts
+++ b/src/services/plex-server.service.ts
@@ -1468,14 +1468,7 @@ export class PlexServerService {
    * Polling jobs remain as a safety net - SSE provides faster reaction times.
    */
   async connectSSE(): Promise<void> {
-    // Use a configured URL verbatim so a restart can't auto-negotiate to a
-    // different connection than the one the admin saved. Empty means unset.
-    const manualUrl = this.config.plexServerUrl || null
-    const serverUrl = manualUrl ?? (await this.getPlexServerUrl())
-    this.log.info(
-      { serverUrl, source: manualUrl ? 'manual-config' : 'auto-negotiated' },
-      'Resolved Plex server URL for SSE connection',
-    )
+    const serverUrl = await this.getPlexServerUrl()
     const token = this.config.plexTokens?.[0] || ''
 
     if (!token) {

--- a/src/services/plex-server/sse/plex-event-source.ts
+++ b/src/services/plex-server/sse/plex-event-source.ts
@@ -43,7 +43,6 @@ const CONNECTION_TIMEOUT_MS = 30_000
 const MAX_BACKOFF_MS = 30_000
 const INITIAL_BACKOFF_MS = 1_000
 const STABLE_CONNECTION_MS = 60_000
-const HEALTH_PROBE_TIMEOUT_MS = 5_000
 
 // Plex emits 'buffering' between 'playing' frames during scrubs and hiccups.
 export function normalizePlayingNotification(
@@ -96,7 +95,7 @@ export class PlexEventSource {
 
   async connect(): Promise<void> {
     if (this.shutdownRequested) return
-    await this.createConnection()
+    this.createConnection()
   }
 
   disconnect(): void {
@@ -128,13 +127,8 @@ export class PlexEventSource {
 
   // -- Connection lifecycle --
 
-  private async createConnection(): Promise<void> {
+  private createConnection(): void {
     this.cleanup()
-    if (this.shutdownRequested) return
-
-    // Warm a fresh connection first: a stale pooled socket (Plex drops idle
-    // keep-alives) can otherwise leave the SSE fetch hung in CONNECTING.
-    await this.warmConnection()
     if (this.shutdownRequested) return
 
     const url = `${this.serverUrl}/:/eventsource/notifications`
@@ -207,19 +201,6 @@ export class PlexEventSource {
     this.connectedSince = null
   }
 
-  private async warmConnection(): Promise<void> {
-    try {
-      const res = await fetch(`${this.serverUrl}/identity`, {
-        headers: { 'X-Plex-Token': this.token },
-        signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS),
-      })
-      // Drain the response so the connection returns to the pool.
-      await res.text()
-    } catch {
-      this.log.debug('SSE pre-connect health probe failed - continuing')
-    }
-  }
-
   private resetHeartbeat(): void {
     if (this.heartbeatTimer) {
       clearTimeout(this.heartbeatTimer)
@@ -245,7 +226,7 @@ export class PlexEventSource {
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null
       if (!this.shutdownRequested) {
-        void this.createConnection()
+        this.createConnection()
       }
     }, delay)
 


### PR DESCRIPTION
…ion diagnostics

## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved Plex server connection handling by streamlining URL resolution and simplifying Server-Sent Events (SSE) connection initialization for more efficient server communications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->