### PR TITLE
fix(content-router): clear stale target-specific fields when a rule changes target type

### DIFF
--- a/src/routes/v1/content-router/content-router-management.ts
+++ b/src/routes/v1/content-router/content-router-management.ts
@@ -350,6 +350,7 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (fastify) => {
         body: ContentRouterRuleUpdateSchema,
         response: {
           200: ContentRouterRuleResponseSchema,
+          400: ContentRouterRuleErrorSchema,
           404: ContentRouterRuleErrorSchema,
           500: ContentRouterRuleErrorSchema,
         },
@@ -432,6 +433,19 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (fastify) => {
 
         if (updates.quality_profile !== undefined)
           updatesAsRouterRule.quality_profile = updates.quality_profile
+
+        // A target_type switch leaves the old type's stored fields behind; clear them
+        if (
+          updates.target_type !== undefined &&
+          updates.target_type !== existingRule.target_type
+        ) {
+          if (updates.target_type === 'radarr') {
+            updatesAsRouterRule.season_monitoring = null
+            updatesAsRouterRule.series_type = null
+          } else {
+            updatesAsRouterRule.monitor = null
+          }
+        }
 
         if (updates.condition) {
           updatesAsRouterRule.criteria = {

--- a/test/integration/routes/content-router.test.ts
+++ b/test/integration/routes/content-router.test.ts
@@ -262,6 +262,63 @@ describe('Content Router Rules API', () => {
       expect(row.monitor).toBeNull()
     })
 
+    it('preserves new radarr fields when switching from sonarr', async () => {
+      const createRes = await app.inject({
+        method: 'POST',
+        url: '/v1/content-router/rules',
+        payload: {
+          ...sonarrRule,
+          season_monitoring: 'all',
+          series_type: 'anime',
+        },
+      })
+      const id = createRes.json().rule.id
+
+      const putRes = await app.inject({
+        method: 'PUT',
+        url: `/v1/content-router/rules/${id}`,
+        payload: {
+          target_type: 'radarr',
+          target_instance_id: 1,
+          monitor: 'movieOnly',
+        },
+      })
+      expect(putRes.statusCode).toBe(200)
+
+      const knex = getTestDatabase()
+      const row = await knex('router_rules').where({ id }).first()
+      expect(row.season_monitoring).toBeNull()
+      expect(row.series_type).toBeNull()
+      expect(row.monitor).toBe('movieOnly')
+    })
+
+    it('preserves new sonarr fields when switching from radarr', async () => {
+      const createRes = await app.inject({
+        method: 'POST',
+        url: '/v1/content-router/rules',
+        payload: { ...radarrRule, monitor: 'movieOnly' },
+      })
+      const id = createRes.json().rule.id
+
+      const putRes = await app.inject({
+        method: 'PUT',
+        url: `/v1/content-router/rules/${id}`,
+        payload: {
+          target_type: 'sonarr',
+          target_instance_id: 1,
+          season_monitoring: 'all',
+          series_type: 'anime',
+        },
+      })
+      expect(putRes.statusCode).toBe(200)
+
+      const knex = getTestDatabase()
+      const row = await knex('router_rules').where({ id }).first()
+      expect(row.monitor).toBeNull()
+      expect(row.season_monitoring).toBe('all')
+      expect(row.series_type).toBe('anime')
+    })
+
     it('accepts sonarr fields on Sonarr rules', async () => {
       const res = await app.inject({
         method: 'POST',

--- a/test/integration/routes/content-router.test.ts
+++ b/test/integration/routes/content-router.test.ts
@@ -217,6 +217,51 @@ describe('Content Router Rules API', () => {
       expect(row.quality_profile).toBeNull()
     })
 
+    it('clears sonarr fields when a rule switches to radarr', async () => {
+      const createRes = await app.inject({
+        method: 'POST',
+        url: '/v1/content-router/rules',
+        payload: {
+          ...sonarrRule,
+          season_monitoring: 'all',
+          series_type: 'anime',
+        },
+      })
+      const id = createRes.json().rule.id
+
+      const putRes = await app.inject({
+        method: 'PUT',
+        url: `/v1/content-router/rules/${id}`,
+        payload: { target_type: 'radarr', target_instance_id: 1 },
+      })
+      expect(putRes.statusCode).toBe(200)
+
+      const knex = getTestDatabase()
+      const row = await knex('router_rules').where({ id }).first()
+      expect(row.season_monitoring).toBeNull()
+      expect(row.series_type).toBeNull()
+    })
+
+    it('clears monitor when a rule switches to sonarr', async () => {
+      const createRes = await app.inject({
+        method: 'POST',
+        url: '/v1/content-router/rules',
+        payload: { ...radarrRule, monitor: 'movieOnly' },
+      })
+      const id = createRes.json().rule.id
+
+      const putRes = await app.inject({
+        method: 'PUT',
+        url: `/v1/content-router/rules/${id}`,
+        payload: { target_type: 'sonarr', target_instance_id: 1 },
+      })
+      expect(putRes.statusCode).toBe(200)
+
+      const knex = getTestDatabase()
+      const row = await knex('router_rules').where({ id }).first()
+      expect(row.monitor).toBeNull()
+    })
+
     it('accepts sonarr fields on Sonarr rules', async () => {
       const res = await app.inject({
         method: 'POST',


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Content Router rule updates when changing between Sonarr and Radarr targets.
  * Target-specific settings are now cleared automatically when they no longer apply, preventing outdated configuration from being retained.
  * Added a documented 400 error response for invalid rule updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->