### PR TITLE
fix(ci): pin release asset downloads to tag version and serialize rel…

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -402,6 +402,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    concurrency:
+      group: release-drafting
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -450,10 +452,10 @@ jobs:
       matrix:
         include:
           - variant: standard
-            zip_pattern: "*windows-x64.zip"
+            zip_suffix: "-windows-x64.zip"
             iss_file: pulsarr.iss
           - variant: baseline
-            zip_pattern: "*windows-x64-baseline.zip"
+            zip_suffix: "-windows-x64-baseline.zip"
             iss_file: pulsarr-baseline.iss
     steps:
       - name: Checkout
@@ -483,7 +485,7 @@ jobs:
           RELEASE_VERSION: ${{ steps.version.outputs.version }}
         run: |
           gh release download "$RELEASE_VERSION" \
-            --pattern "${{ matrix.zip_pattern }}" \
+            --pattern "pulsarr-${RELEASE_VERSION}${{ matrix.zip_suffix }}" \
             --dir scripts/installers/windows
 
       - name: Extract zip
@@ -557,7 +559,7 @@ jobs:
           ARCH: ${{ matrix.arch }}
         run: |
           gh release download "$RELEASE_VERSION" \
-            --pattern "*macos-${ARCH}.zip" \
+            --pattern "pulsarr-${RELEASE_VERSION}-macos-${ARCH}.zip" \
             --dir .
 
       - name: Install create-dmg
@@ -568,17 +570,10 @@ jobs:
           RELEASE_VERSION: ${{ steps.version.outputs.version }}
           ARCH: ${{ matrix.arch }}
         run: |
-          # Extract the native build zip
-          unzip -q "pulsarr-"*"-macos-${ARCH}.zip"
-
-          # Enter the extracted directory
-          cd "pulsarr-"*"-macos-${ARCH}"
-
-          # Run the build script
+          unzip -q "pulsarr-${RELEASE_VERSION}-macos-${ARCH}.zip"
+          cd "pulsarr-${RELEASE_VERSION}-macos-${ARCH}"
           ../scripts/installers/macos/build-app.sh "$RELEASE_VERSION" "$ARCH"
-
-          # Move output to workspace root
-          mv pulsarr-*.dmg ../
+          mv "pulsarr-${RELEASE_VERSION}-macos-${ARCH}.dmg" ../
 
       - name: Upload installer to release
         env:
@@ -587,5 +582,5 @@ jobs:
           ARCH: ${{ matrix.arch }}
         run: |
           gh release upload "$RELEASE_VERSION" \
-            "pulsarr-"*"-macos-${ARCH}.dmg" \
+            "pulsarr-${RELEASE_VERSION}-macos-${ARCH}.dmg" \
             --clobber

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,6 +11,9 @@ permissions:
   contents: write
   pull-requests: read
 
+concurrency:
+  group: release-drafting
+
 jobs:
   label:
     runs-on: ubuntu-latest


### PR DESCRIPTION
…ease drafting

## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated release build reliability by preventing overlapping release-drafting runs through workflow concurrency.
  * Made Windows installer packaging download and publish deterministic artifacts to avoid mismatches.
  * Tightened macOS installer packaging to download, build, and publish using exact expected installer filenames.
* **Chores**
  * Updated release workflow coordination settings for more predictable automated releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->