### PR TITLE
fix(installers): clear stale files on native update to prevent startu…

### DIFF
--- a/dockerfile.node
+++ b/dockerfile.node
@@ -14,6 +14,7 @@ RUN cat package.json.bak \
     | sed 's|"file:packages/better-sqlite3-bun"|"12.11.1"|' \
     | sed '/"better-sqlite3":/a\    "tsx": "^4.22.5",' \
     | sed 's|bun run build:server|npm run build:server|g' \
+    | sed 's|bun run clean:server|npm run clean:server|g' \
     | sed 's|bun run clean:client|npm run clean:client|g' \
     | sed 's|bun run --bun vite build|vite build|g' \
     | sed 's|bun run --bun|npx tsx|g' \

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "clean:client": "rimraf dist/client",
     "clean:server": "rimraf dist",
-    "build": "bun run build:server && bun run clean:client && bun run --bun vite build",
+    "build": "bun run clean:server && bun run build:server && bun run clean:client && bun run --bun vite build",
     "build:server": "tsc && tsc-alias",
     "dev:server": "bun run --bun --watch src/server.ts",
     "dev": "bun run --bun src/server.ts --dev",

--- a/scripts/build-native.ts
+++ b/scripts/build-native.ts
@@ -152,8 +152,7 @@ mkdirSync(BUILD_DIR, { recursive: true })
 
 if (!skipBuild) {
   console.log('[1/4] Building server...')
-  // Wipe dist first so files removed or moved since the last build do not linger
-  // in the shipped tree (tsc builds incrementally and never deletes stale output).
+  // Wipe dist first: tsc builds incrementally and never deletes stale output.
   run('bun run clean:server')
   run('bun run build:server')
 
@@ -275,8 +274,7 @@ exec ./bun run --bun dist/server.js "$@"
 
 const UPDATE_UNIX = `#!/bin/bash
 # Update a portable Pulsarr install from a downloaded release zip.
-# Only Pulsarr's own program directories are replaced, so config and data stay
-# put wherever .env points them (dbPath, dataDir, custom locations, and all).
+# Replaces only Pulsarr's own program files; your config and data are left alone.
 #
 # Usage: ./update.sh <path-to-new-release-zip>
 set -euo pipefail
@@ -309,11 +307,13 @@ if [ ! -f "$NEW/start.sh" ]; then
   echo "This does not look like a Pulsarr release zip (start.sh not found)."
   exit 1
 fi
+if [ ! -d "$NEW/dist" ] || [ ! -d "$NEW/node_modules" ]; then
+  echo "This release zip is incomplete (dist or node_modules missing)."
+  exit 1
+fi
 
 echo "Replacing application files..."
-# Remove only the fully owned code directories where a stale file breaks startup,
-# then copy the new tree over the rest. Nothing else is deleted, so config and
-# data are left untouched wherever they live.
+# Only dist and node_modules are deleted; config and data are left in place.
 rm -rf "$INSTALL_DIR/dist" "$INSTALL_DIR/node_modules"
 cp -a "$NEW/." "$INSTALL_DIR/"
 chmod +x "$INSTALL_DIR/start.sh" "$INSTALL_DIR/bun" 2>/dev/null || true
@@ -366,7 +366,11 @@ set "ZIP=%~2"
 set "STAGEDIR=%TEMP%\\pulsarr-new-%RANDOM%%RANDOM%"
 
 echo Extracting update...
-powershell -NoProfile -Command "Expand-Archive -LiteralPath '%ZIP%' -DestinationPath '%STAGEDIR%' -Force"
+rem Pass paths to PowerShell via environment variables so quotes or apostrophes
+rem in the path cannot break out of the command string.
+set "PS_ZIP=%ZIP%"
+set "PS_DEST=%STAGEDIR%"
+powershell -NoProfile -Command "Expand-Archive -LiteralPath $env:PS_ZIP -DestinationPath $env:PS_DEST -Force"
 if errorlevel 1 (
   echo Failed to extract zip.
   rd /s /q "%STAGEDIR%" 2>nul
@@ -382,6 +386,16 @@ if not exist "!NEW!\\start.bat" (
   rd /s /q "%STAGEDIR%" 2>nul
   exit /b 1
 )
+if not exist "!NEW!\\dist" (
+  echo This release zip is incomplete (dist missing).
+  rd /s /q "%STAGEDIR%" 2>nul
+  exit /b 1
+)
+if not exist "!NEW!\\node_modules" (
+  echo This release zip is incomplete (node_modules missing).
+  rd /s /q "%STAGEDIR%" 2>nul
+  exit /b 1
+)
 
 if exist "!INSTALL!\\pulsarr-service.exe" (
   echo Stopping Pulsarr service...
@@ -390,9 +404,7 @@ if exist "!INSTALL!\\pulsarr-service.exe" (
 )
 
 echo Replacing application files...
-rem Remove only the fully owned code directories where a stale file breaks
-rem startup, then copy the new tree over the rest with /E (no purge). Nothing
-rem else is deleted, so config and data are left untouched wherever they live.
+rem Only dist and node_modules are removed; /E copies without purging the rest.
 rd /s /q "!INSTALL!\\dist" 2>nul
 rd /s /q "!INSTALL!\\node_modules" 2>nul
 robocopy "!NEW!" "!INSTALL!" /E /R:2 /W:2 /NFL /NDL /NJH /NJS /NP >nul

--- a/scripts/build-native.ts
+++ b/scripts/build-native.ts
@@ -2,7 +2,7 @@
 /// <reference types="bun-types" />
 /**
  * Build native distribution packages for Pulsarr
- * Produces per-platform zips with the Bun runtime included — no install needed
+ * Produces per-platform zips with the Bun runtime included - no install needed
  *
  * Usage: bun run --bun scripts/build-native.ts [options]
  *   --run          Build for current platform and start the app
@@ -152,6 +152,9 @@ mkdirSync(BUILD_DIR, { recursive: true })
 
 if (!skipBuild) {
   console.log('[1/4] Building server...')
+  // Wipe dist first so files removed or moved since the last build do not linger
+  // in the shipped tree (tsc builds incrementally and never deletes stale output).
+  run('bun run clean:server')
   run('bun run build:server')
 
   console.log('[2/4] Building client...')
@@ -165,7 +168,7 @@ if (!skipBuild) {
 console.log('[3/4] Assembling common files...')
 mkdirSync(COMMON_DIR, { recursive: true })
 
-// dist/ — tsc server output + vite client output
+// dist/ - tsc server output + vite client output
 const distDir = resolve(PROJECT_ROOT, 'dist')
 if (!existsSync(distDir)) {
   throw new Error(
@@ -180,7 +183,7 @@ if (existsSync(nestedBuild)) {
   rmSync(nestedBuild, { recursive: true })
 }
 
-// migrations/ — Knex runtime directory scanning + utils (clientDetection.ts)
+// migrations/ - Knex runtime directory scanning + utils (clientDetection.ts)
 mkdirSync(resolve(COMMON_DIR, 'migrations'), { recursive: true })
 cpSync(
   resolve(PROJECT_ROOT, 'migrations', 'migrations'),
@@ -201,7 +204,7 @@ cpSync(
   resolve(COMMON_DIR, 'migrations', 'migrate.ts'),
 )
 
-// packages/ — better-sqlite3-bun shim (package.json uses file: reference)
+// packages/ - better-sqlite3-bun shim (package.json uses file: reference)
 mkdirSync(resolve(COMMON_DIR, 'packages'), { recursive: true })
 cpSync(
   resolve(PROJECT_ROOT, 'packages', 'better-sqlite3-bun'),
@@ -270,6 +273,54 @@ echo "Starting Pulsarr..."
 exec ./bun run --bun dist/server.js "$@"
 `
 
+const UPDATE_UNIX = `#!/bin/bash
+# Update a portable Pulsarr install from a downloaded release zip.
+# Only Pulsarr's own program directories are replaced, so config and data stay
+# put wherever .env points them (dbPath, dataDir, custom locations, and all).
+#
+# Usage: ./update.sh <path-to-new-release-zip>
+set -euo pipefail
+
+cd "$(dirname "\${BASH_SOURCE[0]}")"
+INSTALL_DIR="$(pwd)"
+
+ZIP="\${1:-}"
+if [ -z "$ZIP" ] || [ ! -f "$ZIP" ]; then
+  echo "Usage: ./update.sh <path-to-new-release-zip>"
+  exit 1
+fi
+
+if ! command -v unzip >/dev/null 2>&1; then
+  echo "unzip is required but was not found."
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "Extracting update..."
+unzip -q "$ZIP" -d "$TMP"
+
+# Release zips hold a single top-level pulsarr-vX.Y.Z-<platform>/ directory.
+NEW="$(find "$TMP" -mindepth 1 -maxdepth 1 -type d -name 'pulsarr-*' | head -1)" || true
+if [ -z "$NEW" ]; then NEW="$TMP"; fi
+
+if [ ! -f "$NEW/start.sh" ]; then
+  echo "This does not look like a Pulsarr release zip (start.sh not found)."
+  exit 1
+fi
+
+echo "Replacing application files..."
+# Remove only the fully owned code directories where a stale file breaks startup,
+# then copy the new tree over the rest. Nothing else is deleted, so config and
+# data are left untouched wherever they live.
+rm -rf "$INSTALL_DIR/dist" "$INSTALL_DIR/node_modules"
+cp -a "$NEW/." "$INSTALL_DIR/"
+chmod +x "$INSTALL_DIR/start.sh" "$INSTALL_DIR/bun" 2>/dev/null || true
+
+echo "Update complete. Start Pulsarr with ./start.sh (or restart your service)."
+`
+
 const WINDOWS_START = `@echo off
 cd /d "%~dp0"
 
@@ -282,6 +333,80 @@ echo Starting Pulsarr...
 echo.
 echo Pulsarr has exited (code: %ERRORLEVEL%)
 if not defined PULSARR_SERVICE pause
+`
+
+const UPDATE_WINDOWS = `@echo off
+setlocal enabledelayedexpansion
+
+if "%~1"=="" (
+  echo Usage: update.bat ^<path-to-new-release-zip^>
+  exit /b 1
+)
+if not exist "%~1" (
+  echo Zip not found: %~1
+  exit /b 1
+)
+
+rem cmd reads this file from disk as it runs and the update replaces this folder,
+rem so relaunch a copy from TEMP before touching anything here.
+if not defined PULSARR_UPDATE_STAGED (
+  set "STAGED=%TEMP%\\pulsarr-update-%RANDOM%%RANDOM%.bat"
+  copy /y "%~f0" "!STAGED!" >nul
+  set "PULSARR_UPDATE_STAGED=1"
+  call "!STAGED!" "%~dp0." "%~f1"
+  set "RC=!ERRORLEVEL!"
+  del "!STAGED!" >nul 2>&1
+  exit /b !RC!
+)
+
+set "INSTALL=%~1"
+if "!INSTALL:~-2!"=="\\." set "INSTALL=!INSTALL:~0,-2!"
+if "!INSTALL:~-1!"=="\\" set "INSTALL=!INSTALL:~0,-1!"
+set "ZIP=%~2"
+set "STAGEDIR=%TEMP%\\pulsarr-new-%RANDOM%%RANDOM%"
+
+echo Extracting update...
+powershell -NoProfile -Command "Expand-Archive -LiteralPath '%ZIP%' -DestinationPath '%STAGEDIR%' -Force"
+if errorlevel 1 (
+  echo Failed to extract zip.
+  rd /s /q "%STAGEDIR%" 2>nul
+  exit /b 1
+)
+
+set "NEW="
+for /d %%D in ("%STAGEDIR%\\pulsarr-*") do set "NEW=%%D"
+if not defined NEW set "NEW=%STAGEDIR%"
+
+if not exist "!NEW!\\start.bat" (
+  echo This does not look like a Pulsarr release zip.
+  rd /s /q "%STAGEDIR%" 2>nul
+  exit /b 1
+)
+
+if exist "!INSTALL!\\pulsarr-service.exe" (
+  echo Stopping Pulsarr service...
+  "!INSTALL!\\pulsarr-service.exe" stop >nul 2>&1
+  timeout /t 2 /nobreak >nul
+)
+
+echo Replacing application files...
+rem Remove only the fully owned code directories where a stale file breaks
+rem startup, then copy the new tree over the rest with /E (no purge). Nothing
+rem else is deleted, so config and data are left untouched wherever they live.
+rd /s /q "!INSTALL!\\dist" 2>nul
+rd /s /q "!INSTALL!\\node_modules" 2>nul
+robocopy "!NEW!" "!INSTALL!" /E /R:2 /W:2 /NFL /NDL /NJH /NJS /NP >nul
+set "RC=!ERRORLEVEL!"
+rd /s /q "%STAGEDIR%" 2>nul
+
+if !RC! GEQ 8 (
+  echo Update failed ^(robocopy code !RC!^). Make sure Pulsarr is fully stopped and retry.
+  exit /b 1
+)
+
+echo Update complete.
+echo Start Pulsarr with start.bat, or: pulsarr-service.exe start
+exit /b 0
 `
 
 const WINSW_XML = `<service>
@@ -337,7 +462,7 @@ echo Pulsarr service has been removed.
 pause
 `
 
-const README_LINUX = `# Pulsarr — Native Install (Linux)
+const README_LINUX = `# Pulsarr - Native Install (Linux)
 
 ## Quick Start
 
@@ -383,10 +508,13 @@ Manage with:
 1. Stop Pulsarr (Ctrl+C, or stop the service):
    sudo systemctl stop pulsarr
 
-2. Download the new release zip and extract it over this directory.
-   Your .env and data/ folder will not be overwritten.
+2. Download the new release zip, then run the updater with its path:
+   ./update.sh ~/Downloads/pulsarr-vX.Y.Z-linux-x64.zip
+   Pulsarr's program files are replaced; your config and data are left untouched
+   wherever .env points them.
+   (If you installed with the install script, re-running it updates in place too.)
 
-3. Restart Pulsarr:
+3. Start Pulsarr:
    ./start.sh
    (or: sudo systemctl start pulsarr)
 
@@ -398,19 +526,19 @@ Migrations run automatically on startup.
 - Database and logs: ./data/
 `
 
-const README_MACOS = `# Pulsarr — Native Install (macOS)
+const README_MACOS = `# Pulsarr - Native Install (macOS)
 
 ## Quick Start
 
-1. Copy .env.example to .env and edit your settings:
-   cp .env.example .env
-
-2. Run Pulsarr:
+1. Run Pulsarr (this creates ~/.config/Pulsarr on first start):
    ./start.sh
 
    If macOS blocks execution, allow it in System Settings > Privacy & Security,
    or remove the quarantine attribute:
    xattr -r -d com.apple.quarantine .
+
+2. Optional: to configure via .env, copy .env.example to ~/.config/Pulsarr/.env
+   and edit it, then restart. Pulsarr reads config from there, not this folder.
 
 3. Open http://localhost:3003 in your browser.
 
@@ -457,10 +585,13 @@ Manage with:
 1. Stop Pulsarr (Ctrl+C, or stop the service):
    launchctl stop com.pulsarr
 
-2. Download the new release zip and extract it over this directory.
-   Your .env and data/ folder will not be overwritten.
+2. Download the new release zip, then run the updater with its path:
+   ./update.sh ~/Downloads/pulsarr-vX.Y.Z-macos-arm64.zip
+   Pulsarr's program files are replaced; your config and data are left untouched
+   wherever .env points them.
+   (If you installed the .app via the DMG, just reinstall the new DMG instead.)
 
-3. Restart Pulsarr:
+3. Start Pulsarr:
    ./start.sh
    (or: launchctl start com.pulsarr)
 
@@ -468,18 +599,20 @@ Migrations run automatically on startup.
 
 ## Data & Configuration
 
-- Configuration: .env (copied from .env.example)
-- Database and logs: ./data/
+- Configuration and data live in ~/.config/Pulsarr (.env, db, and logs)
 `
 
-const README_WINDOWS = `# Pulsarr — Native Install (Windows)
+const README_WINDOWS = `# Pulsarr - Native Install (Windows)
 
 ## Quick Start
 
-1. Copy .env.example to .env and edit your settings.
-
-2. Double-click start.bat or run it from a terminal:
+1. Double-click start.bat or run it from a terminal (this creates
+   %PROGRAMDATA%\\Pulsarr on first start):
    start.bat
+
+2. Optional: to configure via .env, copy .env.example to
+   %PROGRAMDATA%\\Pulsarr\\.env and edit it, then restart. Pulsarr reads config
+   from there, not this folder.
 
 3. Open http://localhost:3003 in your browser.
 
@@ -505,10 +638,13 @@ Remove the service:
 1. Stop Pulsarr (Ctrl+C, close the window, or stop the service):
    pulsarr-service.exe stop
 
-2. Download the new release zip and extract it over this directory.
-   Your .env and data folder will not be overwritten.
+2. Download the new release zip, then run the updater with its path:
+   update.bat C:\\Users\\You\\Downloads\\pulsarr-vX.Y.Z-windows-x64.zip
+   Pulsarr's program files are replaced; your config and data are left untouched
+   wherever .env points them.
+   (If you installed with the Windows installer, just run the new installer instead.)
 
-3. Restart Pulsarr:
+3. Start Pulsarr:
    start.bat
    (or: pulsarr-service.exe start)
 
@@ -516,8 +652,7 @@ Migrations run automatically on startup.
 
 ## Data & Configuration
 
-- Configuration: .env (copied from .env.example)
-- Database and logs: .\\data\\
+- Configuration and data live in %PROGRAMDATA%\\Pulsarr (.env, db, and logs)
 `
 
 function getReadme(zipSuffix: string): string {
@@ -606,6 +741,7 @@ for (const platform of PLATFORMS) {
 
   if (isWindows) {
     writeFileSync(resolve(platformDir, 'start.bat'), WINDOWS_START)
+    writeFileSync(resolve(platformDir, 'update.bat'), UPDATE_WINDOWS)
 
     const winswTmp = resolve(BUILD_DIR, '_winsw.exe')
     if (!existsSync(winswTmp)) {
@@ -625,6 +761,10 @@ for (const platform of PLATFORMS) {
     const startPath = resolve(platformDir, 'start.sh')
     writeFileSync(startPath, UNIX_START)
     chmodSync(startPath, 0o755)
+
+    const updatePath = resolve(platformDir, 'update.sh')
+    writeFileSync(updatePath, UPDATE_UNIX)
+    chmodSync(updatePath, 0o755)
   }
 
   writeFileSync(
@@ -638,7 +778,7 @@ for (const platform of PLATFORMS) {
   console.log(`      -> ${zipName}.zip (${formatSize(zipSize)})`)
 }
 
-// Cleanup — keep unzipped dirs when --run needs them
+// Cleanup - keep unzipped dirs when --run needs them
 rmSync(COMMON_DIR, { recursive: true, force: true })
 const currentPlatformConfig = PLATFORMS.find(
   (p) => p.detectName === currentPlatform,

--- a/scripts/build-native.ts
+++ b/scripts/build-native.ts
@@ -279,46 +279,55 @@ const UPDATE_UNIX = `#!/bin/bash
 # Usage: ./update.sh <path-to-new-release-zip>
 set -euo pipefail
 
-cd "$(dirname "\${BASH_SOURCE[0]}")"
-INSTALL_DIR="$(pwd)"
+# The cp below overwrites this script mid-run. Bash reads the script from disk as
+# it executes, so keep the whole body in a function (parsed up front) and exit on
+# the last line before bash can read past it into the replacement.
+main() {
+  ZIP="\${1:-}"
+  if [ -z "$ZIP" ] || [ ! -f "$ZIP" ]; then
+    echo "Usage: ./update.sh <path-to-new-release-zip>"
+    exit 1
+  fi
+  # Resolve the zip to an absolute path before cd so a relative arg keeps working.
+  ZIP="$(cd "$(dirname "$ZIP")" && pwd)/$(basename "$ZIP")"
 
-ZIP="\${1:-}"
-if [ -z "$ZIP" ] || [ ! -f "$ZIP" ]; then
-  echo "Usage: ./update.sh <path-to-new-release-zip>"
-  exit 1
-fi
+  cd "$(dirname "\${BASH_SOURCE[0]}")"
+  INSTALL_DIR="$(pwd)"
 
-if ! command -v unzip >/dev/null 2>&1; then
-  echo "unzip is required but was not found."
-  exit 1
-fi
+  if ! command -v unzip >/dev/null 2>&1; then
+    echo "unzip is required but was not found."
+    exit 1
+  fi
 
-TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT
+  TMP="$(mktemp -d)"
+  trap 'rm -rf "$TMP"' EXIT
 
-echo "Extracting update..."
-unzip -q "$ZIP" -d "$TMP"
+  echo "Extracting update..."
+  unzip -q "$ZIP" -d "$TMP"
 
-# Release zips hold a single top-level pulsarr-vX.Y.Z-<platform>/ directory.
-NEW="$(find "$TMP" -mindepth 1 -maxdepth 1 -type d -name 'pulsarr-*' | head -1)" || true
-if [ -z "$NEW" ]; then NEW="$TMP"; fi
+  # Release zips hold a single top-level pulsarr-vX.Y.Z-<platform>/ directory.
+  NEW="$(find "$TMP" -mindepth 1 -maxdepth 1 -type d -name 'pulsarr-*' | head -1)" || true
+  if [ -z "$NEW" ]; then NEW="$TMP"; fi
 
-if [ ! -f "$NEW/start.sh" ]; then
-  echo "This does not look like a Pulsarr release zip (start.sh not found)."
-  exit 1
-fi
-if [ ! -d "$NEW/dist" ] || [ ! -d "$NEW/node_modules" ]; then
-  echo "This release zip is incomplete (dist or node_modules missing)."
-  exit 1
-fi
+  if [ ! -f "$NEW/start.sh" ]; then
+    echo "This does not look like a Pulsarr release zip (start.sh not found)."
+    exit 1
+  fi
+  if [ ! -d "$NEW/dist" ] || [ ! -d "$NEW/node_modules" ]; then
+    echo "This release zip is incomplete (dist or node_modules missing)."
+    exit 1
+  fi
 
-echo "Replacing application files..."
-# Only dist and node_modules are deleted; config and data are left in place.
-rm -rf "$INSTALL_DIR/dist" "$INSTALL_DIR/node_modules"
-cp -a "$NEW/." "$INSTALL_DIR/"
-chmod +x "$INSTALL_DIR/start.sh" "$INSTALL_DIR/bun" 2>/dev/null || true
+  echo "Replacing application files..."
+  # Only dist and node_modules are deleted; config and data are left in place.
+  rm -rf "$INSTALL_DIR/dist" "$INSTALL_DIR/node_modules"
+  cp -a "$NEW/." "$INSTALL_DIR/"
+  chmod +x "$INSTALL_DIR/start.sh" "$INSTALL_DIR/bun" 2>/dev/null || true
 
-echo "Update complete. Start Pulsarr with ./start.sh (or restart your service)."
+  echo "Update complete. Start Pulsarr with ./start.sh (or restart your service)."
+}
+
+main "$@"; exit 0
 `
 
 const WINDOWS_START = `@echo off

--- a/scripts/installers/linux/install.sh
+++ b/scripts/installers/linux/install.sh
@@ -156,6 +156,11 @@ install_files() {
         die "Copy failed. No changes were made to the installation."
     fi
 
+    if [[ ! -d "${staging}/dist" ]] || [[ ! -d "${staging}/node_modules" ]]; then
+        rm -rf "${staging:?}"
+        die "Release payload is incomplete (dist or node_modules missing). No changes were made."
+    fi
+
     for d in $owned; do
         rm -rf "${INSTALL_DIR:?}/${d}"
         mv "${staging}/${d}" "${INSTALL_DIR}/${d}"

--- a/scripts/installers/linux/install.sh
+++ b/scripts/installers/linux/install.sh
@@ -138,69 +138,51 @@ create_user() {
     fi
 }
 
-# Install application files
+# Install application files.
+# Only Pulsarr-owned code directories are replaced. Config and data are never
+# touched, so a relocated dbPath or dataDir survives wherever .env points it.
+# The owned dirs are renamed aside in place (no /tmp copy) so a failed copy rolls
+# back to the previous version.
 install_files() {
     local src_dir="$1"
+    local owned="dist node_modules"
+    local d
 
-    # Backup existing .env and data if present
-    local env_backup=""
-    local data_backup=""
-
-    if [[ -f "${INSTALL_DIR}/.env" ]]; then
-        info "Backing up existing .env..."
-        env_backup=$(mktemp)
-        cp "${INSTALL_DIR}/.env" "$env_backup"
-    fi
-
-    if [[ -d "${INSTALL_DIR}/data" ]]; then
-        info "Backing up existing data directory..."
-        data_backup=$(mktemp -d)
-        cp -r "${INSTALL_DIR}/data" "$data_backup/"
-    fi
-
-    # Remove old installation (except .env and data which are backed up)
-    if [[ -d "$INSTALL_DIR" ]]; then
-        info "Removing old installation..."
-        rm -rf "$INSTALL_DIR"
-    fi
-
-    # Create install directory
     mkdir -p "$INSTALL_DIR"
 
-    # Copy new files
+    for d in $owned; do
+        if [[ -e "${INSTALL_DIR}/${d}" ]]; then
+            rm -rf "${INSTALL_DIR}/${d}.old"
+            mv "${INSTALL_DIR}/${d}" "${INSTALL_DIR}/${d}.old"
+        fi
+    done
+
     info "Installing files to ${INSTALL_DIR}..."
-    cp -r "${src_dir}/." "${INSTALL_DIR}/"
-
-    # Remove any .env or data from the source (fresh install shouldn't have user data)
-    rm -f "${INSTALL_DIR}/.env" 2>/dev/null || true
-    rm -rf "${INSTALL_DIR}/data" 2>/dev/null || true
-
-    # Restore backups
-    if [[ -n "$env_backup" && -f "$env_backup" ]]; then
-        info "Restoring .env..."
-        cp "$env_backup" "${INSTALL_DIR}/.env"
-        rm "$env_backup"
+    if ! cp -a "${src_dir}/." "${INSTALL_DIR}/"; then
+        error "Copy failed, restoring the previous version..."
+        for d in $owned; do
+            if [[ -e "${INSTALL_DIR}/${d}.old" ]]; then
+                rm -rf "${INSTALL_DIR}/${d}"
+                mv "${INSTALL_DIR}/${d}.old" "${INSTALL_DIR}/${d}"
+            fi
+        done
+        die "Update aborted and rolled back. Your config and data were not touched."
     fi
 
-    if [[ -n "$data_backup" && -d "${data_backup}/data" ]]; then
-        info "Restoring data directory..."
-        cp -r "${data_backup}/data" "${INSTALL_DIR}/"
-        rm -rf "$data_backup"
-    fi
+    # Copy succeeded, discard the saved copies.
+    for d in $owned; do
+        rm -rf "${INSTALL_DIR}/${d}.old"
+    done
 
-    # Create data directories if they don't exist
+    # First-install scaffolding (the default dbPath and log dir live under data/).
     mkdir -p "${INSTALL_DIR}/data/db"
     mkdir -p "${INSTALL_DIR}/data/logs"
 
-    # Create .env from template if it doesn't exist
     if [[ ! -f "${INSTALL_DIR}/.env" ]]; then
         cp "${INSTALL_DIR}/.env.example" "${INSTALL_DIR}/.env"
     fi
 
-    # Set ownership
     chown -R "${APP_USER}:${APP_GROUP}" "$INSTALL_DIR"
-
-    # Make start script executable
     chmod +x "${INSTALL_DIR}/start.sh"
     chmod +x "${INSTALL_DIR}/bun"
 }

--- a/scripts/installers/linux/install.sh
+++ b/scripts/installers/linux/install.sh
@@ -138,41 +138,30 @@ create_user() {
     fi
 }
 
-# Install application files.
-# Only Pulsarr-owned code directories are replaced. Config and data are never
-# touched, so a relocated dbPath or dataDir survives wherever .env points it.
-# The owned dirs are renamed aside in place (no /tmp copy) so a failed copy rolls
-# back to the previous version.
+# Replace only Pulsarr-owned code (dist, node_modules); config and data are left
+# alone. Stage in a sibling dir first so a failed copy changes nothing.
 install_files() {
     local src_dir="$1"
     local owned="dist node_modules"
+    local staging="${INSTALL_DIR}.staging"
     local d
 
     mkdir -p "$INSTALL_DIR"
 
-    for d in $owned; do
-        if [[ -e "${INSTALL_DIR}/${d}" ]]; then
-            rm -rf "${INSTALL_DIR}/${d}.old"
-            mv "${INSTALL_DIR}/${d}" "${INSTALL_DIR}/${d}.old"
-        fi
-    done
-
+    rm -rf "${staging:?}"
+    mkdir -p "$staging"
     info "Installing files to ${INSTALL_DIR}..."
-    if ! cp -a "${src_dir}/." "${INSTALL_DIR}/"; then
-        error "Copy failed, restoring the previous version..."
-        for d in $owned; do
-            if [[ -e "${INSTALL_DIR}/${d}.old" ]]; then
-                rm -rf "${INSTALL_DIR}/${d}"
-                mv "${INSTALL_DIR}/${d}.old" "${INSTALL_DIR}/${d}"
-            fi
-        done
-        die "Update aborted and rolled back. Your config and data were not touched."
+    if ! cp -a "${src_dir}/." "${staging}/"; then
+        rm -rf "${staging:?}"
+        die "Copy failed. No changes were made to the installation."
     fi
 
-    # Copy succeeded, discard the saved copies.
     for d in $owned; do
-        rm -rf "${INSTALL_DIR}/${d}.old"
+        rm -rf "${INSTALL_DIR:?}/${d}"
+        mv "${staging}/${d}" "${INSTALL_DIR}/${d}"
     done
+    cp -a "${staging}/." "${INSTALL_DIR}/"
+    rm -rf "${staging:?}"
 
     # First-install scaffolding (the default dbPath and log dir live under data/).
     mkdir -p "${INSTALL_DIR}/data/db"

--- a/scripts/installers/linux/install.sh
+++ b/scripts/installers/linux/install.sh
@@ -165,7 +165,10 @@ install_files() {
         rm -rf "${INSTALL_DIR:?}/${d}"
         mv "${staging}/${d}" "${INSTALL_DIR}/${d}"
     done
-    cp -a "${staging}/." "${INSTALL_DIR}/"
+    if ! cp -a "${staging}/." "${INSTALL_DIR}/"; then
+        rm -rf "${staging:?}"
+        die "Failed to copy application files. Re-run the installer to complete the installation."
+    fi
     rm -rf "${staging:?}"
 
     # First-install scaffolding (the default dbPath and log dir live under data/).

--- a/scripts/installers/windows/pulsarr-baseline.iss
+++ b/scripts/installers/windows/pulsarr-baseline.iss
@@ -53,9 +53,19 @@ Name: "service"; Description: "Install as Windows Service"; Types: full
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 Name: "startafterinstall"; Description: "Start Pulsarr after installation"; GroupDescription: "Startup:"; Flags: checkedonce
 
+[InstallDelete]
+; Wipe only the code subdirectories before copying the new version so files
+; removed or moved between releases do not linger and get loaded alongside their
+; replacements. Here {app} and {#MyAppDataDir} are the same folder, so the data
+; (db, logs, .env) sits at the root next to these subdirs and is left untouched.
+Type: filesandordirs; Name: "{app}\dist"
+Type: filesandordirs; Name: "{app}\node_modules"
+
 [Files]
-; Main application files (from extracted native build zip)
-Source: "build\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs; Components: main
+; Main application files (from extracted native build zip).
+; update.bat is the portable-install updater; installer users update by re-running
+; the installer, so it is left out to keep them on that path.
+Source: "build\*"; DestDir: "{app}"; Excludes: "update.bat"; Flags: ignoreversion recursesubdirs createallsubdirs; Components: main
 ; Icon for uninstaller
 Source: "pulsarr.ico"; DestDir: "{app}"; Flags: ignoreversion; Components: main
 

--- a/scripts/installers/windows/pulsarr-baseline.iss
+++ b/scripts/installers/windows/pulsarr-baseline.iss
@@ -54,17 +54,15 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 Name: "startafterinstall"; Description: "Start Pulsarr after installation"; GroupDescription: "Startup:"; Flags: checkedonce
 
 [InstallDelete]
-; Wipe only the code subdirectories before copying the new version so files
-; removed or moved between releases do not linger and get loaded alongside their
-; replacements. Here {app} and {#MyAppDataDir} are the same folder, so the data
-; (db, logs, .env) sits at the root next to these subdirs and is left untouched.
+; Clear the code dirs before copying so files removed between releases can't
+; linger. {app} and {#MyAppDataDir} are the same folder, so db/logs/.env sit
+; alongside these and are left untouched.
 Type: filesandordirs; Name: "{app}\dist"
 Type: filesandordirs; Name: "{app}\node_modules"
 
 [Files]
 ; Main application files (from extracted native build zip).
-; update.bat is the portable-install updater; installer users update by re-running
-; the installer, so it is left out to keep them on that path.
+; Exclude update.bat: installer users update by re-running the installer.
 Source: "build\*"; DestDir: "{app}"; Excludes: "update.bat"; Flags: ignoreversion recursesubdirs createallsubdirs; Components: main
 ; Icon for uninstaller
 Source: "pulsarr.ico"; DestDir: "{app}"; Flags: ignoreversion; Components: main

--- a/scripts/installers/windows/pulsarr.iss
+++ b/scripts/installers/windows/pulsarr.iss
@@ -53,9 +53,19 @@ Name: "service"; Description: "Install as Windows Service"; Types: full
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 Name: "startafterinstall"; Description: "Start Pulsarr after installation"; GroupDescription: "Startup:"; Flags: checkedonce
 
+[InstallDelete]
+; Wipe only the code subdirectories before copying the new version so files
+; removed or moved between releases do not linger and get loaded alongside their
+; replacements. Here {app} and {#MyAppDataDir} are the same folder, so the data
+; (db, logs, .env) sits at the root next to these subdirs and is left untouched.
+Type: filesandordirs; Name: "{app}\dist"
+Type: filesandordirs; Name: "{app}\node_modules"
+
 [Files]
-; Main application files (from extracted native build zip)
-Source: "build\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs; Components: main
+; Main application files (from extracted native build zip).
+; update.bat is the portable-install updater; installer users update by re-running
+; the installer, so it is left out to keep them on that path.
+Source: "build\*"; DestDir: "{app}"; Excludes: "update.bat"; Flags: ignoreversion recursesubdirs createallsubdirs; Components: main
 ; Icon for uninstaller
 Source: "pulsarr.ico"; DestDir: "{app}"; Flags: ignoreversion; Components: main
 

--- a/scripts/installers/windows/pulsarr.iss
+++ b/scripts/installers/windows/pulsarr.iss
@@ -54,17 +54,15 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 Name: "startafterinstall"; Description: "Start Pulsarr after installation"; GroupDescription: "Startup:"; Flags: checkedonce
 
 [InstallDelete]
-; Wipe only the code subdirectories before copying the new version so files
-; removed or moved between releases do not linger and get loaded alongside their
-; replacements. Here {app} and {#MyAppDataDir} are the same folder, so the data
-; (db, logs, .env) sits at the root next to these subdirs and is left untouched.
+; Clear the code dirs before copying so files removed between releases can't
+; linger. {app} and {#MyAppDataDir} are the same folder, so db/logs/.env sit
+; alongside these and are left untouched.
 Type: filesandordirs; Name: "{app}\dist"
 Type: filesandordirs; Name: "{app}\node_modules"
 
 [Files]
 ; Main application files (from extracted native build zip).
-; update.bat is the portable-install updater; installer users update by re-running
-; the installer, so it is left out to keep them on that path.
+; Exclude update.bat: installer users update by re-running the installer.
 Source: "build\*"; DestDir: "{app}"; Excludes: "update.bat"; Flags: ignoreversion recursesubdirs createallsubdirs; Components: main
 ; Icon for uninstaller
 Source: "pulsarr.ico"; DestDir: "{app}"; Flags: ignoreversion; Components: main


### PR DESCRIPTION
…p crashes

## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added platform-specific release updater scripts (Linux/macOS/Windows) that update program files while preserving configuration and data.
* **Bug Fixes**
  * Clean server output before rebuilding to reduce stale artifacts.
  * Updated installers (Windows and Linux) to remove existing `dist` and `node_modules` before installing new artifacts.
  * Linux installer now performs staged replacements, preserving `.env` and existing data.
* **Documentation**
  * Refreshed updater instructions and `.env`/wording guidance.
* **Chores**
  * Improved production build script rewriting to prefer `npm` over `bun`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->