### PR TITLE
chore(renovate): block undici major updates while discord.js pins v6

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -275,6 +275,13 @@
       "allowedVersions": "< 3.0.0"
     },
     {
+      "description": "undici override must track discord.js's v6 pin - block majors until discord.js moves to undici 7+",
+      "matchPackageNames": [
+        "undici"
+      ],
+      "allowedVersions": "< 7.0.0"
+    },
+    {
       "description": "Ignore regular updates for docs dependencies but keep security alerts",
       "matchFileNames": [
         "docs/**"


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] My changes work with existing functionality


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management settings to keep `undici` below version 7.0.0 for compatibility with the current Discord integration.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->