### PR TITLE
fix(installers): verify winsw checksum, guard locked files, and stage…

### DIFF
--- a/scripts/build-native.ts
+++ b/scripts/build-native.ts
@@ -296,7 +296,6 @@ main() {
 
   cd "$(dirname "\${BASH_SOURCE[0]}")"
   INSTALL_DIR="$(pwd)"
-  STAGE="$INSTALL_DIR/.update-staging"
 
   if ! command -v unzip >/dev/null 2>&1; then
     echo "unzip is required but was not found."
@@ -304,7 +303,7 @@ main() {
   fi
 
   TMP="$(mktemp -d)"
-  trap 'rm -rf "$TMP" "$STAGE"' EXIT
+  trap 'rm -rf "$TMP"' EXIT
 
   echo "Extracting update..."
   unzip -q "$ZIP" -d "$TMP"
@@ -328,8 +327,11 @@ main() {
   echo "Replacing application files..."
   # Stage inside the install dir (same filesystem, so mv is a rename) and only
   # then delete Pulsarr-owned code dirs; config and data are left in place.
-  rm -rf "$STAGE"
-  mkdir -p "$STAGE"
+  # Unique staging dir keeps concurrent runs from clobbering each other; only
+  # sweep leftovers old enough to be from a dead run.
+  find "$INSTALL_DIR" -maxdepth 1 -name '.update-staging.*' -mmin +60 -exec rm -rf {} + 2>/dev/null || true
+  STAGE="$(mktemp -d "$INSTALL_DIR/.update-staging.XXXXXX")"
+  trap 'rm -rf "$TMP" "$STAGE"' EXIT
   if ! cp -a "$NEW/." "$STAGE/"; then
     echo "Copy failed. No changes were made to the installation."
     exit 1

--- a/scripts/build-native.ts
+++ b/scripts/build-native.ts
@@ -327,10 +327,8 @@ main() {
   echo "Replacing application files..."
   # Stage inside the install dir (same filesystem, so mv is a rename) and only
   # then delete Pulsarr-owned code dirs; config and data are left in place.
-  # Unique staging dir keeps concurrent runs from clobbering each other; only
-  # sweep leftovers old enough to be from a dead run.
   find "$INSTALL_DIR" -maxdepth 1 -name '.update-staging.*' -mmin +60 -exec rm -rf {} + 2>/dev/null || true
-  STAGE="$(mktemp -d "$INSTALL_DIR/.update-staging.XXXXXX")"
+  STAGE="$(mktemp -d "$INSTALL_DIR/.update-staging.XXXXXX")" || { echo "Failed to create staging directory."; exit 1; }
   trap 'rm -rf "$TMP" "$STAGE"' EXIT
   if ! cp -a "$NEW/." "$STAGE/"; then
     echo "Copy failed. No changes were made to the installation."

--- a/scripts/build-native.ts
+++ b/scripts/build-native.ts
@@ -39,6 +39,9 @@ if (!BUN_VERSION) {
 }
 const WINSW_VERSION = '2.12.0'
 const WINSW_URL = `https://github.com/winsw/winsw/releases/download/v${WINSW_VERSION}/WinSW-x64.exe`
+// WinSW publishes no checksum file, so pin the known-good hash per version
+const WINSW_SHA256 =
+  '05b82d46ad331cc16bdc00de5c6332c1ef818df8ceefcd49c726553209b3a0da'
 const VERSION = packageJson.version
 
 interface Platform {
@@ -293,6 +296,7 @@ main() {
 
   cd "$(dirname "\${BASH_SOURCE[0]}")"
   INSTALL_DIR="$(pwd)"
+  STAGE="$INSTALL_DIR/.update-staging"
 
   if ! command -v unzip >/dev/null 2>&1; then
     echo "unzip is required but was not found."
@@ -300,7 +304,7 @@ main() {
   fi
 
   TMP="$(mktemp -d)"
-  trap 'rm -rf "$TMP"' EXIT
+  trap 'rm -rf "$TMP" "$STAGE"' EXIT
 
   echo "Extracting update..."
   unzip -q "$ZIP" -d "$TMP"
@@ -322,11 +326,20 @@ main() {
   done
 
   echo "Replacing application files..."
-  # Only Pulsarr-owned code dirs are deleted; config and data are left in place.
+  # Stage inside the install dir (same filesystem, so mv is a rename) and only
+  # then delete Pulsarr-owned code dirs; config and data are left in place.
+  rm -rf "$STAGE"
+  mkdir -p "$STAGE"
+  if ! cp -a "$NEW/." "$STAGE/"; then
+    echo "Copy failed. No changes were made to the installation."
+    exit 1
+  fi
   for d in $OWNED; do
     rm -rf "$INSTALL_DIR/$d"
+    mv "$STAGE/$d" "$INSTALL_DIR/$d"
   done
-  cp -a "$NEW/." "$INSTALL_DIR/"
+  cp -a "$STAGE/." "$INSTALL_DIR/"
+  rm -rf "$STAGE"
   chmod +x "$INSTALL_DIR/start.sh" "$INSTALL_DIR/bun" 2>/dev/null || true
 
   echo "Update complete. Start Pulsarr with ./start.sh (or restart your service)."
@@ -485,6 +498,7 @@ const UNINSTALL_SERVICE_BAT = `@echo off
 cd /d "%~dp0"
 echo Stopping Pulsarr service...
 pulsarr-service.exe stop
+timeout /t 2 /nobreak >nul
 echo Uninstalling Pulsarr service...
 pulsarr-service.exe uninstall
 echo.
@@ -776,6 +790,16 @@ for (const platform of PLATFORMS) {
     const winswTmp = resolve(BUILD_DIR, '_winsw.exe')
     if (!existsSync(winswTmp)) {
       runFile('curl', ['-fsSL', WINSW_URL, '-o', winswTmp])
+      const winswHasher = new Bun.CryptoHasher('sha256')
+      winswHasher.update(readFileSync(winswTmp))
+      const winswHash = winswHasher.digest('hex')
+      if (winswHash !== WINSW_SHA256) {
+        rmSync(winswTmp, { force: true })
+        throw new Error(
+          `Checksum mismatch for WinSW-x64.exe: expected ${WINSW_SHA256}, got ${winswHash}`,
+        )
+      }
+      console.log('      Checksum verified for WinSW-x64.exe')
     }
     cpSync(winswTmp, resolve(platformDir, 'pulsarr-service.exe'))
     writeFileSync(resolve(platformDir, 'pulsarr-service.xml'), WINSW_XML)

--- a/scripts/installers/linux/install.sh
+++ b/scripts/installers/linux/install.sh
@@ -147,10 +147,9 @@ install_files() {
 
     mkdir -p "$INSTALL_DIR"
 
-    # Unique staging dir keeps concurrent runs from clobbering each other; only
-    # sweep leftovers old enough to be from a dead run.
     find "$(dirname "$INSTALL_DIR")" -maxdepth 1 -name "$(basename "$INSTALL_DIR").staging.*" -mmin +60 -exec rm -rf {} + 2>/dev/null || true
-    staging="$(mktemp -d "${INSTALL_DIR}.staging.XXXXXX")"
+    staging="$(mktemp -d "${INSTALL_DIR}.staging.XXXXXX")" || die "Failed to create staging directory"
+    [[ -d "$staging" ]] || die "Staging directory was not created"
     info "Installing files to ${INSTALL_DIR}..."
     if ! cp -a "${src_dir}/." "${staging}/"; then
         rm -rf "${staging:?}"
@@ -258,8 +257,7 @@ uninstall() {
         systemctl daemon-reload
     fi
 
-    # Remove user. userdel also removes the group it created; a pre-existing
-    # admin-managed group must be left alone.
+    # Remove user
     if id "$APP_USER" &>/dev/null; then
         info "Removing user '$APP_USER'..."
         userdel "$APP_USER" 2>/dev/null || true
@@ -347,8 +345,7 @@ install() {
     version=$(get_latest_version)
     info "Latest version: $version"
 
-    # Download and extract before stopping, so a failed download leaves the
-    # running install untouched
+    # Download and extract
     extracted_dir=$(download_release "$version" "$arch")
 
     # Create user

--- a/scripts/installers/linux/install.sh
+++ b/scripts/installers/linux/install.sh
@@ -257,10 +257,13 @@ uninstall() {
         systemctl daemon-reload
     fi
 
-    # Remove user
+    # Remove user and group
     if id "$APP_USER" &>/dev/null; then
         info "Removing user '$APP_USER'..."
         userdel "$APP_USER" 2>/dev/null || true
+    fi
+    if getent group "$APP_GROUP" &>/dev/null; then
+        groupdel "$APP_GROUP" 2>/dev/null || true
     fi
 
     # Handle data directory
@@ -345,14 +348,15 @@ install() {
     version=$(get_latest_version)
     info "Latest version: $version"
 
-    # Stop existing service if running
-    stop_service
-
-    # Download and extract
+    # Download and extract before stopping, so a failed download leaves the
+    # running install untouched
     extracted_dir=$(download_release "$version" "$arch")
 
     # Create user
     create_user
+
+    # Stop existing service if running
+    stop_service
 
     # Install files
     install_files "$extracted_dir"

--- a/scripts/installers/linux/install.sh
+++ b/scripts/installers/linux/install.sh
@@ -143,13 +143,14 @@ create_user() {
 install_files() {
     local src_dir="$1"
     local owned="dist node_modules migrations packages"
-    local staging="${INSTALL_DIR}.staging"
-    local d
+    local staging d
 
     mkdir -p "$INSTALL_DIR"
 
-    rm -rf "${staging:?}"
-    mkdir -p "$staging"
+    # Unique staging dir keeps concurrent runs from clobbering each other; only
+    # sweep leftovers old enough to be from a dead run.
+    find "$(dirname "$INSTALL_DIR")" -maxdepth 1 -name "$(basename "$INSTALL_DIR").staging.*" -mmin +60 -exec rm -rf {} + 2>/dev/null || true
+    staging="$(mktemp -d "${INSTALL_DIR}.staging.XXXXXX")"
     info "Installing files to ${INSTALL_DIR}..."
     if ! cp -a "${src_dir}/." "${staging}/"; then
         rm -rf "${staging:?}"
@@ -257,13 +258,11 @@ uninstall() {
         systemctl daemon-reload
     fi
 
-    # Remove user and group
+    # Remove user. userdel also removes the group it created; a pre-existing
+    # admin-managed group must be left alone.
     if id "$APP_USER" &>/dev/null; then
         info "Removing user '$APP_USER'..."
         userdel "$APP_USER" 2>/dev/null || true
-    fi
-    if getent group "$APP_GROUP" &>/dev/null; then
-        groupdel "$APP_GROUP" 2>/dev/null || true
     fi
 
     # Handle data directory

--- a/scripts/installers/windows/pulsarr-baseline.iss
+++ b/scripts/installers/windows/pulsarr-baseline.iss
@@ -63,6 +63,8 @@ Type: filesandordirs; Name: "{app}\migrations"
 Type: filesandordirs; Name: "{app}\packages"
 ; Shipped by older installers; now excluded from [Files]
 Type: files; Name: "{app}\README.txt"
+; Leftover lock probe from an interrupted run
+Type: files; Name: "{app}\bun.exe.locktest"
 
 [Files]
 ; Main application files (from extracted native build zip).
@@ -115,7 +117,7 @@ function PrepareToInstall(var NeedsRestart: Boolean): String;
 var
   ResultCode: Integer;
   BunPath, ProbePath: String;
-  I: Integer;
+  I, J: Integer;
 begin
   Result := '';
   if FileExists(ExpandConstant('{app}\pulsarr-service.exe')) then
@@ -131,11 +133,20 @@ begin
   if FileExists(BunPath) then
   begin
     ProbePath := BunPath + '.locktest';
+    { A stale probe file from an interrupted run blocks the rename below }
+    DeleteFile(ProbePath);
     for I := 1 to 5 do
     begin
       if RenameFile(BunPath, ProbePath) then
       begin
-        RenameFile(ProbePath, BunPath);
+        { Retry the restore; AV scanners can briefly lock a renamed file }
+        for J := 1 to 5 do
+        begin
+          if RenameFile(ProbePath, BunPath) then
+            Exit;
+          Sleep(1000);
+        end;
+        Result := 'Setup could not restore bun.exe. Rename ' + ProbePath + ' back to bun.exe, then run Setup again.';
         Exit;
       end;
       Sleep(2000);

--- a/scripts/installers/windows/pulsarr-baseline.iss
+++ b/scripts/installers/windows/pulsarr-baseline.iss
@@ -61,11 +61,13 @@ Type: filesandordirs; Name: "{app}\dist"
 Type: filesandordirs; Name: "{app}\node_modules"
 Type: filesandordirs; Name: "{app}\migrations"
 Type: filesandordirs; Name: "{app}\packages"
+; Shipped by older installers; now excluded from [Files]
+Type: files; Name: "{app}\README.txt"
 
 [Files]
 ; Main application files (from extracted native build zip).
-; Exclude update.bat: installer users update by re-running the installer.
-Source: "build\*"; DestDir: "{app}"; Excludes: "update.bat"; Flags: ignoreversion recursesubdirs createallsubdirs; Components: main
+; Exclude zip-flow files: installer users update by re-running the installer.
+Source: "build\*"; DestDir: "{app}"; Excludes: "update.bat,README.txt"; Flags: ignoreversion recursesubdirs createallsubdirs; Components: main
 ; Icon for uninstaller
 Source: "pulsarr.ico"; DestDir: "{app}"; Flags: ignoreversion; Components: main
 
@@ -95,6 +97,8 @@ Filename: "{app}\{#MyAppExeName}"; Description: "Start {#MyAppName}"; Flags: now
 [UninstallRun]
 ; Stop and uninstall service
 Filename: "{app}\pulsarr-service.exe"; Parameters: "stop"; Flags: runhidden; RunOnceId: "StopService"
+; WinSW stop can return before the process tree exits
+Filename: "cmd.exe"; Parameters: "/c timeout /t 2 /nobreak"; Flags: runhidden; RunOnceId: "StopSettle"
 Filename: "{app}\pulsarr-service.exe"; Parameters: "uninstall"; Flags: runhidden; RunOnceId: "UninstallService"
 
 [UninstallDelete]
@@ -107,25 +111,36 @@ Type: files; Name: "{app}\pulsarr-service.err.log"
 const
   CRLF = #13#10;
 
-var
-  DataDirPage: TInputDirWizardPage;
-  DeleteDataCheckbox: TNewCheckBox;
-
-procedure InitializeWizard;
-begin
-  { Add custom page for data directory selection (optional, for advanced users) }
-  { For now, we use the default ProgramData\Pulsarr location }
-end;
-
 function PrepareToInstall(var NeedsRestart: Boolean): String;
 var
   ResultCode: Integer;
+  BunPath, ProbePath: String;
+  I: Integer;
 begin
   Result := '';
-  { Stop existing service if running }
   if FileExists(ExpandConstant('{app}\pulsarr-service.exe')) then
   begin
     Exec(ExpandConstant('{app}\pulsarr-service.exe'), 'stop', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+    { WinSW stop can return before the process tree exits }
+    Sleep(2000);
+  end;
+
+  { A locked bun.exe means Pulsarr is still running. Abort here, before
+    InstallDelete wipes the code dirs with no rollback. }
+  BunPath := ExpandConstant('{app}\bun.exe');
+  if FileExists(BunPath) then
+  begin
+    ProbePath := BunPath + '.locktest';
+    for I := 1 to 5 do
+    begin
+      if RenameFile(BunPath, ProbePath) then
+      begin
+        RenameFile(ProbePath, BunPath);
+        Exit;
+      end;
+      Sleep(2000);
+    end;
+    Result := 'Pulsarr appears to be running. Stop the Pulsarr service or close the Pulsarr window, then run Setup again.';
   end;
 end;
 

--- a/scripts/installers/windows/pulsarr.iss
+++ b/scripts/installers/windows/pulsarr.iss
@@ -63,6 +63,8 @@ Type: filesandordirs; Name: "{app}\migrations"
 Type: filesandordirs; Name: "{app}\packages"
 ; Shipped by older installers; now excluded from [Files]
 Type: files; Name: "{app}\README.txt"
+; Leftover lock probe from an interrupted run
+Type: files; Name: "{app}\bun.exe.locktest"
 
 [Files]
 ; Main application files (from extracted native build zip).
@@ -115,7 +117,7 @@ function PrepareToInstall(var NeedsRestart: Boolean): String;
 var
   ResultCode: Integer;
   BunPath, ProbePath: String;
-  I: Integer;
+  I, J: Integer;
 begin
   Result := '';
   if FileExists(ExpandConstant('{app}\pulsarr-service.exe')) then
@@ -131,11 +133,20 @@ begin
   if FileExists(BunPath) then
   begin
     ProbePath := BunPath + '.locktest';
+    { A stale probe file from an interrupted run blocks the rename below }
+    DeleteFile(ProbePath);
     for I := 1 to 5 do
     begin
       if RenameFile(BunPath, ProbePath) then
       begin
-        RenameFile(ProbePath, BunPath);
+        { Retry the restore; AV scanners can briefly lock a renamed file }
+        for J := 1 to 5 do
+        begin
+          if RenameFile(ProbePath, BunPath) then
+            Exit;
+          Sleep(1000);
+        end;
+        Result := 'Setup could not restore bun.exe. Rename ' + ProbePath + ' back to bun.exe, then run Setup again.';
         Exit;
       end;
       Sleep(2000);

--- a/scripts/installers/windows/pulsarr.iss
+++ b/scripts/installers/windows/pulsarr.iss
@@ -61,11 +61,13 @@ Type: filesandordirs; Name: "{app}\dist"
 Type: filesandordirs; Name: "{app}\node_modules"
 Type: filesandordirs; Name: "{app}\migrations"
 Type: filesandordirs; Name: "{app}\packages"
+; Shipped by older installers; now excluded from [Files]
+Type: files; Name: "{app}\README.txt"
 
 [Files]
 ; Main application files (from extracted native build zip).
-; Exclude update.bat: installer users update by re-running the installer.
-Source: "build\*"; DestDir: "{app}"; Excludes: "update.bat"; Flags: ignoreversion recursesubdirs createallsubdirs; Components: main
+; Exclude zip-flow files: installer users update by re-running the installer.
+Source: "build\*"; DestDir: "{app}"; Excludes: "update.bat,README.txt"; Flags: ignoreversion recursesubdirs createallsubdirs; Components: main
 ; Icon for uninstaller
 Source: "pulsarr.ico"; DestDir: "{app}"; Flags: ignoreversion; Components: main
 
@@ -95,6 +97,8 @@ Filename: "{app}\{#MyAppExeName}"; Description: "Start {#MyAppName}"; Flags: now
 [UninstallRun]
 ; Stop and uninstall service
 Filename: "{app}\pulsarr-service.exe"; Parameters: "stop"; Flags: runhidden; RunOnceId: "StopService"
+; WinSW stop can return before the process tree exits
+Filename: "cmd.exe"; Parameters: "/c timeout /t 2 /nobreak"; Flags: runhidden; RunOnceId: "StopSettle"
 Filename: "{app}\pulsarr-service.exe"; Parameters: "uninstall"; Flags: runhidden; RunOnceId: "UninstallService"
 
 [UninstallDelete]
@@ -107,25 +111,36 @@ Type: files; Name: "{app}\pulsarr-service.err.log"
 const
   CRLF = #13#10;
 
-var
-  DataDirPage: TInputDirWizardPage;
-  DeleteDataCheckbox: TNewCheckBox;
-
-procedure InitializeWizard;
-begin
-  { Add custom page for data directory selection (optional, for advanced users) }
-  { For now, we use the default ProgramData\Pulsarr location }
-end;
-
 function PrepareToInstall(var NeedsRestart: Boolean): String;
 var
   ResultCode: Integer;
+  BunPath, ProbePath: String;
+  I: Integer;
 begin
   Result := '';
-  { Stop existing service if running }
   if FileExists(ExpandConstant('{app}\pulsarr-service.exe')) then
   begin
     Exec(ExpandConstant('{app}\pulsarr-service.exe'), 'stop', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+    { WinSW stop can return before the process tree exits }
+    Sleep(2000);
+  end;
+
+  { A locked bun.exe means Pulsarr is still running. Abort here, before
+    InstallDelete wipes the code dirs with no rollback. }
+  BunPath := ExpandConstant('{app}\bun.exe');
+  if FileExists(BunPath) then
+  begin
+    ProbePath := BunPath + '.locktest';
+    for I := 1 to 5 do
+    begin
+      if RenameFile(BunPath, ProbePath) then
+      begin
+        RenameFile(ProbePath, BunPath);
+        Exit;
+      end;
+      Sleep(2000);
+    end;
+    Result := 'Pulsarr appears to be running. Stop the Pulsarr service or close the Pulsarr window, then run Setup again.';
   end;
 end;
 


### PR DESCRIPTION
… updates safely

## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upgrades now use a staged, safer replacement flow to minimize disruption to existing data.
* **Bug Fixes**
  * Windows packaging now verifies the WinSW binary checksum and aborts safely on mismatch.
  * Windows install/uninstall now waits briefly after stopping the service and improves handling of locked `bun.exe`, with clearer retry guidance.
  * Removed/excludes legacy `README.txt` and stale lock-test artifacts during install/uninstall.
* **Improvements**
  * Linux installs now use per-run staging directories (and clean up older leftovers) and delay stopping the service until after extraction and setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->