### PR TITLE
fix(content-router): reject target-specific rule fields on mismatched…

### DIFF
--- a/src/client/features/content-router/components/accordion-route-card.tsx
+++ b/src/client/features/content-router/components/accordion-route-card.tsx
@@ -81,10 +81,13 @@ interface Criteria {
 }
 
 // Extended ContentRouterRule to include criteria and type
-interface ExtendedContentRouterRule extends ContentRouterRule {
+// quality_profile allows null since the update schema coerces unparseable strings to null
+interface ExtendedContentRouterRule
+  extends Omit<ContentRouterRule, 'quality_profile'> {
   type?: string
   criteria?: Criteria
   condition?: ConditionGroup
+  quality_profile?: string | number | null
 }
 
 /**

--- a/src/routes/v1/content-router/content-router-management.ts
+++ b/src/routes/v1/content-router/content-router-management.ts
@@ -267,16 +267,6 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (fastify) => {
       try {
         const ruleData = request.body
 
-        if (
-          ruleData.target_type === 'radarr' &&
-          ruleData.season_monitoring !== null &&
-          ruleData.season_monitoring !== undefined
-        ) {
-          return reply.badRequest(
-            'season_monitoring field is not supported for Radarr rules',
-          )
-        }
-
         const builtRule = RuleBuilder.createRule({
           name: ruleData.name,
           target_type: ruleData.target_type,
@@ -287,14 +277,8 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (fastify) => {
             negate: false,
           },
           root_folder: ruleData.root_folder,
-          quality_profile: (() => {
-            if (typeof ruleData.quality_profile === 'string') {
-              const parsed = Number.parseInt(ruleData.quality_profile, 10)
-              return Number.isFinite(parsed) ? parsed : null
-            }
-            return ruleData.quality_profile
-          })(),
-          tags: Array.isArray(ruleData.tags) ? ruleData.tags : [],
+          quality_profile: ruleData.quality_profile,
+          tags: ruleData.tags,
           order: ruleData.order ?? 50,
           enabled: ruleData.enabled ?? true,
           search_on_add: ruleData.search_on_add,
@@ -394,6 +378,26 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (fastify) => {
           )
         }
 
+        if (
+          targetType === 'radarr' &&
+          updates.series_type !== null &&
+          updates.series_type !== undefined
+        ) {
+          return reply.badRequest(
+            'series_type field is not supported for Radarr rules',
+          )
+        }
+
+        if (
+          targetType === 'sonarr' &&
+          updates.monitor !== null &&
+          updates.monitor !== undefined
+        ) {
+          return reply.badRequest(
+            'monitor field is not supported for Sonarr rules',
+          )
+        }
+
         const updatesAsRouterRule: Partial<
           Omit<RouterRule, 'id' | 'created_at' | 'updated_at'>
         > = {}
@@ -409,10 +413,7 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (fastify) => {
           updatesAsRouterRule.order = updates.order
         if (updates.enabled !== undefined)
           updatesAsRouterRule.enabled = updates.enabled
-        if (updates.tags !== undefined)
-          updatesAsRouterRule.tags = Array.isArray(updates.tags)
-            ? updates.tags
-            : []
+        if (updates.tags !== undefined) updatesAsRouterRule.tags = updates.tags
         if (updates.search_on_add !== undefined)
           updatesAsRouterRule.search_on_add = updates.search_on_add
         if (updates.season_monitoring !== undefined)
@@ -429,15 +430,8 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (fastify) => {
         if (updates.approval_reason !== undefined)
           updatesAsRouterRule.approval_reason = updates.approval_reason
 
-        if (updates.quality_profile !== undefined) {
-          updatesAsRouterRule.quality_profile = (() => {
-            if (typeof updates.quality_profile === 'string') {
-              const parsed = Number.parseInt(updates.quality_profile, 10)
-              return Number.isFinite(parsed) ? parsed : null
-            }
-            return updates.quality_profile ?? null
-          })()
-        }
+        if (updates.quality_profile !== undefined)
+          updatesAsRouterRule.quality_profile = updates.quality_profile
 
         if (updates.condition) {
           updatesAsRouterRule.criteria = {

--- a/src/schemas/content-router/content-router.schema.ts
+++ b/src/schemas/content-router/content-router.schema.ts
@@ -263,15 +263,27 @@ export const BaseRouterRuleSchema = z.object({
   order: z.number().optional(),
   enabled: z.boolean().optional(),
   search_on_add: z.boolean().nullable().optional(),
-  // For Sonarr only - sending this with Radarr rules will be rejected by the API
-  // Additional validation happens in the route handlers
-  season_monitoring: z.string().nullable().optional(),
-  series_type: z.enum(SERIES_TYPES).nullable().optional(),
-  // For Radarr only - monitor type when adding movies
+  season_monitoring: z
+    .string()
+    .nullable()
+    .optional()
+    .describe(
+      'Sonarr rules only - season monitoring mode applied when adding series. Sending this for Radarr rules returns a 400 error.',
+    ),
+  series_type: z
+    .enum(SERIES_TYPES)
+    .nullable()
+    .optional()
+    .describe(
+      'Sonarr rules only - series type applied when adding series. Sending this for Radarr rules returns a 400 error.',
+    ),
   monitor: z
     .enum(['movieOnly', 'movieAndCollection', 'none'])
     .nullable()
-    .optional(),
+    .optional()
+    .describe(
+      'Radarr rules only - monitor mode applied when adding movies. Sending this for Sonarr rules returns a 400 error.',
+    ),
   always_require_approval: z.boolean().optional(),
   bypass_user_quotas: z.boolean().optional(),
   approval_reason: z.string().optional(),
@@ -315,11 +327,37 @@ export const ContentRouterPluginsResponseSchema = z.object({
   ),
 })
 
+// Accepts numeric strings from API clients; unparseable strings become null
+const QualityProfileInputSchema = z
+  .union([z.number(), z.string()])
+  .optional()
+  .transform((val) => {
+    if (val === undefined || typeof val === 'number') return val
+    const parsed = Number.parseInt(val, 10)
+    return Number.isFinite(parsed) ? parsed : null
+  })
+  .pipe(z.number().nullable().optional())
+
 // Schema for creating a new rule
-export const ContentRouterRuleSchema = BaseRouterRuleSchema
+// Update-side target-type checks live in the route handler since updates may omit target_type
+export const ContentRouterRuleSchema = BaseRouterRuleSchema.extend({
+  quality_profile: QualityProfileInputSchema,
+})
+  .refine((v) => v.target_type !== 'radarr' || v.season_monitoring == null, {
+    message: 'season_monitoring field is not supported for Radarr rules',
+  })
+  .refine((v) => v.target_type !== 'radarr' || v.series_type == null, {
+    message: 'series_type field is not supported for Radarr rules',
+  })
+  .refine((v) => v.target_type !== 'sonarr' || v.monitor == null, {
+    message: 'monitor field is not supported for Sonarr rules',
+  })
 
 // Schema for updating an existing rule
-export const ContentRouterRuleUpdateSchema = BaseRouterRuleSchema.partial()
+export const ContentRouterRuleUpdateSchema =
+  BaseRouterRuleSchema.partial().extend({
+    quality_profile: QualityProfileInputSchema,
+  })
 
 // Schema for toggling a rule
 export const ContentRouterRuleToggleSchema = z.object({

--- a/test/integration/routes/content-router.test.ts
+++ b/test/integration/routes/content-router.test.ts
@@ -1,0 +1,218 @@
+import type { FastifyInstance } from 'fastify'
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+import { build } from '../../helpers/app.js'
+import { getTestDatabase, resetDatabase } from '../../helpers/database.js'
+import { seedConfig } from '../../helpers/seeds/config.js'
+import { seedInstances } from '../../helpers/seeds/instances.js'
+
+describe('Content Router Rules API', () => {
+  let app: FastifyInstance
+
+  beforeAll(async () => {
+    app = await build()
+    await app.ready()
+  })
+
+  afterAll(async () => {
+    await app.close()
+  })
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    const knex = getTestDatabase()
+    await resetDatabase()
+    await seedConfig(knex)
+    await seedInstances(knex)
+    app.config.authenticationMethod = 'disabled'
+    app.contentRouter.clearRouterRulesCache()
+  })
+
+  const radarrRule = {
+    name: 'Radarr Rule',
+    target_type: 'radarr' as const,
+    target_instance_id: 1,
+    condition: { operator: 'AND', conditions: [], negate: false },
+  }
+
+  const sonarrRule = {
+    name: 'Sonarr Rule',
+    target_type: 'sonarr' as const,
+    target_instance_id: 1,
+    condition: { operator: 'AND', conditions: [], negate: false },
+  }
+
+  describe('monitor field persistence', () => {
+    it('persists monitor on create and returns it on subsequent GET', async () => {
+      const createRes = await app.inject({
+        method: 'POST',
+        url: '/v1/content-router/rules',
+        payload: { ...radarrRule, monitor: 'movieOnly' },
+      })
+      expect(createRes.statusCode).toBe(201)
+      expect(createRes.json().rule.monitor).toBe('movieOnly')
+
+      const getRes = await app.inject({
+        method: 'GET',
+        url: `/v1/content-router/rules/${createRes.json().rule.id}`,
+      })
+      expect(getRes.statusCode).toBe(200)
+      expect(getRes.json().rule.monitor).toBe('movieOnly')
+
+      const knex = getTestDatabase()
+      const row = await knex('router_rules')
+        .where({ id: createRes.json().rule.id })
+        .first()
+      expect(row.monitor).toBe('movieOnly')
+    })
+
+    it('persists monitor on update', async () => {
+      const createRes = await app.inject({
+        method: 'POST',
+        url: '/v1/content-router/rules',
+        payload: { ...radarrRule, monitor: 'movieOnly' },
+      })
+      const id = createRes.json().rule.id
+
+      const putRes = await app.inject({
+        method: 'PUT',
+        url: `/v1/content-router/rules/${id}`,
+        payload: { monitor: 'movieAndCollection' },
+      })
+      expect(putRes.statusCode).toBe(200)
+      expect(putRes.json().rule.monitor).toBe('movieAndCollection')
+
+      const knex = getTestDatabase()
+      const row = await knex('router_rules').where({ id }).first()
+      expect(row.monitor).toBe('movieAndCollection')
+    })
+  })
+
+  describe('target-type field validation', () => {
+    it('rejects monitor on Sonarr rule create', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v1/content-router/rules',
+        payload: { ...sonarrRule, monitor: 'movieOnly' },
+      })
+      expect(res.statusCode).toBe(400)
+      expect(res.json().message).toContain('monitor')
+    })
+
+    it('rejects monitor on Sonarr rule update', async () => {
+      const createRes = await app.inject({
+        method: 'POST',
+        url: '/v1/content-router/rules',
+        payload: sonarrRule,
+      })
+      const id = createRes.json().rule.id
+
+      const putRes = await app.inject({
+        method: 'PUT',
+        url: `/v1/content-router/rules/${id}`,
+        payload: { monitor: 'movieOnly' },
+      })
+      expect(putRes.statusCode).toBe(400)
+      expect(putRes.json().message).toContain('monitor')
+    })
+
+    it('rejects series_type on Radarr rule create', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v1/content-router/rules',
+        payload: { ...radarrRule, series_type: 'anime' },
+      })
+      expect(res.statusCode).toBe(400)
+      expect(res.json().message).toContain('series_type')
+    })
+
+    it('rejects series_type on Radarr rule update', async () => {
+      const createRes = await app.inject({
+        method: 'POST',
+        url: '/v1/content-router/rules',
+        payload: radarrRule,
+      })
+      const id = createRes.json().rule.id
+
+      const putRes = await app.inject({
+        method: 'PUT',
+        url: `/v1/content-router/rules/${id}`,
+        payload: { series_type: 'anime' },
+      })
+      expect(putRes.statusCode).toBe(400)
+      expect(putRes.json().message).toContain('series_type')
+    })
+
+    it('rejects season_monitoring on Radarr rule create', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v1/content-router/rules',
+        payload: { ...radarrRule, season_monitoring: 'all' },
+      })
+      expect(res.statusCode).toBe(400)
+      expect(res.json().message).toContain('season_monitoring')
+    })
+
+    it('accepts explicit null for target-specific fields', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v1/content-router/rules',
+        payload: { ...sonarrRule, monitor: null },
+      })
+      expect(res.statusCode).toBe(201)
+    })
+
+    it('coerces string quality_profile to a number', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v1/content-router/rules',
+        payload: { ...radarrRule, quality_profile: '5' },
+      })
+      expect(res.statusCode).toBe(201)
+      expect(res.json().rule.quality_profile).toBe(5)
+
+      const knex = getTestDatabase()
+      const row = await knex('router_rules')
+        .where({ id: res.json().rule.id })
+        .first()
+      expect(row.quality_profile).toBe(5)
+    })
+
+    it('stores null for unparseable quality_profile strings', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v1/content-router/rules',
+        payload: { ...radarrRule, quality_profile: 'not-a-number' },
+      })
+      expect(res.statusCode).toBe(201)
+
+      const knex = getTestDatabase()
+      const row = await knex('router_rules')
+        .where({ id: res.json().rule.id })
+        .first()
+      expect(row.quality_profile).toBeNull()
+    })
+
+    it('accepts sonarr fields on Sonarr rules', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/v1/content-router/rules',
+        payload: {
+          ...sonarrRule,
+          season_monitoring: 'all',
+          series_type: 'anime',
+        },
+      })
+      expect(res.statusCode).toBe(201)
+      expect(res.json().rule.season_monitoring).toBe('all')
+      expect(res.json().rule.series_type).toBe('anime')
+    })
+  })
+})

--- a/test/integration/routes/content-router.test.ts
+++ b/test/integration/routes/content-router.test.ts
@@ -160,6 +160,23 @@ describe('Content Router Rules API', () => {
       expect(res.json().message).toContain('season_monitoring')
     })
 
+    it('rejects season_monitoring on Radarr rule update', async () => {
+      const createRes = await app.inject({
+        method: 'POST',
+        url: '/v1/content-router/rules',
+        payload: radarrRule,
+      })
+      const id = createRes.json().rule.id
+
+      const putRes = await app.inject({
+        method: 'PUT',
+        url: `/v1/content-router/rules/${id}`,
+        payload: { season_monitoring: 'all' },
+      })
+      expect(putRes.statusCode).toBe(400)
+      expect(putRes.json().message).toContain('season_monitoring')
+    })
+
     it('accepts explicit null for target-specific fields', async () => {
       const res = await app.inject({
         method: 'POST',

--- a/test/unit/utils/content-router-formatter.test.ts
+++ b/test/unit/utils/content-router-formatter.test.ts
@@ -37,6 +37,7 @@ describe('content-router-formatter', () => {
         search_on_add: true,
         season_monitoring: 'all',
         series_type: 'standard',
+        monitor: 'movieAndCollection',
         always_require_approval: false,
         bypass_user_quotas: false,
         approval_reason: 'Test reason',
@@ -58,6 +59,7 @@ describe('content-router-formatter', () => {
         search_on_add: true,
         season_monitoring: 'all',
         series_type: 'standard',
+        monitor: 'movieAndCollection',
         always_require_approval: false,
         bypass_user_quotas: false,
         approval_reason: 'Test reason',
@@ -217,6 +219,19 @@ describe('content-router-formatter', () => {
       expect(result.series_type).toBeUndefined()
     })
 
+    it('should handle null monitor as undefined', () => {
+      const rule = createMockRule({
+        id: 13,
+        name: 'Null Monitor',
+        target_type: 'radarr',
+        monitor: null,
+      })
+
+      const result = formatRule(rule)
+
+      expect(result.monitor).toBeUndefined()
+    })
+
     it('should default always_require_approval to false when null', () => {
       const rule = createMockRule({
         id: 14,
@@ -369,6 +384,34 @@ describe('content-router-formatter', () => {
       const result = formatRule(rule)
 
       expect(result.series_type).toBeUndefined()
+      expect(result.condition).toBeUndefined()
+    })
+
+    it('should handle null monitor in catch path', () => {
+      const rule = createMockRule({
+        id: 26,
+        name: 'Catch Null Monitor',
+        criteria: '{invalid json',
+        monitor: null,
+      })
+
+      const result = formatRule(rule)
+
+      expect(result.monitor).toBeUndefined()
+      expect(result.condition).toBeUndefined()
+    })
+
+    it('should preserve monitor value in catch path', () => {
+      const rule = createMockRule({
+        id: 26,
+        name: 'Catch Monitor Value',
+        criteria: '{invalid json',
+        monitor: 'movieOnly',
+      })
+
+      const result = formatRule(rule)
+
+      expect(result.monitor).toBe('movieOnly')
       expect(result.condition).toBeUndefined()
     })
 

--- a/test/unit/utils/rule-builder.test.ts
+++ b/test/unit/utils/rule-builder.test.ts
@@ -350,6 +350,7 @@ describe('rule-builder', () => {
         search_on_add: undefined,
         season_monitoring: undefined,
         series_type: undefined,
+        monitor: undefined,
         always_require_approval: undefined,
         bypass_user_quotas: undefined,
         approval_reason: undefined,
@@ -456,6 +457,19 @@ describe('rule-builder', () => {
       expect(rule.target_type).toBe('sonarr')
       expect(rule.season_monitoring).toBe('future')
       expect(rule.series_type).toBe('daily')
+    })
+
+    it('should handle radarr-specific fields', () => {
+      const rule = RuleBuilder.createRule({
+        name: 'Movie Rule',
+        target_type: 'radarr',
+        target_instance_id: 1,
+        condition: RuleBuilder.genre('Action'),
+        monitor: 'movieAndCollection',
+      })
+
+      expect(rule.target_type).toBe('radarr')
+      expect(rule.monitor).toBe('movieAndCollection')
     })
 
     it('should handle empty tags array by default', () => {


### PR DESCRIPTION
… target types

## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Content Router rules now enforce target-aware support more consistently (e.g., Sonarr `monitor`, Radarr `series_type`/`season_monitoring`).
  * `quality_profile` can be provided as a numeric string and will be stored as a number, with invalid strings treated as `null`.

* **Bug Fixes**
  * Fixed rule create/update behavior for target-specific fields, including stronger validation and more predictable handling of `tags` and `quality_profile`.
  * Improved formatting behavior for `monitor`, including correct normalization of `null` to an omitted value in outputs.

* **Tests**
  * Added and expanded integration and unit coverage for target-aware field validation and `quality_profile` coercion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->