### PR TITLE
fix(notifications): mention users with only public mentions enabled

### DIFF
--- a/src/services/notifications/orchestration/media-available.ts
+++ b/src/services/notifications/orchestration/media-available.ts
@@ -372,7 +372,7 @@ async function buildEnrichmentData(
   }
 }
 
-async function buildUserNotifications(
+export async function buildUserNotifications(
   deps: MediaAvailableDeps,
   mediaInfo: MediaInfo,
   options: MediaAvailableOptions,
@@ -388,14 +388,27 @@ async function buildUserNotifications(
   const users = await deps.db.getUsersByIds(userIds)
   const userMap = new Map(users.map((u) => [u.id, u]))
 
+  // public mention IDs are derived from these results, so mention-only users must stay in
+  const { hasDiscordUrls } = getPublicContentNotificationFlags(
+    deps.config.publicContentNotifications,
+  )
+  const publicMentionsPossible =
+    Boolean(deps.config.publicContentNotifications?.enabled) && hasDiscordUrls
+
   for (const item of watchlistItems) {
     const user = userMap.get(item.user_id)
     if (!user) continue
 
+    const mentionEligible =
+      publicMentionsPossible &&
+      user.notify_discord_mention &&
+      Boolean(user.discord_id?.trim())
+
     if (
       !user.notify_discord &&
       !user.notify_apprise &&
-      !user.notify_plex_mobile
+      !user.notify_plex_mobile &&
+      !mentionEligible
     )
       continue
 

--- a/test/unit/services/notifications/orchestration/media-available.test.ts
+++ b/test/unit/services/notifications/orchestration/media-available.test.ts
@@ -6,16 +6,21 @@ vi.mock('@services/notifications/channels/native-webhook.js', () => ({
   hasWebhooksForEvent: vi.fn().mockReturnValue(false),
 }))
 
+import type { Config, User } from '@root/types/config.types.js'
+import type { TokenWatchlistItem } from '@root/types/plex.types.js'
 import type {
   NotificationResult,
   SonarrEpisodeSchema,
 } from '@root/types/sonarr.types.js'
+import type { MediaAvailableDeps } from '@services/notifications/orchestration/media-available.js'
 import {
+  buildUserNotifications,
   determineNotificationType,
   extractUserDiscordIds,
   getPublicContentNotificationFlags,
 } from '@services/notifications/orchestration/media-available.js'
 import { describe, expect, it, vi } from 'vitest'
+import { createMockLogger } from '../../../../mocks/logger.js'
 
 function createTestNotification(
   userId: number,
@@ -41,6 +46,60 @@ function createTestNotification(
       username: `user${userId}`,
     },
   }
+}
+
+function createTestUser(overrides: Partial<User> = {}): User {
+  return {
+    id: 1,
+    name: 'user1',
+    apprise: null,
+    alias: null,
+    discord_id: '123456789',
+    notify_apprise: false,
+    notify_discord: false,
+    notify_discord_mention: false,
+    notify_plex_mobile: false,
+    can_sync: true,
+    requires_approval: false,
+    is_primary_token: false,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function createTestItem(userId: number): TokenWatchlistItem {
+  return {
+    id: '10',
+    title: 'Test Movie',
+    key: 'plex-key-1',
+    type: 'movie',
+    user_id: userId,
+    status: 'grabbed',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  }
+}
+
+function createDeps(
+  users: User[],
+  publicContentNotifications: Config['publicContentNotifications'],
+) {
+  const db = {
+    getUsersByIds: vi.fn().mockResolvedValue(users),
+    hasActiveNotification: vi.fn().mockResolvedValue(false),
+    updateWatchlistItem: vi.fn().mockResolvedValue(undefined),
+    createNotificationRecord: vi.fn().mockResolvedValue(1),
+    transaction: vi.fn(
+      async (cb: (trx: unknown) => Promise<void>) => await cb({}),
+    ),
+  }
+  const deps = {
+    db,
+    config: { publicContentNotifications },
+    logger: createMockLogger(),
+  } as unknown as MediaAvailableDeps
+  return { deps, db }
 }
 
 describe('media-available helpers', () => {
@@ -156,6 +215,140 @@ describe('media-available helpers', () => {
       const result = extractUserDiscordIds(notifications)
 
       expect(result).toEqual(['user1', 'user2'])
+    })
+  })
+
+  describe('buildUserNotifications', () => {
+    const mediaInfo = {
+      type: 'movie' as const,
+      guid: 'tmdb:12345',
+      title: 'Test Movie',
+    }
+    const options = { isBulkRelease: false }
+    const enrichment = {
+      posterUrl: undefined,
+      guids: [],
+      tmdbUrl: undefined,
+      episodeDetails: undefined,
+    }
+    const typeInfo = { contentType: 'movie' as const }
+    const publicDiscordConfig = {
+      enabled: true,
+      discordWebhookUrls: 'https://discord.com/api/webhooks/1',
+    }
+
+    it('should include a mention-only user when a public Discord webhook is configured', async () => {
+      const user = createTestUser({ notify_discord_mention: true })
+      const { deps, db } = createDeps([user], publicDiscordConfig)
+
+      const results = await buildUserNotifications(
+        deps,
+        mediaInfo,
+        options,
+        [createTestItem(user.id)],
+        enrichment,
+        typeInfo,
+        false,
+      )
+
+      expect(results).toHaveLength(1)
+      expect(db.createNotificationRecord).toHaveBeenCalledTimes(1)
+      expect(extractUserDiscordIds(results)).toEqual(['123456789'])
+    })
+
+    it('should skip a mention-only user when public content notifications are disabled', async () => {
+      const user = createTestUser({ notify_discord_mention: true })
+      const { deps, db } = createDeps([user], {
+        ...publicDiscordConfig,
+        enabled: false,
+      })
+
+      const results = await buildUserNotifications(
+        deps,
+        mediaInfo,
+        options,
+        [createTestItem(user.id)],
+        enrichment,
+        typeInfo,
+        false,
+      )
+
+      expect(results).toEqual([])
+      expect(db.createNotificationRecord).not.toHaveBeenCalled()
+    })
+
+    it('should skip a mention-only user when no public Discord webhook is configured', async () => {
+      const user = createTestUser({ notify_discord_mention: true })
+      const { deps, db } = createDeps([user], { enabled: true })
+
+      const results = await buildUserNotifications(
+        deps,
+        mediaInfo,
+        options,
+        [createTestItem(user.id)],
+        enrichment,
+        typeInfo,
+        false,
+      )
+
+      expect(results).toEqual([])
+      expect(db.createNotificationRecord).not.toHaveBeenCalled()
+    })
+
+    it('should skip a mention-only user without a discord_id', async () => {
+      const user = createTestUser({
+        notify_discord_mention: true,
+        discord_id: null,
+      })
+      const { deps, db } = createDeps([user], publicDiscordConfig)
+
+      const results = await buildUserNotifications(
+        deps,
+        mediaInfo,
+        options,
+        [createTestItem(user.id)],
+        enrichment,
+        typeInfo,
+        false,
+      )
+
+      expect(results).toEqual([])
+      expect(db.createNotificationRecord).not.toHaveBeenCalled()
+    })
+
+    it('should skip a user with all channels and mentions disabled', async () => {
+      const user = createTestUser()
+      const { deps, db } = createDeps([user], publicDiscordConfig)
+
+      const results = await buildUserNotifications(
+        deps,
+        mediaInfo,
+        options,
+        [createTestItem(user.id)],
+        enrichment,
+        typeInfo,
+        false,
+      )
+
+      expect(results).toEqual([])
+      expect(db.createNotificationRecord).not.toHaveBeenCalled()
+    })
+
+    it('should include a user with a personal channel enabled regardless of public config', async () => {
+      const user = createTestUser({ notify_discord: true })
+      const { deps } = createDeps([user], undefined)
+
+      const results = await buildUserNotifications(
+        deps,
+        mediaInfo,
+        options,
+        [createTestItem(user.id)],
+        enrichment,
+        typeInfo,
+        false,
+      )
+
+      expect(results).toHaveLength(1)
     })
   })
 


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded notification delivery so users who only qualify for Discord mentions can still receive alerts, even if they don’t have other direct notification channels enabled.
  * Notification handling now respects public Discord availability when deciding whether mention-only delivery is possible.

* **Tests**
  * Added coverage for mention-only notification scenarios, including public Discord enabled/disabled, missing Discord IDs, and users with direct notification channels turned on.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->