### PR TITLE
fix(session-monitor): honor reset and propagate type changes in bulk …

### DIFF
--- a/src/client/features/utilities/components/session-monitoring/bulk-manage-dialog.tsx
+++ b/src/client/features/utilities/components/session-monitoring/bulk-manage-dialog.tsx
@@ -67,7 +67,13 @@ export function BulkManageDialog({
           if (data.enrolled > 0) parts.push(`${data.enrolled} enrolled`)
           if (data.modified > 0) parts.push(`${data.modified} modified`)
           if (data.skipped > 0) parts.push(`${data.skipped} skipped`)
-          toast.success(parts.join(', ') || data.message)
+          if (data.failed > 0) parts.push(`${data.failed} failed`)
+          const summary = parts.join(', ') || data.message
+          if (data.failed > 0) {
+            toast.warning(summary)
+          } else {
+            toast.success(summary)
+          }
           setMonitoringType('')
           setResetMonitoring(false)
           onSuccess()
@@ -149,7 +155,9 @@ export function BulkManageDialog({
               Resetting to baseline will immediately unmonitor excess episodes
               and delete their files based on the selected type. If unchecked,
               shows keep their current monitoring state but will still reset
-              automatically when they exceed the inactivity threshold.
+              automatically when they exceed the inactivity threshold. Selecting
+              All Season Pilot monitors the first episode of every season even
+              without a reset.
             </p>
           </div>
         </CredenzaBody>

--- a/src/routes/v1/session-monitoring/session-monitoring.ts
+++ b/src/routes/v1/session-monitoring/session-monitoring.ts
@@ -341,9 +341,7 @@ const sessionMonitoringRoutes: FastifyPluginAsyncZodOpenApi = async (
                 if (newShow) {
                   await resetShowMonitoring(newShow, fastify.plexSessionMonitor)
                 }
-              }
-
-              if (monitoringType === 'allSeasonPilotRolling') {
+              } else if (monitoringType === 'allSeasonPilotRolling') {
                 await fastify.plexSessionMonitor.monitorAllSeasonPilots(
                   show.sonarrSeriesId,
                   show.sonarrInstanceId,

--- a/src/routes/v1/session-monitoring/session-monitoring.ts
+++ b/src/routes/v1/session-monitoring/session-monitoring.ts
@@ -316,80 +316,102 @@ const sessionMonitoringRoutes: FastifyPluginAsyncZodOpenApi = async (
         let enrolled = 0
         let modified = 0
         let skipped = 0
+        let failed = 0
 
         for (const show of shows) {
-          if (show.rollingShowId === null) {
-            const tvdbGuid = show.guids.find((g) =>
-              g.toLowerCase().startsWith('tvdb:'),
-            )
-            const tvdbId = tvdbGuid ? tvdbGuid.replace(/^tvdb:/i, '') : ''
-
-            const newId =
-              await fastify.plexSessionMonitor.createRollingMonitoredShow(
-                show.sonarrSeriesId,
-                show.sonarrInstanceId,
-                tvdbId,
-                show.title,
-                monitoringType,
+          try {
+            if (show.rollingShowId === null) {
+              const tvdbGuid = show.guids.find((g) =>
+                g.toLowerCase().startsWith('tvdb:'),
               )
+              const tvdbId = tvdbGuid ? tvdbGuid.replace(/^tvdb:/i, '') : ''
 
-            if (resetMonitoring) {
-              const newShow =
-                await fastify.db.getRollingMonitoredShowById(newId)
-              if (newShow) {
-                await resetShowMonitoring(newShow, fastify.plexSessionMonitor)
+              const newId =
+                await fastify.plexSessionMonitor.createRollingMonitoredShow(
+                  show.sonarrSeriesId,
+                  show.sonarrInstanceId,
+                  tvdbId,
+                  show.title,
+                  monitoringType,
+                )
+
+              if (resetMonitoring) {
+                const newShow =
+                  await fastify.db.getRollingMonitoredShowById(newId)
+                if (newShow) {
+                  await resetShowMonitoring(newShow, fastify.plexSessionMonitor)
+                }
               }
-            }
 
-            if (monitoringType === 'allSeasonPilotRolling') {
-              await fastify.plexSessionMonitor.monitorAllSeasonPilots(
-                show.sonarrSeriesId,
-                show.sonarrInstanceId,
-              )
-            }
-
-            enrolled++
-          } else {
-            const existing = await fastify.db.getRollingMonitoredShowById(
-              show.rollingShowId,
-            )
-
-            if (!existing) {
-              skipped++
-              continue
-            }
-
-            if (existing.monitoring_type === monitoringType) {
-              skipped++
-              continue
-            }
-
-            const initialSeason =
-              monitoringType === 'allSeasonPilotRolling' ? 0 : 1
-
-            await fastify.db.updateRollingShowMonitoringType(
-              show.rollingShowId,
-              monitoringType,
-              initialSeason,
-            )
-
-            if (resetMonitoring) {
-              const updatedShow = await fastify.db.getRollingMonitoredShowById(
-                show.rollingShowId,
-              )
-              if (updatedShow) {
-                await resetShowMonitoring(
-                  updatedShow,
-                  fastify.plexSessionMonitor,
+              if (monitoringType === 'allSeasonPilotRolling') {
+                await fastify.plexSessionMonitor.monitorAllSeasonPilots(
+                  show.sonarrSeriesId,
+                  show.sonarrInstanceId,
                 )
               }
 
-              await fastify.db.resetRollingMonitoredShowToOriginal(
+              enrolled++
+            } else {
+              const existing = await fastify.db.getRollingMonitoredShowById(
                 show.rollingShowId,
               )
-            }
 
-            modified++
+              if (!existing) {
+                skipped++
+                continue
+              }
+
+              const typeChanged = existing.monitoring_type !== monitoringType
+
+              if (!typeChanged && !resetMonitoring) {
+                skipped++
+                continue
+              }
+
+              if (typeChanged) {
+                const initialSeason =
+                  monitoringType === 'allSeasonPilotRolling' ? 0 : 1
+
+                await fastify.db.updateRollingShowMonitoringType(
+                  show.rollingShowId,
+                  monitoringType,
+                  initialSeason,
+                )
+              }
+
+              if (resetMonitoring) {
+                const target = typeChanged
+                  ? await fastify.db.getRollingMonitoredShowById(
+                      show.rollingShowId,
+                    )
+                  : existing
+                if (target) {
+                  await resetShowMonitoring(target, fastify.plexSessionMonitor)
+                }
+
+                await fastify.db.resetRollingMonitoredShowToOriginal(
+                  show.rollingShowId,
+                )
+              } else if (
+                typeChanged &&
+                monitoringType === 'allSeasonPilotRolling'
+              ) {
+                // Without a reset nothing else seeds season pilots, and this
+                // mode only expands via a pilot watch
+                await fastify.plexSessionMonitor.monitorAllSeasonPilots(
+                  show.sonarrSeriesId,
+                  show.sonarrInstanceId,
+                )
+              }
+
+              modified++
+            }
+          } catch (error) {
+            failed++
+            request.log.error(
+              { error, title: show.title, rollingShowId: show.rollingShowId },
+              'Failed to bulk manage rolling monitored show',
+            )
           }
         }
 
@@ -397,13 +419,15 @@ const sessionMonitoringRoutes: FastifyPluginAsyncZodOpenApi = async (
         if (enrolled > 0) parts.push(`${enrolled} enrolled`)
         if (modified > 0) parts.push(`${modified} modified`)
         if (skipped > 0) parts.push(`${skipped} skipped`)
+        if (failed > 0) parts.push(`${failed} failed`)
 
         return reply.send({
-          success: true,
+          success: failed === 0,
           message: `Bulk manage complete: ${parts.join(', ')}`,
           enrolled,
           modified,
           skipped,
+          failed,
         })
       } catch (error) {
         logRouteError(request.log, request, error, {

--- a/src/schemas/session-monitoring/session-monitoring.schema.ts
+++ b/src/schemas/session-monitoring/session-monitoring.schema.ts
@@ -217,6 +217,7 @@ export const bulkManageRollingMonitoredSchema = {
       enrolled: z.number(),
       modified: z.number(),
       skipped: z.number(),
+      failed: z.number(),
     }),
     400: ErrorSchema,
   },

--- a/src/services/database/methods/session.ts
+++ b/src/services/database/methods/session.ts
@@ -412,7 +412,7 @@ export async function resetRollingMonitoredShowToOriginal(
         .whereNotNull('plex_user_id') // Only delete user entries, not master
         .delete()
 
-      // Reset the master record to original state (if it exists)
+      // allSeasonPilotRolling tracks full-season expansion from 0, not 1
       await trx('rolling_monitored_shows')
         .where({
           sonarr_series_id: show.sonarr_series_id,
@@ -420,7 +420,8 @@ export async function resetRollingMonitoredShowToOriginal(
         })
         .whereNull('plex_user_id') // Only update master record
         .update({
-          current_monitored_season: 1,
+          current_monitored_season:
+            show.monitoring_type === 'allSeasonPilotRolling' ? 0 : 1,
           last_watched_season: 0,
           last_watched_episode: 0,
           updated_at: this.timestamp,
@@ -547,12 +548,13 @@ export async function getInactiveRollingMonitoredShows(
  * Updates the monitoring type and initial season for a rolling monitored show.
  *
  * Used when changing an enrolled show's monitoring approach (e.g. pilotRolling
- * to firstSeasonRolling). Only updates the master record.
+ * to firstSeasonRolling). The type change propagates to per-user entries; the
+ * initial season is only written to the master record.
  *
  * @param id - The ID of the master rolling monitored show entry
  * @param monitoringType - The new monitoring type
  * @param currentMonitoredSeason - The initial season for the new type
- * @returns True if a row was updated
+ * @returns True if the master entry was found and updated
  */
 export async function updateRollingShowMonitoringType(
   this: DatabaseService,
@@ -564,17 +566,35 @@ export async function updateRollingShowMonitoringType(
   currentMonitoredSeason: number,
 ): Promise<boolean> {
   try {
-    const updated = await this.knex('rolling_monitored_shows')
-      .where({ id })
-      .whereNull('plex_user_id')
-      .update({
-        monitoring_type: monitoringType,
-        current_monitored_season: currentMonitoredSeason,
-        updated_at: this.timestamp,
-        last_updated_at: this.timestamp,
-      })
+    return await this.knex.transaction(async (trx) => {
+      const master = await trx('rolling_monitored_shows')
+        .where({ id })
+        .whereNull('plex_user_id')
+        .first()
 
-    return Number(updated) > 0
+      if (!master) {
+        return false
+      }
+
+      // The session monitor reads monitoring_type from per-user rows, so the
+      // type change must reach them too. Per-user season progress is left alone.
+      await trx('rolling_monitored_shows')
+        .where({
+          sonarr_series_id: master.sonarr_series_id,
+          sonarr_instance_id: master.sonarr_instance_id,
+        })
+        .update({
+          monitoring_type: monitoringType,
+          updated_at: this.timestamp,
+          last_updated_at: this.timestamp,
+        })
+
+      await trx('rolling_monitored_shows')
+        .where({ id })
+        .update({ current_monitored_season: currentMonitoredSeason })
+
+      return true
+    })
   } catch (error) {
     this.log.error(
       { error, id, monitoringType },

--- a/src/services/database/methods/session.ts
+++ b/src/services/database/methods/session.ts
@@ -384,7 +384,7 @@ export async function deleteAllRollingMonitoredShowEntries(
 /**
  * Reset a show's rolling monitored data to its original (master) state.
  *
- * Deletes all per-user entries for the show identified by `id`'s series/instance and updates the master record (plex_user_id IS NULL) to season 1 with cleared progress and refreshed timestamps. The provided `id` may be any entry (master or user) for the target show.
+ * Deletes all per-user entries for the show identified by `id`'s series/instance and updates the master record (plex_user_id IS NULL) to its type's baseline season (0 for allSeasonPilotRolling, 1 otherwise) with cleared progress and refreshed timestamps. The provided `id` may be any entry (master or user) for the target show.
  *
  * @param id - ID of any rolling monitored show entry for the target show
  * @returns The number of user-specific entries deleted. Returns 0 if the show was not found or an error occurred.
@@ -567,10 +567,11 @@ export async function updateRollingShowMonitoringType(
 ): Promise<boolean> {
   try {
     return await this.knex.transaction(async (trx) => {
-      const master = await trx('rolling_monitored_shows')
+      const masterQuery = trx('rolling_monitored_shows')
         .where({ id })
         .whereNull('plex_user_id')
-        .first()
+      if (this.isPostgres) masterQuery.forUpdate() // row-level lock only on PG
+      const master = await masterQuery.first()
 
       if (!master) {
         return false

--- a/src/services/database/types/session-methods.ts
+++ b/src/services/database/types/session-methods.ts
@@ -137,11 +137,11 @@ declare module '@services/database.service.js' {
     ): Promise<RollingMonitoredShow[]>
 
     /**
-     * Updates the monitoring type and initial season for a master rolling monitored show.
+     * Updates the monitoring type for a rolling monitored show, propagating to per-user entries.
      * @param id - The ID of the master entry
      * @param monitoringType - The new monitoring type
-     * @param currentMonitoredSeason - The initial season for the new type
-     * @returns True if a row was updated
+     * @param currentMonitoredSeason - The initial season for the new type (master only)
+     * @returns True if the master entry was found and updated
      */
     updateRollingShowMonitoringType(
       id: number,

--- a/src/services/database/types/session-methods.ts
+++ b/src/services/database/types/session-methods.ts
@@ -108,7 +108,8 @@ declare module '@services/database.service.js' {
     /**
      * Resets a rolling monitored show to its original state:
      * - Removes all user entries
-     * - Resets master record to season 1
+     * - Resets master record to its type's baseline season (0 for
+     *   allSeasonPilotRolling, 1 otherwise)
      * @param id - The ID of any rolling monitored show entry for the show
      * @returns Promise resolving to number of user entries deleted
      */

--- a/src/services/plex-session-monitor.service.ts
+++ b/src/services/plex-session-monitor.service.ts
@@ -944,7 +944,7 @@ export class PlexSessionMonitorService {
 
   /**
    * Reset inactive rolling monitored shows to their original monitoring state
-   * Removes all user entries and resets master records to season 1
+   * Removes all user entries and resets master records to their type's baseline season
    * Should be called periodically to clean up shows that haven't been watched recently
    */
   async resetInactiveRollingShows(inactivityDays = 7): Promise<void> {

--- a/test/helpers/rolling-shows.ts
+++ b/test/helpers/rolling-shows.ts
@@ -1,0 +1,28 @@
+import type { RollingMonitoredShow } from '@root/types/plex-session.types.js'
+import type { Knex } from 'knex'
+
+export async function insertRollingShow(
+  knex: Knex,
+  overrides: Partial<RollingMonitoredShow> & {
+    show_title: string
+    monitoring_type: RollingMonitoredShow['monitoring_type']
+    sonarr_series_id: number
+    sonarr_instance_id: number
+    tvdb_id: string
+  },
+): Promise<number> {
+  const now = new Date().toISOString()
+  const [result] = await knex('rolling_monitored_shows')
+    .insert({
+      current_monitored_season: 1,
+      last_watched_season: 0,
+      last_watched_episode: 0,
+      last_session_date: now,
+      created_at: now,
+      updated_at: now,
+      last_updated_at: now,
+      ...overrides,
+    })
+    .returning('id')
+  return typeof result === 'object' ? result.id : (result as number)
+}

--- a/test/integration/plugins/secret-persistence.test.ts
+++ b/test/integration/plugins/secret-persistence.test.ts
@@ -11,8 +11,10 @@ import { seedConfig } from '../../helpers/seeds/config.js'
 const STORED_COOKIE_SECRET = 'stored-cookie-secret-0123456789abcdef'
 const STORED_WEBHOOK_SECRET = 'stored-webhook-secret'
 
-// Each test seeds its own configs row and boots the app to simulate a restart
-describe('secret persistence across restarts', () => {
+// Each test seeds its own configs row and boots the app to simulate a restart.
+// Booting the full app takes 7-10s on loaded CI runners, so the global 10s
+// timeout has no headroom.
+describe('secret persistence across restarts', { timeout: 30_000 }, () => {
   let app: FastifyInstance | undefined
 
   beforeAll(async () => {

--- a/test/integration/routes/session-monitoring.test.ts
+++ b/test/integration/routes/session-monitoring.test.ts
@@ -30,6 +30,7 @@ describe('Session Monitoring Routes - bulk manage', () => {
     vi.clearAllMocks()
     await resetDatabase()
     await seedAll(getTestDatabase())
+    app.config.authenticationMethod = 'disabled'
 
     app.plexSessionMonitor.resetToPilotOnly = vi
       .fn()

--- a/test/integration/routes/session-monitoring.test.ts
+++ b/test/integration/routes/session-monitoring.test.ts
@@ -71,7 +71,7 @@ describe('Session Monitoring Routes - bulk manage', () => {
     return { masterId, userId }
   }
 
-  function showEntry(rollingShowId: number, seriesId = 100) {
+  function showEntry(rollingShowId: number | null, seriesId = 100) {
     return {
       sonarrSeriesId: seriesId,
       sonarrInstanceId: 1,
@@ -268,6 +268,23 @@ describe('Session Monitoring Routes - bulk manage', () => {
       .where({ id: userId })
       .first()
     expect(userEntry).toBeUndefined()
+  })
+
+  it('does not double-seed pilots when enrolling into allSeasonPilotRolling with a reset', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/session-monitoring/rolling-monitored/bulk',
+      payload: bulkBody([showEntry(null, 300)], 'allSeasonPilotRolling', true),
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toMatchObject({ enrolled: 1, failed: 0 })
+    expect(app.plexSessionMonitor.resetToAllSeasonPilots).toHaveBeenCalledWith(
+      300,
+      1,
+      'Test Show 300',
+    )
+    expect(app.plexSessionMonitor.monitorAllSeasonPilots).not.toHaveBeenCalled()
   })
 
   it('continues past a failing show and reports it as failed', async () => {

--- a/test/integration/routes/session-monitoring.test.ts
+++ b/test/integration/routes/session-monitoring.test.ts
@@ -1,0 +1,310 @@
+import type { RollingMonitoredShow } from '@root/types/plex-session.types.js'
+import type { FastifyInstance } from 'fastify'
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+import { build } from '../../helpers/app.js'
+import { getTestDatabase, resetDatabase } from '../../helpers/database.js'
+import { insertRollingShow } from '../../helpers/rolling-shows.js'
+import { seedAll } from '../../helpers/seeds/index.js'
+
+describe('Session Monitoring Routes - bulk manage', () => {
+  let app: FastifyInstance
+
+  beforeAll(async () => {
+    app = await build()
+    await app.ready()
+  })
+
+  afterAll(async () => {
+    await app.close()
+  })
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    await resetDatabase()
+    await seedAll(getTestDatabase())
+
+    app.plexSessionMonitor.resetToPilotOnly = vi
+      .fn()
+      .mockResolvedValue(undefined)
+    app.plexSessionMonitor.resetToFirstSeasonOnly = vi
+      .fn()
+      .mockResolvedValue(undefined)
+    app.plexSessionMonitor.resetToAllSeasonPilots = vi
+      .fn()
+      .mockResolvedValue(undefined)
+    app.plexSessionMonitor.monitorAllSeasonPilots = vi
+      .fn()
+      .mockResolvedValue(undefined)
+  })
+
+  async function seedEnrolledShow(
+    monitoringType: RollingMonitoredShow['monitoring_type'] = 'pilotRolling',
+    seriesId = 100,
+  ) {
+    const knex = getTestDatabase()
+    const masterId = await insertRollingShow(knex, {
+      show_title: `Test Show ${seriesId}`,
+      monitoring_type: monitoringType,
+      sonarr_series_id: seriesId,
+      sonarr_instance_id: 1,
+      tvdb_id: `${seriesId}456`,
+      current_monitored_season:
+        monitoringType === 'allSeasonPilotRolling' ? 0 : 1,
+    })
+    const userId = await insertRollingShow(knex, {
+      show_title: `Test Show ${seriesId}`,
+      monitoring_type: monitoringType,
+      sonarr_series_id: seriesId,
+      sonarr_instance_id: 1,
+      tvdb_id: `${seriesId}456`,
+      plex_user_id: 'user-1',
+      plex_username: 'Alice',
+    })
+    return { masterId, userId }
+  }
+
+  function showEntry(rollingShowId: number, seriesId = 100) {
+    return {
+      sonarrSeriesId: seriesId,
+      sonarrInstanceId: 1,
+      title: `Test Show ${seriesId}`,
+      guids: [`tvdb:${seriesId}456`],
+      rollingShowId,
+    }
+  }
+
+  function bulkBody(
+    shows: ReturnType<typeof showEntry>[],
+    monitoringType: string,
+    resetMonitoring: boolean,
+  ) {
+    return { shows, monitoringType, resetMonitoring }
+  }
+
+  it('skips same-type shows when reset is not requested', async () => {
+    const { masterId, userId } = await seedEnrolledShow()
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/session-monitoring/rolling-monitored/bulk',
+      payload: bulkBody([showEntry(masterId)], 'pilotRolling', false),
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toMatchObject({
+      enrolled: 0,
+      modified: 0,
+      skipped: 1,
+      failed: 0,
+    })
+    expect(app.plexSessionMonitor.resetToPilotOnly).not.toHaveBeenCalled()
+
+    const knex = getTestDatabase()
+    const userEntry = await knex('rolling_monitored_shows')
+      .where({ id: userId })
+      .first()
+    expect(userEntry).toBeDefined()
+  })
+
+  it('resets same-type shows when reset is requested', async () => {
+    const { masterId, userId } = await seedEnrolledShow()
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/session-monitoring/rolling-monitored/bulk',
+      payload: bulkBody([showEntry(masterId)], 'pilotRolling', true),
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toMatchObject({
+      enrolled: 0,
+      modified: 1,
+      skipped: 0,
+      failed: 0,
+    })
+    expect(app.plexSessionMonitor.resetToPilotOnly).toHaveBeenCalledWith(
+      100,
+      1,
+      'Test Show 100',
+    )
+
+    const knex = getTestDatabase()
+    const userEntry = await knex('rolling_monitored_shows')
+      .where({ id: userId })
+      .first()
+    expect(userEntry).toBeUndefined()
+
+    const master = await knex('rolling_monitored_shows')
+      .where({ id: masterId })
+      .first()
+    expect(master.monitoring_type).toBe('pilotRolling')
+    expect(master.current_monitored_season).toBe(1)
+  })
+
+  it('keeps the season-0 baseline when resetting a same-type allSeasonPilotRolling show', async () => {
+    const { masterId } = await seedEnrolledShow('allSeasonPilotRolling')
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/session-monitoring/rolling-monitored/bulk',
+      payload: bulkBody([showEntry(masterId)], 'allSeasonPilotRolling', true),
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toMatchObject({ modified: 1, failed: 0 })
+    expect(app.plexSessionMonitor.resetToAllSeasonPilots).toHaveBeenCalledWith(
+      100,
+      1,
+      'Test Show 100',
+    )
+
+    const knex = getTestDatabase()
+    const master = await knex('rolling_monitored_shows')
+      .where({ id: masterId })
+      .first()
+    expect(master.current_monitored_season).toBe(0)
+  })
+
+  it('changes type without touching Sonarr when reset is not requested', async () => {
+    const { masterId, userId } = await seedEnrolledShow()
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/session-monitoring/rolling-monitored/bulk',
+      payload: bulkBody([showEntry(masterId)], 'firstSeasonRolling', false),
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toMatchObject({
+      enrolled: 0,
+      modified: 1,
+      skipped: 0,
+      failed: 0,
+    })
+    expect(app.plexSessionMonitor.resetToPilotOnly).not.toHaveBeenCalled()
+    expect(app.plexSessionMonitor.resetToFirstSeasonOnly).not.toHaveBeenCalled()
+
+    const knex = getTestDatabase()
+    const master = await knex('rolling_monitored_shows')
+      .where({ id: masterId })
+      .first()
+    expect(master.monitoring_type).toBe('firstSeasonRolling')
+
+    const userEntry = await knex('rolling_monitored_shows')
+      .where({ id: userId })
+      .first()
+    expect(userEntry).toBeDefined()
+    expect(userEntry.monitoring_type).toBe('firstSeasonRolling')
+  })
+
+  it('seeds season pilots when converting to allSeasonPilotRolling without a reset', async () => {
+    const { masterId, userId } = await seedEnrolledShow()
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/session-monitoring/rolling-monitored/bulk',
+      payload: bulkBody([showEntry(masterId)], 'allSeasonPilotRolling', false),
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toMatchObject({ modified: 1, failed: 0 })
+    expect(app.plexSessionMonitor.monitorAllSeasonPilots).toHaveBeenCalledWith(
+      100,
+      1,
+    )
+    expect(app.plexSessionMonitor.resetToAllSeasonPilots).not.toHaveBeenCalled()
+
+    const knex = getTestDatabase()
+    const master = await knex('rolling_monitored_shows')
+      .where({ id: masterId })
+      .first()
+    expect(master.monitoring_type).toBe('allSeasonPilotRolling')
+    expect(master.current_monitored_season).toBe(0)
+
+    const userEntry = await knex('rolling_monitored_shows')
+      .where({ id: userId })
+      .first()
+    expect(userEntry.monitoring_type).toBe('allSeasonPilotRolling')
+  })
+
+  it('changes type and resets to the new baseline when reset is requested', async () => {
+    const { masterId, userId } = await seedEnrolledShow()
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/session-monitoring/rolling-monitored/bulk',
+      payload: bulkBody([showEntry(masterId)], 'firstSeasonRolling', true),
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toMatchObject({
+      enrolled: 0,
+      modified: 1,
+      skipped: 0,
+      failed: 0,
+    })
+    expect(app.plexSessionMonitor.resetToFirstSeasonOnly).toHaveBeenCalledWith(
+      100,
+      1,
+      'Test Show 100',
+    )
+    expect(app.plexSessionMonitor.resetToPilotOnly).not.toHaveBeenCalled()
+
+    const knex = getTestDatabase()
+    const master = await knex('rolling_monitored_shows')
+      .where({ id: masterId })
+      .first()
+    expect(master.monitoring_type).toBe('firstSeasonRolling')
+
+    const userEntry = await knex('rolling_monitored_shows')
+      .where({ id: userId })
+      .first()
+    expect(userEntry).toBeUndefined()
+  })
+
+  it('continues past a failing show and reports it as failed', async () => {
+    const showA = await seedEnrolledShow('pilotRolling', 100)
+    const showB = await seedEnrolledShow('pilotRolling', 200)
+
+    app.plexSessionMonitor.resetToPilotOnly = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Sonarr instance 1 not found'))
+      .mockResolvedValueOnce(undefined)
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/v1/session-monitoring/rolling-monitored/bulk',
+      payload: bulkBody(
+        [showEntry(showA.masterId, 100), showEntry(showB.masterId, 200)],
+        'pilotRolling',
+        true,
+      ),
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toMatchObject({
+      success: false,
+      modified: 1,
+      failed: 1,
+    })
+
+    const knex = getTestDatabase()
+    const userA = await knex('rolling_monitored_shows')
+      .where({ id: showA.userId })
+      .first()
+    expect(userA).toBeDefined()
+
+    const userB = await knex('rolling_monitored_shows')
+      .where({ id: showB.userId })
+      .first()
+    expect(userB).toBeUndefined()
+  })
+})

--- a/test/integration/services/plex-session-monitor/progressive-cleanup-workflow.test.ts
+++ b/test/integration/services/plex-session-monitor/progressive-cleanup-workflow.test.ts
@@ -7,10 +7,7 @@
  * which files get deleted) for each monitoring type.
  */
 
-import type {
-  PlexSession,
-  RollingMonitoredShow,
-} from '@root/types/plex-session.types.js'
+import type { PlexSession } from '@root/types/plex-session.types.js'
 import type { SonarrEpisode, SonarrSeries } from '@root/types/sonarr.types.js'
 import type { FastifyInstance } from 'fastify'
 import {
@@ -24,33 +21,8 @@ import {
 } from 'vitest'
 import { build } from '../../../helpers/app.js'
 import { getTestDatabase, resetDatabase } from '../../../helpers/database.js'
+import { insertRollingShow } from '../../../helpers/rolling-shows.js'
 import { seedAll } from '../../../helpers/seeds/index.js'
-
-async function insertRollingShow(
-  knex: ReturnType<typeof getTestDatabase>,
-  overrides: Partial<RollingMonitoredShow> & {
-    show_title: string
-    monitoring_type: RollingMonitoredShow['monitoring_type']
-    sonarr_series_id: number
-    sonarr_instance_id: number
-    tvdb_id: string
-  },
-): Promise<number> {
-  const now = new Date().toISOString()
-  const [result] = await knex('rolling_monitored_shows')
-    .insert({
-      current_monitored_season: 1,
-      last_watched_season: 0,
-      last_watched_episode: 0,
-      last_session_date: now,
-      created_at: now,
-      updated_at: now,
-      last_updated_at: now,
-      ...overrides,
-    })
-    .returning('id')
-  return typeof result === 'object' ? result.id : (result as number)
-}
 
 describe('Progressive Cleanup → Multi-User Safety Integration', () => {
   let app: FastifyInstance


### PR DESCRIPTION
…rolling manage

## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Bulk session-monitoring now reports a **failed** count in results, and the UI displays **warning toasts** when any items fail.
  - Selecting **All Season Pilot** without requesting a reset now continues to monitor the first episode of every season, with clearer inline guidance.

- **Bug Fixes**
  - Bulk processing no longer aborts on individual failures; requests return HTTP **200** with `success: false` when any fail.
  - Monitoring type switching and baseline resets now preserve the correct **All Season Pilot** behavior, including avoiding double-seeding when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->