### PR TITLE
fix(installers): fail loudly on locked files and clear migrations and packages on update

### DIFF
--- a/scripts/build-native.ts
+++ b/scripts/build-native.ts
@@ -313,14 +313,16 @@ main() {
     echo "This does not look like a Pulsarr release zip (start.sh not found)."
     exit 1
   fi
-  if [ ! -d "$NEW/dist" ] || [ ! -d "$NEW/node_modules" ]; then
-    echo "This release zip is incomplete (dist or node_modules missing)."
-    exit 1
-  fi
+  for d in dist node_modules migrations packages; do
+    if [ ! -d "$NEW/$d" ]; then
+      echo "This release zip is incomplete ($d missing)."
+      exit 1
+    fi
+  done
 
   echo "Replacing application files..."
-  # Only dist and node_modules are deleted; config and data are left in place.
-  rm -rf "$INSTALL_DIR/dist" "$INSTALL_DIR/node_modules"
+  # Only Pulsarr-owned code dirs are deleted; config and data are left in place.
+  rm -rf "$INSTALL_DIR/dist" "$INSTALL_DIR/node_modules" "$INSTALL_DIR/migrations" "$INSTALL_DIR/packages"
   cp -a "$NEW/." "$INSTALL_DIR/"
   chmod +x "$INSTALL_DIR/start.sh" "$INSTALL_DIR/bun" 2>/dev/null || true
 
@@ -395,15 +397,12 @@ if not exist "!NEW!\\start.bat" (
   rd /s /q "%STAGEDIR%" 2>nul
   exit /b 1
 )
-if not exist "!NEW!\\dist" (
-  echo This release zip is incomplete (dist missing).
-  rd /s /q "%STAGEDIR%" 2>nul
-  exit /b 1
-)
-if not exist "!NEW!\\node_modules" (
-  echo This release zip is incomplete (node_modules missing).
-  rd /s /q "%STAGEDIR%" 2>nul
-  exit /b 1
+for %%D in (dist node_modules migrations packages) do (
+  if not exist "!NEW!\\%%D" (
+    echo This release zip is incomplete (%%D missing).
+    rd /s /q "%STAGEDIR%" 2>nul
+    exit /b 1
+  )
 )
 
 if exist "!INSTALL!\\pulsarr-service.exe" (
@@ -413,9 +412,16 @@ if exist "!INSTALL!\\pulsarr-service.exe" (
 )
 
 echo Replacing application files...
-rem Only dist and node_modules are removed; /E copies without purging the rest.
-rd /s /q "!INSTALL!\\dist" 2>nul
-rd /s /q "!INSTALL!\\node_modules" 2>nul
+rem Only Pulsarr-owned code dirs are removed; /E copies without purging the rest.
+rem rd exits 0 even when a locked file survives, so verify each dir is gone.
+for %%D in (dist node_modules migrations packages) do (
+  rd /s /q "!INSTALL!\\%%D" 2>nul
+  if exist "!INSTALL!\\%%D" (
+    echo Failed to remove !INSTALL!\\%%D. Make sure Pulsarr is fully stopped and retry.
+    rd /s /q "%STAGEDIR%" 2>nul
+    exit /b 1
+  )
+)
 robocopy "!NEW!" "!INSTALL!" /E /R:2 /W:2 /NFL /NDL /NJH /NJS /NP >nul
 set "RC=!ERRORLEVEL!"
 rd /s /q "%STAGEDIR%" 2>nul

--- a/scripts/build-native.ts
+++ b/scripts/build-native.ts
@@ -313,7 +313,8 @@ main() {
     echo "This does not look like a Pulsarr release zip (start.sh not found)."
     exit 1
   fi
-  for d in dist node_modules migrations packages; do
+  OWNED="dist node_modules migrations packages"
+  for d in $OWNED; do
     if [ ! -d "$NEW/$d" ]; then
       echo "This release zip is incomplete ($d missing)."
       exit 1
@@ -322,7 +323,9 @@ main() {
 
   echo "Replacing application files..."
   # Only Pulsarr-owned code dirs are deleted; config and data are left in place.
-  rm -rf "$INSTALL_DIR/dist" "$INSTALL_DIR/node_modules" "$INSTALL_DIR/migrations" "$INSTALL_DIR/packages"
+  for d in $OWNED; do
+    rm -rf "$INSTALL_DIR/$d"
+  done
   cp -a "$NEW/." "$INSTALL_DIR/"
   chmod +x "$INSTALL_DIR/start.sh" "$INSTALL_DIR/bun" 2>/dev/null || true
 

--- a/scripts/installers/linux/install.sh
+++ b/scripts/installers/linux/install.sh
@@ -138,11 +138,11 @@ create_user() {
     fi
 }
 
-# Replace only Pulsarr-owned code (dist, node_modules); config and data are left
-# alone. Stage in a sibling dir first so a failed copy changes nothing.
+# Replace only Pulsarr-owned code dirs; config and data are left alone.
+# Stage in a sibling dir first so a failed copy changes nothing.
 install_files() {
     local src_dir="$1"
-    local owned="dist node_modules"
+    local owned="dist node_modules migrations packages"
     local staging="${INSTALL_DIR}.staging"
     local d
 
@@ -156,10 +156,12 @@ install_files() {
         die "Copy failed. No changes were made to the installation."
     fi
 
-    if [[ ! -d "${staging}/dist" ]] || [[ ! -d "${staging}/node_modules" ]]; then
-        rm -rf "${staging:?}"
-        die "Release payload is incomplete (dist or node_modules missing). No changes were made."
-    fi
+    for d in $owned; do
+        if [[ ! -d "${staging}/${d}" ]]; then
+            rm -rf "${staging:?}"
+            die "Release payload is incomplete (${d} missing). No changes were made."
+        fi
+    done
 
     for d in $owned; do
         rm -rf "${INSTALL_DIR:?}/${d}"

--- a/scripts/installers/windows/pulsarr-baseline.iss
+++ b/scripts/installers/windows/pulsarr-baseline.iss
@@ -59,6 +59,8 @@ Name: "startafterinstall"; Description: "Start Pulsarr after installation"; Grou
 ; alongside these and are left untouched.
 Type: filesandordirs; Name: "{app}\dist"
 Type: filesandordirs; Name: "{app}\node_modules"
+Type: filesandordirs; Name: "{app}\migrations"
+Type: filesandordirs; Name: "{app}\packages"
 
 [Files]
 ; Main application files (from extracted native build zip).

--- a/scripts/installers/windows/pulsarr.iss
+++ b/scripts/installers/windows/pulsarr.iss
@@ -59,6 +59,8 @@ Name: "startafterinstall"; Description: "Start Pulsarr after installation"; Grou
 ; alongside these and are left untouched.
 Type: filesandordirs; Name: "{app}\dist"
 Type: filesandordirs; Name: "{app}\node_modules"
+Type: filesandordirs; Name: "{app}\migrations"
+Type: filesandordirs; Name: "{app}\packages"
 
 [Files]
 ; Main application files (from extracted native build zip).


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated native installers and in-zip updaters to ensure releases include and replace migrations and packages alongside the existing distribution contents.
  * Added stronger completeness checks so installs/updates fail early if any required release directories are missing, preventing partial deployments.
  * Improved upgrade cleanup on Windows and Linux by removing stale migration and package directories from prior installations before copying new files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->