### PR TITLE
fix(config): persist cookie and webhook secrets across restarts

### DIFF
--- a/migrations/migrations/094_20260702_add_webhook_secret_column.ts
+++ b/migrations/migrations/094_20260702_add_webhook_secret_column.ts
@@ -1,0 +1,13 @@
+import type { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('configs', (table) => {
+    table.string('webhookSecret').nullable()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('configs', (table) => {
+    table.dropColumn('webhookSecret')
+  })
+}

--- a/src/plugins/custom/database.ts
+++ b/src/plugins/custom/database.ts
@@ -55,6 +55,24 @@ export default fp(
             }),
           )
 
+          // Secrets must stay stable across restarts
+          const storedSecrets = await dbService.getSecrets()
+          for (const key of ['cookieSecret', 'webhookSecret'] as const) {
+            let stored = storedSecrets[key]
+            // drop legacy short values that @fastify/session would reject at boot
+            if (key === 'cookieSecret' && stored && stored.length < 32) {
+              stored = null
+            }
+            if (stored) {
+              if (!isSetInEnvironment(key)) {
+                dbOverrides[key] = stored
+              }
+            } else {
+              delete dbOverrides[key]
+              await dbService.setSecret(key, envConfig[key])
+            }
+          }
+
           const mergedConfig = {
             ...envConfig,
             ...dbOverrides,

--- a/src/plugins/custom/session.ts
+++ b/src/plugins/custom/session.ts
@@ -29,6 +29,7 @@ export default fp(
   },
   {
     name: 'session',
-    dependencies: ['config'],
+    // database must load first so the persisted cookieSecret is used
+    dependencies: ['config', 'database'],
   },
 )

--- a/src/plugins/external/env.ts
+++ b/src/plugins/external/env.ts
@@ -130,7 +130,8 @@ const schema = {
     },
     cookieSecret: {
       type: 'string',
-      minLength: 16,
+      // @fastify/session requires 32+ chars
+      minLength: 32,
       default: generateSecret(),
     },
     cookieName: {

--- a/src/schemas/config/config.schema.ts
+++ b/src/schemas/config/config.schema.ts
@@ -138,8 +138,7 @@ export const ConfigFullSchema = z.object({
   baseUrl: z.string().optional(),
   port: z.number().int().min(1).max(65535).optional(),
   dbPath: z.string().optional(),
-  cookieSecret: z.string().optional(),
-  cookieName: z.string().optional(),
+  // cookieSecret, webhookSecret, and cookieName are server-internal
   cookieSecured: z.boolean(),
   // Logging & Performance
   logLevel: LogLevelEnum.optional(),
@@ -284,8 +283,7 @@ export const ConfigUpdateSchema = z
     baseUrl: HttpUrlOptionalSchema,
     port: z.number().int().min(1).max(65535).optional(),
     dbPath: z.string().optional(),
-    cookieSecret: z.string().optional(),
-    cookieName: z.string().optional(),
+    // cookieSecret, webhookSecret, and cookieName are server-internal
     cookieSecured: z.boolean().optional(),
     logLevel: LogLevelEnum.optional(),
     closeGraceDelay: z.number().optional(),

--- a/src/services/database/methods/config.ts
+++ b/src/services/database/methods/config.ts
@@ -1,5 +1,5 @@
 import type { ConfigFull } from '@root/schemas/config/config.schema.js'
-import type { Config } from '@root/types/config.types.js'
+import type { Config, SecretColumn } from '@root/types/config.types.js'
 import type { DatabaseService } from '@services/database.service.js'
 
 /**
@@ -660,8 +660,6 @@ export async function setLastNotifiedVersion(
     return false
   }
 }
-
-export type SecretColumn = 'cookieSecret' | 'webhookSecret'
 
 /**
  * Reads the persisted secrets, null when the row predates the columns.

--- a/src/services/database/methods/config.ts
+++ b/src/services/database/methods/config.ts
@@ -273,6 +273,7 @@ export async function createConfig(
       dbPath: config.dbPath,
       baseUrl: config.baseUrl,
       cookieSecret: config.cookieSecret,
+      webhookSecret: config.webhookSecret,
       cookieName: config.cookieName,
       cookieSecured: config.cookieSecured,
       logLevel: config.logLevel,
@@ -440,8 +441,7 @@ const ALLOWED_COLUMNS = new Set([
   'dbConnectionString',
 
   // Security & authentication
-  'cookieSecret',
-  'cookieName',
+  // NOTE: cookieSecret, webhookSecret, and cookieName are intentionally omitted
   'cookieSecured',
   'authenticationMethod',
   'allowIframes',
@@ -658,5 +658,40 @@ export async function setLastNotifiedVersion(
   } catch (error) {
     this.log.error({ error, version }, 'Error setting lastNotifiedVersion')
     return false
+  }
+}
+
+export type SecretColumn = 'cookieSecret' | 'webhookSecret'
+
+/**
+ * Reads the persisted secrets, null when the row predates the columns.
+ * Errors propagate so boot aborts instead of overwriting a stored secret.
+ */
+export async function getSecrets(
+  this: DatabaseService,
+): Promise<Record<SecretColumn, string | null>> {
+  const row = await this.knex('configs')
+    .where({ id: 1 })
+    .first('cookieSecret', 'webhookSecret')
+  return {
+    cookieSecret: (row?.cookieSecret as string | null) ?? null,
+    webhookSecret: (row?.webhookSecret as string | null) ?? null,
+  }
+}
+
+/**
+ * Persists a secret. Bypasses ALLOWED_COLUMNS so these internal fields
+ * cannot be set through the public config update API.
+ */
+export async function setSecret(
+  this: DatabaseService,
+  key: SecretColumn,
+  value: string,
+): Promise<void> {
+  const updated = await this.knex('configs')
+    .where({ id: 1 })
+    .update({ [key]: value, updated_at: this.timestamp })
+  if (updated === 0) {
+    throw new Error(`Failed to persist ${key}: config row missing`)
   }
 }

--- a/src/services/database/types/config-methods.ts
+++ b/src/services/database/types/config-methods.ts
@@ -2,6 +2,7 @@ import type {
   ConfigFull,
   ConfigUpdate,
 } from '@root/schemas/config/config.schema.js'
+import type { SecretColumn } from '../methods/config.js'
 
 declare module '@services/database.service.js' {
   interface DatabaseService {
@@ -16,5 +17,9 @@ declare module '@services/database.service.js' {
     getLastNotifiedVersion(): Promise<string | null>
 
     setLastNotifiedVersion(version: string): Promise<boolean>
+
+    getSecrets(): Promise<Record<SecretColumn, string | null>>
+
+    setSecret(key: SecretColumn, value: string): Promise<void>
   }
 }

--- a/src/services/database/types/config-methods.ts
+++ b/src/services/database/types/config-methods.ts
@@ -2,7 +2,7 @@ import type {
   ConfigFull,
   ConfigUpdate,
 } from '@root/schemas/config/config.schema.js'
-import type { SecretColumn } from '../methods/config.js'
+import type { SecretColumn } from '@root/types/config.types.js'
 
 declare module '@services/database.service.js' {
   interface DatabaseService {

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -105,6 +105,8 @@ export type PublicContentKeyMap = Record<
   }
 >
 
+export type SecretColumn = 'cookieSecret' | 'webhookSecret'
+
 export interface Config {
   id: number
   // System Config

--- a/test/integration/plugins/secret-persistence.test.ts
+++ b/test/integration/plugins/secret-persistence.test.ts
@@ -1,0 +1,106 @@
+import type { FastifyInstance } from 'fastify'
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import { build } from '../../helpers/app.js'
+import {
+  getTestDatabase,
+  initializeTestDatabase,
+} from '../../helpers/database.js'
+import { seedConfig } from '../../helpers/seeds/config.js'
+
+// @fastify/session requires cookie secrets of 32+ chars
+const STORED_COOKIE_SECRET = 'stored-cookie-secret-0123456789abcdef'
+const STORED_WEBHOOK_SECRET = 'stored-webhook-secret'
+
+// Each test seeds its own configs row and boots the app to simulate a restart
+describe('secret persistence across restarts', () => {
+  let app: FastifyInstance | undefined
+
+  beforeAll(async () => {
+    await initializeTestDatabase()
+  })
+
+  beforeEach(async () => {
+    const knex = getTestDatabase()
+    await knex('configs').del()
+  })
+
+  afterEach(async () => {
+    await app?.close()
+    app = undefined
+    delete process.env.webhookSecret
+  })
+
+  async function seedStoredSecrets(
+    secrets: { cookieSecret?: string; webhookSecret?: string | null } = {},
+  ) {
+    const knex = getTestDatabase()
+    await seedConfig(knex)
+    await knex('configs')
+      .where({ id: 1 })
+      .update({
+        cookieSecret: secrets.cookieSecret ?? STORED_COOKIE_SECRET,
+        webhookSecret:
+          secrets.webhookSecret === undefined
+            ? STORED_WEBHOOK_SECRET
+            : secrets.webhookSecret,
+        // keep boot light - no service initialization
+        _isReady: false,
+      })
+  }
+
+  async function getStoredSecrets() {
+    const knex = getTestDatabase()
+    const row = await knex('configs').where({ id: 1 }).first()
+    return {
+      cookieSecret: row?.cookieSecret as string | null,
+      webhookSecret: row?.webhookSecret as string | null,
+    }
+  }
+
+  it('persists generated secrets on fresh install', async () => {
+    app = await build()
+    await app.ready()
+
+    const stored = await getStoredSecrets()
+    expect(stored.cookieSecret).toBeTruthy()
+    expect(stored.webhookSecret).toBeTruthy()
+    expect(stored.cookieSecret).toBe(app.config.cookieSecret)
+    expect(stored.webhookSecret).toBe(app.config.webhookSecret)
+  })
+
+  it('reuses persisted secrets on restart', async () => {
+    await seedStoredSecrets()
+
+    app = await build()
+    await app.ready()
+
+    expect(app.config.cookieSecret).toBe(STORED_COOKIE_SECRET)
+    expect(app.config.webhookSecret).toBe(STORED_WEBHOOK_SECRET)
+  })
+
+  it('backfills webhookSecret for rows that predate the column', async () => {
+    await seedStoredSecrets({ webhookSecret: null })
+
+    app = await build()
+    await app.ready()
+
+    const stored = await getStoredSecrets()
+    expect(stored.webhookSecret).toBeTruthy()
+    expect(stored.webhookSecret).toBe(app.config.webhookSecret)
+    expect(app.config.cookieSecret).toBe(STORED_COOKIE_SECRET)
+  })
+
+  it('lets .env values override persisted secrets', async () => {
+    await seedStoredSecrets()
+    const envSecret = 'env-webhook-secret-override'
+    process.env.webhookSecret = envSecret
+
+    app = await build()
+    await app.ready()
+
+    expect(app.config.webhookSecret).toBe(envSecret)
+
+    const stored = await getStoredSecrets()
+    expect(stored.webhookSecret).toBe(STORED_WEBHOOK_SECRET)
+  })
+})

--- a/test/integration/plugins/secret-persistence.test.ts
+++ b/test/integration/plugins/secret-persistence.test.ts
@@ -90,6 +90,19 @@ describe('secret persistence across restarts', () => {
     expect(app.config.cookieSecret).toBe(STORED_COOKIE_SECRET)
   })
 
+  it('replaces legacy cookieSecret values shorter than 32 chars', async () => {
+    await seedStoredSecrets({ cookieSecret: 'short-legacy-secret' })
+
+    app = await build()
+    await app.ready()
+
+    const stored = await getStoredSecrets()
+    expect(app.config.cookieSecret).not.toBe('short-legacy-secret')
+    expect(app.config.cookieSecret.length).toBeGreaterThanOrEqual(32)
+    expect(stored.cookieSecret).toBe(app.config.cookieSecret)
+    expect(app.config.webhookSecret).toBe(STORED_WEBHOOK_SECRET)
+  })
+
   it('lets .env values override persisted secrets', async () => {
     await seedStoredSecrets()
     const envSecret = 'env-webhook-secret-override'


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persist `cookieSecret` and `webhookSecret` in the database and restore them on startup, including webhook secret reuse/backfill across restarts.
* **Bug Fixes**
  * Restore the persisted cookie secret reliably by ensuring the session layer loads after database initialization.
  * Normalize legacy short `cookieSecret` values to prevent startup/session issues.
  * Environment `webhookSecret` overrides update runtime without changing the stored database value.
* **Chores**
  * Enforce stronger `cookieSecret` validation (32+ chars) and remove secret fields from config GET/PUT payload validation.
  * Add integration test coverage for persistence, backfill, and override behavior.
  * Update the config schema to support the new stored webhook secret column.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->