### PR TITLE
feat(dashboard): add persisted list view toggle to media carousels

### DIFF
--- a/src/client/features/dashboard/components/dashboard-media-carousel.tsx
+++ b/src/client/features/dashboard/components/dashboard-media-carousel.tsx
@@ -1,0 +1,194 @@
+import { ArrowLeft, ArrowRight } from 'lucide-react'
+import { type ReactNode, useCallback, useEffect, useState } from 'react'
+import { useSettings } from '@/components/settings-provider'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Carousel,
+  type CarouselApi,
+  CarouselContent,
+  CarouselItem,
+} from '@/components/ui/carousel'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import MediaCardSkeleton from '@/features/dashboard/components/media-card-skeleton'
+import { useCarouselResponsive } from '@/features/dashboard/hooks/useCarouselResponsive'
+import type { MediaViewMode } from '@/features/dashboard/hooks/useMediaViewMode'
+import { useMediaQuery } from '@/hooks/use-media-query'
+import { cn } from '@/lib/utils'
+
+export type MediaOrientation = 'card' | 'row'
+
+const skeletonIds = (count: number) =>
+  Array.from({ length: count }, (_, i) => `skeleton-${i}`)
+
+interface DashboardMediaCarouselProps<T> {
+  items: T[]
+  renderItem: (
+    item: T,
+    orientation: MediaOrientation,
+    index: number,
+  ) => ReactNode
+  getKey: (item: T, index: number) => string
+  emptyMessage: string
+  title?: string
+  className?: string
+  loading?: boolean
+  error?: string | null
+  /** Full-width sections show 2x items per row; see useCarouselResponsive. */
+  fullWidth?: boolean
+  /** Desktop layout preference; mobile always renders the list. */
+  view?: MediaViewMode
+}
+
+/**
+ * Desktop carousel that collapses to a stacked list on mobile or when the
+ * caller opts into list view. Callers render their own cards via renderItem.
+ */
+export function DashboardMediaCarousel<T>({
+  items,
+  renderItem,
+  getKey,
+  emptyMessage,
+  title,
+  className,
+  loading = false,
+  error = null,
+  fullWidth = false,
+  view = 'carousel',
+}: DashboardMediaCarouselProps<T>) {
+  const [api, setApi] = useState<CarouselApi>()
+  const [canScrollPrev, setCanScrollPrev] = useState(false)
+  const [canScrollNext, setCanScrollNext] = useState(false)
+  // 767 complements MediaViewToggle's md: visibility
+  const isMobile = useMediaQuery('(max-width: 767px)')
+  const { fullscreenEnabled } = useSettings()
+  const { carouselItemClass } = useCarouselResponsive({
+    fullscreenEnabled,
+    fullWidth,
+  })
+
+  const scrollPrev = useCallback(() => {
+    api?.scrollPrev()
+  }, [api])
+
+  const scrollNext = useCallback(() => {
+    api?.scrollNext()
+  }, [api])
+
+  const onSelect = useCallback(() => {
+    if (!api) return
+    setCanScrollPrev(api.canScrollPrev())
+    setCanScrollNext(api.canScrollNext())
+  }, [api])
+
+  useEffect(() => {
+    if (!api) return
+    onSelect()
+    api.on('select', onSelect)
+    api.on('reInit', onSelect)
+    return () => {
+      api.off('select', onSelect)
+      api.off('reInit', onSelect)
+    }
+  }, [api, onSelect])
+
+  const isList = isMobile || view === 'list'
+  const showHeader = Boolean(title) || !isList
+
+  return (
+    <Card className={cn('w-full bg-background relative', className)}>
+      {showHeader && (
+        <CardHeader
+          className={cn(
+            'pb-3 flex flex-row items-center',
+            title ? 'justify-between' : 'justify-end',
+          )}
+        >
+          {title && <CardTitle className="text-foreground">{title}</CardTitle>}
+          {!isList && (
+            <div className="flex items-center gap-2">
+              <Button
+                variant="noShadow"
+                size="icon"
+                className="h-8 w-8 rounded-base"
+                disabled={!canScrollPrev}
+                onClick={scrollPrev}
+              >
+                <ArrowLeft className="h-4 w-4" />
+                <span className="sr-only">Previous</span>
+              </Button>
+              <Button
+                variant="noShadow"
+                size="icon"
+                className="h-8 w-8 rounded-base"
+                disabled={!canScrollNext}
+                onClick={scrollNext}
+              >
+                <ArrowRight className="h-4 w-4" />
+                <span className="sr-only">Next</span>
+              </Button>
+            </div>
+          )}
+        </CardHeader>
+      )}
+      {/* CardContent's default pt-0 assumes a preceding CardHeader */}
+      <CardContent className={cn(!showHeader && 'pt-6')}>
+        {error ? (
+          <div className="flex h-48 items-center justify-center">
+            <span className="text-destructive">{error}</span>
+          </div>
+        ) : items.length === 0 && !loading ? (
+          <div className="flex h-48 items-center justify-center">
+            <span className="text-foreground">{emptyMessage}</span>
+          </div>
+        ) : isList ? (
+          // Max height must also be on the Radix viewport or it clips without
+          // scrolling; type auto keeps the scrollbar visible on touch
+          <ScrollArea
+            type="auto"
+            className="max-h-[60vh] *:data-radix-scroll-area-viewport:max-h-[60vh]"
+          >
+            {/* Clearance so the overlay scrollbar stays off the rows' border */}
+            <div className="flex flex-col gap-2 pr-4.5">
+              {loading
+                ? skeletonIds(5).map((skeletonId) => (
+                    <MediaCardSkeleton key={skeletonId} orientation="row" />
+                  ))
+                : items.map((item, index) => (
+                    <div key={getKey(item, index)}>
+                      {renderItem(item, 'row', index)}
+                    </div>
+                  ))}
+            </div>
+          </ScrollArea>
+        ) : (
+          <Carousel setApi={setApi} className="w-full">
+            <CarouselContent className="-ml-2 md:-ml-4">
+              {loading
+                ? skeletonIds(10).map((skeletonId) => (
+                    <CarouselItem
+                      key={skeletonId}
+                      className={carouselItemClass}
+                    >
+                      <div className="p-1">
+                        <MediaCardSkeleton />
+                      </div>
+                    </CarouselItem>
+                  ))
+                : items.map((item, index) => (
+                    <CarouselItem
+                      key={getKey(item, index)}
+                      className={carouselItemClass}
+                    >
+                      <div className="p-1">
+                        {renderItem(item, 'card', index)}
+                      </div>
+                    </CarouselItem>
+                  ))}
+            </CarouselContent>
+          </Carousel>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/client/features/dashboard/components/media-card-skeleton.tsx
+++ b/src/client/features/dashboard/components/media-card-skeleton.tsx
@@ -1,11 +1,40 @@
 import { AspectRatio } from '@/components/ui/aspect-ratio'
 import { Card, CardContent } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
+import type { MediaOrientation } from '@/features/dashboard/components/dashboard-media-carousel'
+import { MediaRowItem } from '@/features/dashboard/components/media-row-item'
 
-export function MediaCardSkeleton() {
+interface MediaCardSkeletonProps {
+  orientation?: MediaOrientation
+}
+
+export function MediaCardSkeleton({
+  orientation = 'card',
+}: MediaCardSkeletonProps) {
+  if (orientation === 'row') {
+    return (
+      <MediaRowItem
+        poster={
+          <div className="w-16 shrink-0 overflow-hidden rounded-md bg-gray-100 dark:bg-gray-800">
+            <AspectRatio ratio={2 / 3}>
+              <Skeleton className="h-full w-full" />
+            </AspectRatio>
+          </div>
+        }
+        text={
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-3/4" />
+            <Skeleton className="h-3 w-1/2" />
+          </div>
+        }
+        badge={<Skeleton className="h-6 w-20" />}
+      />
+    )
+  }
+
   return (
     <Card className="shadow-none">
-      <CardContent className="p-[10px]">
+      <CardContent className="p-2.5">
         <AspectRatio
           ratio={2 / 3}
           className="overflow-hidden rounded-md bg-gray-100 dark:bg-gray-800"

--- a/src/client/features/dashboard/components/media-card.tsx
+++ b/src/client/features/dashboard/components/media-card.tsx
@@ -11,6 +11,8 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover'
+import type { MediaOrientation } from '@/features/dashboard/components/dashboard-media-carousel'
+import { MediaRowItem } from '@/features/dashboard/components/media-row-item'
 import { usePosterUrl } from '@/features/dashboard/hooks/usePosterUrl'
 import { cn } from '@/lib/utils'
 
@@ -18,27 +20,25 @@ interface MediaCardProps {
   item: ContentStat
   className?: string
   priority?: boolean
+  orientation?: MediaOrientation
 }
 
 /**
- * Renders a media item as a card with poster (or a "No image" placeholder), title, and watchlist badge.
- *
- * If the item includes GUIDs, an info button is shown to open a detail modal. The badge displays the item's
- * watchlist count and pluralizes "watchlist(s)". The title is truncated visually and exposed via the title attribute.
- *
- * @param item - The media item to render (ContentStat). Used for thumb, title, count, and GUIDs for the detail modal.
- * @param className - Optional additional CSS class names to apply to the Card container.
- * @param priority - When true, forces eager image loading and high fetch priority; defaults to false (lazy/auto).
+ * Poster card (default) or list row; row mode opens the detail modal by
+ * tapping the whole item.
  */
 export function MediaCard({
   item,
   className,
   priority = false,
+  orientation = 'card',
 }: MediaCardProps) {
   const [modalOpen, setModalOpen] = useState(false)
+  const isRow = orientation === 'row'
 
   // Only show info button if we have GUIDs available for TMDB lookup
   const hasGuids = Boolean(item.guids?.length)
+  const hasUsers = Boolean(item.users && item.users.length > 0)
 
   // Use unified poster hook - fast path if thumb exists, fallback to TMDB fetch
   const contentType = item.content_type === 'show' ? 'show' : ('movie' as const)
@@ -49,85 +49,117 @@ export function MediaCard({
     context: 'card',
   })
 
+  const CountBadgeContent = (
+    <Badge
+      variant="neutral"
+      className={cn(
+        isRow
+          ? 'shrink-0'
+          : 'absolute top-0 right-0 rounded-bl-md rounded-br-none rounded-tr-md rounded-tl-none',
+        hasUsers && 'cursor-pointer pointer-events-auto',
+      )}
+    >
+      {item.count} {item.count === 1 ? 'watchlist' : 'watchlists'}
+    </Badge>
+  )
+
+  const CountBadge = hasUsers ? (
+    // Modal in row mode so dismiss taps don't hit the row's overlay button
+    <Popover modal={isRow}>
+      <PopoverTrigger asChild>{CountBadgeContent}</PopoverTrigger>
+      <PopoverContent
+        side="bottom"
+        align="end"
+        className="w-auto min-w-[120px] p-2 bg-secondary-background"
+      >
+        <p className="text-xs font-medium mb-1">Watchlisted by:</p>
+        <ul className="text-xs space-y-0.5">
+          {item.users?.map((user) => (
+            <li key={user}>{user}</li>
+          ))}
+        </ul>
+      </PopoverContent>
+    </Popover>
+  ) : (
+    CountBadgeContent
+  )
+
+  const posterVisual = (
+    <div
+      className={cn(
+        'relative overflow-hidden rounded-md bg-gray-100 dark:bg-gray-800',
+        isRow ? 'w-16 shrink-0' : 'w-full',
+      )}
+    >
+      <AspectRatio ratio={2 / 3}>
+        {posterUrl ? (
+          <img
+            src={posterUrl}
+            alt={`${item.title} poster`}
+            className="h-full w-full object-cover"
+            loading={priority ? 'eager' : 'lazy'}
+            fetchPriority={priority ? 'high' : 'auto'}
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center">
+            <span className="text-sm text-gray-500 dark:text-gray-400">
+              No image
+            </span>
+          </div>
+        )}
+      </AspectRatio>
+
+      {!isRow && CountBadge}
+
+      {/* Row mode opens the modal by tapping the whole item, no overlay button needed */}
+      {!isRow && hasGuids && (
+        <Button
+          variant="neutralnoShadow"
+          size="sm"
+          className="absolute bottom-0 right-0 h-6 w-6 p-0 rounded-tl-md rounded-tr-none rounded-br-md rounded-bl-none"
+          onClick={(e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            setModalOpen(true)
+          }}
+          title="View detailed information"
+          aria-label="View detailed information"
+        >
+          <Eye className="h-3 w-3" />
+          <span className="sr-only">View detailed information</span>
+        </Button>
+      )}
+    </div>
+  )
+
+  const titleText = (
+    <h3
+      className="line-clamp-2 text-sm font-medium leading-tight"
+      title={item.title}
+    >
+      {item.title}
+    </h3>
+  )
+
   return (
     <>
-      <Card className={cn('shadow-none', className)}>
-        <CardContent className="p-[10px]">
-          <div className="relative w-full overflow-hidden rounded-md bg-gray-100 dark:bg-gray-800">
-            <AspectRatio ratio={2 / 3}>
-              {posterUrl ? (
-                <img
-                  src={posterUrl}
-                  alt={`${item.title} poster`}
-                  className="h-full w-full object-cover"
-                  loading={priority ? 'eager' : 'lazy'}
-                  fetchPriority={priority ? 'high' : 'auto'}
-                />
-              ) : (
-                <div className="flex h-full w-full items-center justify-center">
-                  <span className="text-sm text-gray-500 dark:text-gray-400">
-                    No image
-                  </span>
-                </div>
-              )}
-            </AspectRatio>
-            {item.users && item.users.length > 0 ? (
-              <Popover>
-                <PopoverTrigger asChild>
-                  <Badge
-                    variant="neutral"
-                    className="absolute top-0 right-0 rounded-bl-md rounded-br-none rounded-tr-md rounded-tl-none cursor-pointer"
-                  >
-                    {item.count} {item.count === 1 ? 'watchlist' : 'watchlists'}
-                  </Badge>
-                </PopoverTrigger>
-                <PopoverContent
-                  side="bottom"
-                  align="end"
-                  className="w-auto min-w-[120px] p-2 bg-secondary-background"
-                >
-                  <p className="text-xs font-medium mb-1">Watchlisted by:</p>
-                  <ul className="text-xs space-y-0.5">
-                    {item.users.map((user) => (
-                      <li key={user}>{user}</li>
-                    ))}
-                  </ul>
-                </PopoverContent>
-              </Popover>
-            ) : (
-              <Badge
-                variant="neutral"
-                className="absolute top-0 right-0 rounded-bl-md rounded-br-none rounded-tr-md rounded-tl-none"
-              >
-                {item.count} {item.count === 1 ? 'watchlist' : 'watchlists'}
-              </Badge>
-            )}
-            {hasGuids && (
-              <Button
-                variant="neutralnoShadow"
-                size="sm"
-                className="absolute bottom-0 right-0 h-6 w-6 p-0 rounded-tl-md rounded-tr-none rounded-br-md rounded-bl-none"
-                onClick={(e) => {
-                  e.preventDefault()
-                  e.stopPropagation()
-                  setModalOpen(true)
-                }}
-                title="View detailed information"
-                aria-label="View detailed information"
-              >
-                <Eye className="h-3 w-3" />
-                <span className="sr-only">View detailed information</span>
-              </Button>
-            )}
-          </div>
-          <h3
-            className="mt-2 line-clamp-2 text-sm font-medium leading-tight"
-            title={item.title}
-          >
-            {item.title}
-          </h3>
-        </CardContent>
-      </Card>
+      {isRow ? (
+        <MediaRowItem
+          poster={posterVisual}
+          text={titleText}
+          badge={CountBadge}
+          onSelect={hasGuids ? () => setModalOpen(true) : undefined}
+          selectLabel={`View details for ${item.title}`}
+          className={className}
+        />
+      ) : (
+        <Card className={cn('shadow-none', className)}>
+          <CardContent className="p-2.5">
+            {posterVisual}
+            <div className="mt-2">{titleText}</div>
+          </CardContent>
+        </Card>
+      )}
 
       {hasGuids && (
         <ContentDetailModal

--- a/src/client/features/dashboard/components/media-row-item.tsx
+++ b/src/client/features/dashboard/components/media-row-item.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from 'react'
+import { Card, CardContent } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+
+interface MediaRowItemProps {
+  poster: ReactNode
+  text: ReactNode
+  badge: ReactNode
+  onSelect?: () => void
+  selectLabel?: string
+  className?: string
+}
+
+/**
+ * Dashboard list row. The tap target is an overlay button because buttons
+ * can't contain block content; the badge stacks above it to stay clickable.
+ */
+export function MediaRowItem({
+  poster,
+  text,
+  badge,
+  onSelect,
+  selectLabel,
+  className,
+}: MediaRowItemProps) {
+  return (
+    <Card
+      className={cn(
+        'relative shadow-none bg-secondary-background text-foreground',
+        className,
+      )}
+    >
+      <CardContent className="flex flex-row items-center gap-3 p-2.5">
+        {onSelect && (
+          <button
+            type="button"
+            className="absolute inset-0 z-10 cursor-pointer"
+            onClick={onSelect}
+            aria-label={selectLabel}
+            title={selectLabel}
+          />
+        )}
+        {poster}
+        <div className="min-w-0 flex-1">{text}</div>
+        {/* Plain badges let taps through; popover badges opt back in via pointer-events-auto */}
+        <span className="pointer-events-none relative z-20 shrink-0">
+          {badge}
+        </span>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/client/features/dashboard/components/media-view-toggle.tsx
+++ b/src/client/features/dashboard/components/media-view-toggle.tsx
@@ -1,0 +1,39 @@
+import { GalleryHorizontal, List } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import type { MediaViewMode } from '@/features/dashboard/hooks/useMediaViewMode'
+
+interface MediaViewToggleProps {
+  view: MediaViewMode
+  onViewChange: (view: MediaViewMode) => void
+}
+
+/** Carousel/list switch; hidden on mobile where the list is forced. */
+export function MediaViewToggle({ view, onViewChange }: MediaViewToggleProps) {
+  const nextView = view === 'list' ? 'carousel' : 'list'
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="neutralnoShadow"
+          size="icon"
+          className="hidden md:inline-flex"
+          onClick={() => onViewChange(nextView)}
+          aria-label={`Switch to ${nextView} view`}
+        >
+          {view === 'list' ? (
+            <GalleryHorizontal className="h-4 w-4" aria-hidden="true" />
+          ) : (
+            <List className="h-4 w-4" aria-hidden="true" />
+          )}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>Switch to {nextView} view</TooltipContent>
+    </Tooltip>
+  )
+}

--- a/src/client/features/dashboard/components/popularity-rankings.tsx
+++ b/src/client/features/dashboard/components/popularity-rankings.tsx
@@ -2,6 +2,7 @@ import { Loader2, RefreshCw } from 'lucide-react'
 import { useMemo } from 'react'
 import { Button } from '@/components/ui/button'
 import { Select } from '@/components/ui/select'
+import { MediaViewToggle } from '@/features/dashboard/components/media-view-toggle'
 import { WatchlistCarousel } from '@/features/dashboard/components/watchlist-carousel'
 import {
   DATE_RANGE_PRESETS,
@@ -10,6 +11,7 @@ import {
   LIMIT_PRESETS,
   useDashboardStats,
 } from '@/features/dashboard/hooks/useDashboardStats'
+import { useMediaViewMode } from '@/features/dashboard/hooks/useMediaViewMode'
 
 interface PopularityRankingsProps {
   onRefresh: () => Promise<void>
@@ -33,6 +35,8 @@ export function PopularityRankings({ onRefresh }: PopularityRankingsProps) {
     limit,
     setLimit,
   } = useDashboardStats()
+  // One shared view so the side-by-side sections never mix carousel and list
+  const { view, setView } = useMediaViewMode('most-watchlisted')
 
   const dateRangeOptions = useMemo(
     () =>
@@ -72,6 +76,7 @@ export function PopularityRankings({ onRefresh }: PopularityRankingsProps) {
           disabled={isLoading}
           className="w-[110px]"
         />
+        <MediaViewToggle view={view} onViewChange={setView} />
         <Button
           onClick={onRefresh}
           disabled={isLoading}
@@ -96,6 +101,7 @@ export function PopularityRankings({ onRefresh }: PopularityRankingsProps) {
       <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
         <WatchlistCarousel
           title="Most Watchlisted Shows"
+          view={view}
           items={mostWatchedShows || []}
           loading={loadingStates.all || loadingStates.shows}
           error={errorStates.all || errorStates.shows}
@@ -103,6 +109,7 @@ export function PopularityRankings({ onRefresh }: PopularityRankingsProps) {
 
         <WatchlistCarousel
           title="Most Watchlisted Movies"
+          view={view}
           items={mostWatchedMovies || []}
           loading={loadingStates.all || loadingStates.movies}
           error={errorStates.all || errorStates.movies}

--- a/src/client/features/dashboard/components/recent-request-card.tsx
+++ b/src/client/features/dashboard/components/recent-request-card.tsx
@@ -21,12 +21,15 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
+import type { MediaOrientation } from '@/features/dashboard/components/dashboard-media-carousel'
+import { MediaRowItem } from '@/features/dashboard/components/media-row-item'
 import { usePosterUrl } from '@/features/dashboard/hooks/usePosterUrl'
 import { cn } from '@/lib/utils'
 
 interface RecentRequestCardProps {
   item: RecentRequestItem
   className?: string
+  orientation?: MediaOrientation
 }
 
 const STATUS_CONFIG: Record<
@@ -85,8 +88,13 @@ function formatTimeAgo(dateString: string): string {
  * Shows poster placeholder, status badge, title, user, and time.
  * Supports multi-instance popover when item exists on multiple instances.
  */
-export function RecentRequestCard({ item, className }: RecentRequestCardProps) {
+export function RecentRequestCard({
+  item,
+  className,
+  orientation = 'card',
+}: RecentRequestCardProps) {
   const [modalOpen, setModalOpen] = useState(false)
+  const isRow = orientation === 'row'
 
   const hasGuids = Boolean(item.guids?.length)
   const hasInstances = item.allInstances.length > 0
@@ -118,131 +126,171 @@ export function RecentRequestCard({ item, className }: RecentRequestCardProps) {
     <Badge
       variant={statusConfig.variant}
       className={cn(
-        'absolute top-0 right-0 rounded-bl-md rounded-br-none rounded-tr-md rounded-tl-none',
+        isRow
+          ? 'shrink-0'
+          : 'absolute top-0 right-0 rounded-bl-md rounded-br-none rounded-tr-md rounded-tl-none',
         statusConfig.className,
-        showInstancePopover && 'cursor-pointer',
+        showInstancePopover && 'cursor-pointer pointer-events-auto',
       )}
     >
       {statusConfig.label}
     </Badge>
   )
 
-  return (
-    <>
-      <Card className={cn('shadow-none', className)}>
-        <CardContent className="p-2.5">
-          <div className="relative w-full overflow-hidden rounded-md bg-gray-100 dark:bg-gray-800">
-            <AspectRatio ratio={2 / 3}>
-              {posterUrl ? (
-                <img
-                  src={posterUrl}
-                  alt={item.title}
-                  className="h-full w-full object-cover"
-                  loading="lazy"
-                />
-              ) : (
-                <div className="flex h-full w-full items-center justify-center">
-                  {isPosterLoading ? (
-                    <div className="h-6 w-6 animate-spin rounded-full border-2 border-gray-300 border-t-gray-600" />
-                  ) : (
-                    <span className="text-sm text-gray-500 dark:text-gray-400">
-                      {item.contentType === 'movie' ? 'Movie' : 'Show'}
-                    </span>
-                  )}
-                </div>
-              )}
-            </AspectRatio>
+  const StatusBadge = showInstancePopover ? (
+    // Modal in row mode so dismiss taps don't hit the row's overlay button
+    <Popover modal={isRow}>
+      <PopoverTrigger asChild>{StatusBadgeContent}</PopoverTrigger>
+      <PopoverContent
+        side="bottom"
+        align="end"
+        className="w-auto min-w-40 p-2 bg-secondary-background"
+      >
+        <p className="text-xs font-medium mb-1">Status:</p>
+        <ul className="text-xs space-y-0.5">
+          {item.allInstances.map((instance) => {
+            const instanceStatusConfig = INSTANCE_STATUS_CONFIG[instance.status]
+            return (
+              <li
+                key={`${instance.instanceType}-${instance.id}`}
+                className="flex items-center gap-1"
+              >
+                <span>{instanceStatusConfig.icon}</span>
+                <span>
+                  {instance.name} ({instanceStatusConfig.label})
+                </span>
+              </li>
+            )
+          })}
+        </ul>
+      </PopoverContent>
+    </Popover>
+  ) : (
+    StatusBadgeContent
+  )
 
-            {/* Status badge with optional instance popover */}
-            {showInstancePopover ? (
-              <Popover>
-                <PopoverTrigger asChild>{StatusBadgeContent}</PopoverTrigger>
-                <PopoverContent
-                  side="bottom"
-                  align="end"
-                  className="w-auto min-w-40 p-2 bg-secondary-background"
-                >
-                  <p className="text-xs font-medium mb-1">Status:</p>
-                  <ul className="text-xs space-y-0.5">
-                    {item.allInstances.map((instance) => {
-                      const instanceStatusConfig =
-                        INSTANCE_STATUS_CONFIG[instance.status]
-                      return (
-                        <li
-                          key={`${instance.instanceType}-${instance.id}`}
-                          className="flex items-center gap-1"
-                        >
-                          <span>{instanceStatusConfig.icon}</span>
-                          <span>
-                            {instance.name} ({instanceStatusConfig.label})
-                          </span>
-                        </li>
-                      )
-                    })}
-                  </ul>
-                </PopoverContent>
-              </Popover>
+  const posterVisual = (
+    <div
+      className={cn(
+        'relative overflow-hidden rounded-md bg-gray-100 dark:bg-gray-800',
+        isRow ? 'w-16 shrink-0' : 'w-full',
+      )}
+    >
+      <AspectRatio ratio={2 / 3}>
+        {posterUrl ? (
+          <img
+            src={posterUrl}
+            alt={item.title}
+            className="h-full w-full object-cover"
+            loading="lazy"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center">
+            {isPosterLoading ? (
+              <div className="h-6 w-6 animate-spin rounded-full border-2 border-gray-300 border-t-gray-600" />
             ) : (
-              StatusBadgeContent
-            )}
-
-            {/* Content type indicator */}
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="neutralnoShadow"
-                  size="sm"
-                  className="absolute top-0 left-0 h-6 w-6 p-0 rounded-tl-md rounded-tr-none rounded-br-md rounded-bl-none"
-                  aria-label={
-                    item.contentType === 'movie' ? 'Movie' : 'TV Show'
-                  }
-                >
-                  {item.contentType === 'movie' ? (
-                    <Monitor className="h-3 w-3" />
-                  ) : (
-                    <Tv className="h-3 w-3" />
-                  )}
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                {item.contentType === 'movie' ? 'Movie' : 'TV Show'}
-              </TooltipContent>
-            </Tooltip>
-
-            {/* Eye button for detail modal */}
-            {hasGuids && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="neutralnoShadow"
-                    size="sm"
-                    className="absolute bottom-0 right-0 h-6 w-6 p-0 rounded-tl-md rounded-tr-none rounded-br-md rounded-bl-none cursor-pointer"
-                    onClick={(e) => {
-                      e.preventDefault()
-                      e.stopPropagation()
-                      setModalOpen(true)
-                    }}
-                    aria-label="View detailed information"
-                  >
-                    <Eye className="h-3 w-3" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>View details</TooltipContent>
-              </Tooltip>
+              <span className="text-sm text-gray-500 dark:text-gray-400">
+                {item.contentType === 'movie' ? 'Movie' : 'Show'}
+              </span>
             )}
           </div>
+        )}
+      </AspectRatio>
 
-          {/* Title */}
-          <h3 className="mt-2 line-clamp-1 text-sm font-medium leading-tight">
-            {item.title}
-          </h3>
+      {!isRow && StatusBadge}
 
-          {/* User and time */}
-          <p className="text-xs text-muted-foreground truncate">
-            @{item.userName} · {formatTimeAgo(item.createdAt)}
-          </p>
-        </CardContent>
-      </Card>
+      {/* Plain span in row mode; the overlay tap target rules out a tooltip button */}
+      {isRow ? (
+        <span
+          className="absolute top-0 left-0 flex h-5 w-5 items-center justify-center rounded-br-md border-2 border-border bg-secondary-background text-foreground"
+          aria-hidden="true"
+        >
+          {item.contentType === 'movie' ? (
+            <Monitor className="h-3 w-3" />
+          ) : (
+            <Tv className="h-3 w-3" />
+          )}
+        </span>
+      ) : (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="neutralnoShadow"
+              size="sm"
+              className="absolute top-0 left-0 h-6 w-6 p-0 rounded-tl-md rounded-tr-none rounded-br-md rounded-bl-none"
+              aria-label={item.contentType === 'movie' ? 'Movie' : 'TV Show'}
+            >
+              {item.contentType === 'movie' ? (
+                <Monitor className="h-3 w-3" />
+              ) : (
+                <Tv className="h-3 w-3" />
+              )}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            {item.contentType === 'movie' ? 'Movie' : 'TV Show'}
+          </TooltipContent>
+        </Tooltip>
+      )}
+
+      {/* Row mode opens the modal by tapping the whole item, no overlay button needed */}
+      {!isRow && hasGuids && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="neutralnoShadow"
+              size="sm"
+              className="absolute bottom-0 right-0 h-6 w-6 p-0 rounded-tl-md rounded-tr-none rounded-br-md rounded-bl-none cursor-pointer"
+              onClick={(e) => {
+                e.preventDefault()
+                e.stopPropagation()
+                setModalOpen(true)
+              }}
+              aria-label="View detailed information"
+            >
+              <Eye className="h-3 w-3" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>View details</TooltipContent>
+        </Tooltip>
+      )}
+    </div>
+  )
+
+  const itemText = (
+    <>
+      <h3 className="line-clamp-1 text-sm font-medium leading-tight">
+        {item.title}
+        <span className="sr-only">
+          {' '}
+          ({item.contentType === 'movie' ? 'movie' : 'show'})
+        </span>
+      </h3>
+      <p className="text-xs text-muted-foreground truncate">
+        @{item.userName} · {formatTimeAgo(item.createdAt)}
+      </p>
+    </>
+  )
+
+  return (
+    <>
+      {isRow ? (
+        <MediaRowItem
+          poster={posterVisual}
+          text={itemText}
+          badge={StatusBadge}
+          onSelect={hasGuids ? () => setModalOpen(true) : undefined}
+          selectLabel={`View details for ${item.title} (${item.contentType === 'movie' ? 'movie' : 'show'})`}
+          className={className}
+        />
+      ) : (
+        <Card className={cn('shadow-none', className)}>
+          <CardContent className="p-2.5">
+            {posterVisual}
+            <div className="mt-2">{itemText}</div>
+          </CardContent>
+        </Card>
+      )}
 
       {hasGuids && (
         <ContentDetailModal

--- a/src/client/features/dashboard/components/recent-requests.tsx
+++ b/src/client/features/dashboard/components/recent-requests.tsx
@@ -1,69 +1,28 @@
-import { ArrowLeft, ArrowRight } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { ArrowRight } from 'lucide-react'
+import { useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useSettings } from '@/components/settings-provider'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader } from '@/components/ui/card'
-import {
-  Carousel,
-  type CarouselApi,
-  CarouselContent,
-  CarouselItem,
-} from '@/components/ui/carousel'
 import { Select } from '@/components/ui/select'
-import MediaCardSkeleton from '@/features/dashboard/components/media-card-skeleton'
+import { DashboardMediaCarousel } from '@/features/dashboard/components/dashboard-media-carousel'
+import { MediaViewToggle } from '@/features/dashboard/components/media-view-toggle'
 import { RecentRequestCard } from '@/features/dashboard/components/recent-request-card'
-import { useCarouselResponsive } from '@/features/dashboard/hooks/useCarouselResponsive'
+import { useMediaViewMode } from '@/features/dashboard/hooks/useMediaViewMode'
 import {
   getLimitLabel,
   LIMIT_PRESETS,
   STATUS_FILTER_OPTIONS,
   useRecentRequests,
 } from '@/features/dashboard/hooks/useRecentRequests'
-import { cn } from '@/lib/utils'
 
 /**
  * Recent Requests section for the dashboard.
- * Displays a carousel of recent requests with status filter.
+ * Status/limit filters plus a shared media carousel (list view on mobile).
  */
 export function RecentRequests() {
   const navigate = useNavigate()
   const { items, isLoading, error, status, setStatus, limit, setLimit } =
     useRecentRequests()
-
-  const [api, setApi] = useState<CarouselApi>()
-  const [canScrollPrev, setCanScrollPrev] = useState(false)
-  const [canScrollNext, setCanScrollNext] = useState(false)
-  const { fullscreenEnabled } = useSettings()
-  const { carouselItemClass } = useCarouselResponsive({
-    fullscreenEnabled,
-    fullWidth: true,
-  })
-
-  const scrollPrev = useCallback(() => {
-    api?.scrollPrev()
-  }, [api])
-
-  const scrollNext = useCallback(() => {
-    api?.scrollNext()
-  }, [api])
-
-  const onSelect = useCallback(() => {
-    if (!api) return
-    setCanScrollPrev(api.canScrollPrev())
-    setCanScrollNext(api.canScrollNext())
-  }, [api])
-
-  useEffect(() => {
-    if (!api) return
-    onSelect()
-    api.on('select', onSelect)
-    api.on('reInit', onSelect)
-    return () => {
-      api.off('select', onSelect)
-      api.off('reInit', onSelect)
-    }
-  }, [api, onSelect])
+  const { view, setView } = useMediaViewMode('recent-requests')
 
   const filterOptions = useMemo(
     () =>
@@ -101,6 +60,7 @@ export function RecentRequests() {
           disabled={isLoading}
           className="w-27.5"
         />
+        <MediaViewToggle view={view} onViewChange={setView} />
         <Button
           variant="neutralnoShadow"
           className="flex items-center gap-2"
@@ -111,72 +71,20 @@ export function RecentRequests() {
         </Button>
       </div>
 
+      {/* grid-cols-1's minmax(0,1fr) keeps the carousel's intrinsic width from stretching the page */}
       <div className="grid grid-cols-1">
-        <Card className={cn('w-full bg-background relative')}>
-          <CardHeader className="pb-3 flex flex-row items-center justify-end">
-            <div className="flex items-center gap-2">
-              <Button
-                variant="noShadow"
-                size="icon"
-                className="h-8 w-8 rounded-base"
-                disabled={!canScrollPrev}
-                onClick={scrollPrev}
-              >
-                <ArrowLeft className="h-4 w-4" />
-                <span className="sr-only">Previous</span>
-              </Button>
-              <Button
-                variant="noShadow"
-                size="icon"
-                className="h-8 w-8 rounded-base"
-                disabled={!canScrollNext}
-                onClick={scrollNext}
-              >
-                <ArrowRight className="h-4 w-4" />
-                <span className="sr-only">Next</span>
-              </Button>
-            </div>
-          </CardHeader>
-          <CardContent>
-            {error ? (
-              <div className="flex h-48 items-center justify-center">
-                <span className="text-destructive">{error}</span>
-              </div>
-            ) : items.length === 0 && !isLoading ? (
-              <div className="flex h-48 items-center justify-center">
-                <span className="text-foreground">No recent requests</span>
-              </div>
-            ) : (
-              <Carousel setApi={setApi} className="w-full">
-                <CarouselContent className="-ml-2 md:-ml-4">
-                  {isLoading
-                    ? Array.from({ length: 10 }, (_, i) => `skeleton-${i}`).map(
-                        (skeletonId) => (
-                          <CarouselItem
-                            key={skeletonId}
-                            className={carouselItemClass}
-                          >
-                            <div className="p-1">
-                              <MediaCardSkeleton />
-                            </div>
-                          </CarouselItem>
-                        ),
-                      )
-                    : items.map((item) => (
-                        <CarouselItem
-                          key={`${item.source}-${item.id}`}
-                          className={carouselItemClass}
-                        >
-                          <div className="p-1">
-                            <RecentRequestCard item={item} />
-                          </div>
-                        </CarouselItem>
-                      ))}
-                </CarouselContent>
-              </Carousel>
-            )}
-          </CardContent>
-        </Card>
+        <DashboardMediaCarousel
+          items={items}
+          loading={isLoading}
+          error={error}
+          emptyMessage="No recent requests"
+          fullWidth
+          view={view}
+          getKey={(item) => `${item.source}-${item.id}`}
+          renderItem={(item, orientation) => (
+            <RecentRequestCard item={item} orientation={orientation} />
+          )}
+        />
       </div>
     </div>
   )

--- a/src/client/features/dashboard/components/watchlist-carousel.tsx
+++ b/src/client/features/dashboard/components/watchlist-carousel.tsx
@@ -1,19 +1,8 @@
 import type { ContentStat } from '@root/schemas/stats/stats.schema'
-import { ArrowLeft, ArrowRight } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import { useSettings } from '@/components/settings-provider'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import {
-  Carousel,
-  type CarouselApi,
-  CarouselContent,
-  CarouselItem,
-} from '@/components/ui/carousel'
+import { useMemo } from 'react'
+import { DashboardMediaCarousel } from '@/features/dashboard/components/dashboard-media-carousel'
 import { MediaCard } from '@/features/dashboard/components/media-card'
-import MediaCardSkeleton from '@/features/dashboard/components/media-card-skeleton'
-import { useCarouselResponsive } from '@/features/dashboard/hooks/useCarouselResponsive'
-import { cn } from '@/lib/utils'
+import type { MediaViewMode } from '@/features/dashboard/hooks/useMediaViewMode'
 
 interface WatchlistCarouselProps {
   title: string
@@ -21,58 +10,18 @@ interface WatchlistCarouselProps {
   className?: string
   loading?: boolean
   error?: string | null
+  view?: MediaViewMode
 }
 
-/**
- * Renders a responsive card containing a horizontally scrollable carousel of media items with navigation controls, adaptive layout, and comprehensive loading and error handling.
- *
- * Media items are sorted by descending count and then alphabetically by title. The carousel dynamically adjusts the number and size of visible items based on fullscreen mode and viewport breakpoints. If an error message is provided, it is displayed in place of the carousel; if there are no items and not loading, a "No data available" message is shown. Navigation buttons are enabled only when additional scrolling is possible.
- *
- * @param title - The title displayed above the carousel.
- * @param items - The list of media items to display.
- * @param className - Optional additional CSS classes for the root card.
- * @param loading - Whether to show loading placeholders (minimum duration handled by useAppQuery).
- * @param error - Optional error message to display instead of the carousel.
- */
+/** Most Watchlisted section: sorts by count then title. */
 export function WatchlistCarousel({
   title,
   items = [],
   className,
   loading = false,
   error = null,
+  view,
 }: WatchlistCarouselProps) {
-  const [api, setApi] = useState<CarouselApi>()
-  const [canScrollPrev, setCanScrollPrev] = useState(false)
-  const [canScrollNext, setCanScrollNext] = useState(false)
-  const { fullscreenEnabled } = useSettings()
-  const { carouselItemClass } = useCarouselResponsive({ fullscreenEnabled })
-
-  const scrollPrev = useCallback(() => {
-    api?.scrollPrev()
-  }, [api])
-
-  const scrollNext = useCallback(() => {
-    api?.scrollNext()
-  }, [api])
-
-  const onSelect = useCallback(() => {
-    if (!api) return
-
-    setCanScrollPrev(api.canScrollPrev())
-    setCanScrollNext(api.canScrollNext())
-  }, [api])
-
-  useEffect(() => {
-    if (!api) return
-    onSelect()
-    api.on('select', onSelect)
-    api.on('reInit', onSelect)
-    return () => {
-      api.off('select', onSelect)
-      api.off('reInit', onSelect)
-    }
-  }, [api, onSelect])
-
   const sortedItems = useMemo(() => {
     if (!items || !Array.isArray(items) || items.length === 0) return []
 
@@ -92,73 +41,22 @@ export function WatchlistCarousel({
   }, [items])
 
   return (
-    <Card className={cn('w-full bg-background relative', className)}>
-      <CardHeader className="pb-3 flex flex-row items-center justify-between">
-        <CardTitle className="text-foreground">{title}</CardTitle>
-        <div className="flex items-center gap-2">
-          <Button
-            variant="noShadow"
-            size="icon"
-            className="h-8 w-8 rounded-base"
-            disabled={!canScrollPrev}
-            onClick={scrollPrev}
-          >
-            <ArrowLeft className="h-4 w-4" />
-            <span className="sr-only">Previous</span>
-          </Button>
-          <Button
-            variant="noShadow"
-            size="icon"
-            className="h-8 w-8 rounded-base"
-            disabled={!canScrollNext}
-            onClick={scrollNext}
-          >
-            <ArrowRight className="h-4 w-4" />
-            <span className="sr-only">Next</span>
-          </Button>
-        </div>
-      </CardHeader>
-      <CardContent>
-        {error ? (
-          <div className="flex h-48 items-center justify-center">
-            <span className="text-destructive">{error}</span>
-          </div>
-        ) : sortedItems.length === 0 && !loading ? (
-          <div className="flex h-48 items-center justify-center">
-            <span className="text-foreground">No data available</span>
-          </div>
-        ) : (
-          <Carousel setApi={setApi} className="w-full">
-            <CarouselContent className="-ml-2 md:-ml-4">
-              {loading
-                ? Array.from({ length: 10 }, (_, i) => `skeleton-${i}`).map(
-                    (skeletonId) => (
-                      <CarouselItem
-                        key={`${title}-${skeletonId}`}
-                        className={carouselItemClass}
-                      >
-                        <div className="p-1">
-                          <MediaCardSkeleton />
-                        </div>
-                      </CarouselItem>
-                    ),
-                  )
-                : // Show actual items when loaded
-                  sortedItems.map((item, index) => (
-                    <CarouselItem
-                      key={`item-${typeof item.title === 'string' ? item.title : ''}-${item.count}`}
-                      className={carouselItemClass}
-                    >
-                      <div className="p-1">
-                        {/* Set priority=true for the first 3 items that will be visible */}
-                        <MediaCard item={item} priority={index < 3} />
-                      </div>
-                    </CarouselItem>
-                  ))}
-            </CarouselContent>
-          </Carousel>
-        )}
-      </CardContent>
-    </Card>
+    <DashboardMediaCarousel
+      title={title}
+      items={sortedItems}
+      loading={loading}
+      error={error}
+      emptyMessage="No data available"
+      className={className}
+      view={view}
+      getKey={(item, index) =>
+        // Guid keys survive reorders (no remounts); index keeps the fallback unique
+        item.guids?.[0] ??
+        `item-${typeof item.title === 'string' ? item.title : ''}-${item.count}-${index}`
+      }
+      renderItem={(item, orientation, index) => (
+        <MediaCard item={item} orientation={orientation} priority={index < 3} />
+      )}
+    />
   )
 }

--- a/src/client/features/dashboard/hooks/useMediaViewMode.ts
+++ b/src/client/features/dashboard/hooks/useMediaViewMode.ts
@@ -1,0 +1,37 @@
+import { useCallback, useState } from 'react'
+
+export type MediaViewMode = 'carousel' | 'list'
+
+/** Persisted desktop view mode for a dashboard section (mobile always lists). */
+export function useMediaViewMode(
+  viewKey: string,
+  defaultView: MediaViewMode = 'carousel',
+) {
+  const storageKey = `pulsarr-${viewKey}-view`
+
+  const [view, setViewState] = useState<MediaViewMode>(() => {
+    try {
+      const stored = localStorage.getItem(storageKey)
+      if (stored === 'carousel' || stored === 'list') {
+        return stored
+      }
+    } catch (error) {
+      console.warn(`Failed to load view mode for ${viewKey}:`, error)
+    }
+    return defaultView
+  })
+
+  const setView = useCallback(
+    (newView: MediaViewMode) => {
+      try {
+        localStorage.setItem(storageKey, newView)
+      } catch (error) {
+        console.error(`Failed to save view mode for ${viewKey}:`, error)
+      }
+      setViewState(newView)
+    },
+    [storageKey, viewKey],
+  )
+
+  return { view, setView }
+}

--- a/src/client/hooks/use-media-query.tsx
+++ b/src/client/hooks/use-media-query.tsx
@@ -1,7 +1,8 @@
 import * as React from "react"
 
 export function useMediaQuery(query: string) {
-  const [value, setValue] = React.useState(false)
+  // Read synchronously on first render to avoid a flash of the wrong layout
+  const [value, setValue] = React.useState(() => matchMedia(query).matches)
 
   React.useEffect(() => {
     function onChange(event: MediaQueryListEvent) {


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared dashboard media component that renders in carousel or list formats.
  * Introduced a view toggle that persists the selected layout for consistent future visits.
  * Added row-style media cards and updated dashboard sections (recent requests, watchlist, popularity rankings) to use the new shared media layout.
* **Bug Fixes**
  * Improved mobile responsiveness for dashboard media.
  * Reduced layout flicker by initializing media-query checks earlier to match the correct layout on first render.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->