### PR TITLE
fix(installers): keep linux code root-owned to block upgrade symlink …

### DIFF
--- a/docs/docs/installation/native-installation.md
+++ b/docs/docs/installation/native-installation.md
@@ -120,7 +120,7 @@ Use **Add or Remove Programs** in Windows Settings, or run the uninstaller from 
 
 | Item | Location |
 |------|----------|
-| Application | `C:\ProgramData\Pulsarr\` |
+| Application | `C:\Program Files\Pulsarr\` |
 | Configuration | `C:\ProgramData\Pulsarr\.env` |
 | Database | `C:\ProgramData\Pulsarr\data\db\` |
 | Logs | `C:\ProgramData\Pulsarr\data\logs\` |

--- a/scripts/installers/linux/install.sh
+++ b/scripts/installers/linux/install.sh
@@ -181,7 +181,12 @@ install_files() {
         cp "${INSTALL_DIR}/.env.example" "${INSTALL_DIR}/.env"
     fi
 
-    chown -R "${APP_USER}:${APP_GROUP}" "$INSTALL_DIR"
+    chown -R root:root "$INSTALL_DIR"
+    chown -R "${APP_USER}:${APP_GROUP}" "${INSTALL_DIR}/data"
+    if [[ -f "${INSTALL_DIR}/.env" ]]; then
+        chown "root:${APP_GROUP}" "${INSTALL_DIR}/.env"
+        chmod 640 "${INSTALL_DIR}/.env"
+    fi
     chmod +x "${INSTALL_DIR}/start.sh"
     chmod +x "${INSTALL_DIR}/bun"
 }
@@ -209,7 +214,7 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=true
-ReadWritePaths=${INSTALL_DIR}
+ReadWritePaths=${INSTALL_DIR}/data
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/installers/linux/install.sh
+++ b/scripts/installers/linux/install.sh
@@ -147,9 +147,11 @@ install_files() {
 
     mkdir -p "$INSTALL_DIR"
 
-    # Own before stripping so the copy below can't follow a symlink left in a
-    # previously writable INSTALL_DIR; a root-owned data symlink is kept.
+    # Own and lock down before stripping so the copy below can't follow a
+    # symlink planted in a previously writable INSTALL_DIR; a root-owned
+    # data symlink is kept.
     chown root:root "$INSTALL_DIR"
+    chmod 755 "$INSTALL_DIR"
     find "$INSTALL_DIR" -mindepth 1 -maxdepth 1 -type l ! \( -name data -user root \) -delete
 
     find "$(dirname "$INSTALL_DIR")" -maxdepth 1 -name "$(basename "$INSTALL_DIR").staging.*" -mmin +60 -exec rm -rf {} + 2>/dev/null || true
@@ -186,8 +188,10 @@ install_files() {
         cp "${INSTALL_DIR}/.env.example" "${INSTALL_DIR}/.env"
     fi
 
-    chown -R root:root "$INSTALL_DIR"
-    chown -R "${APP_USER}:${APP_GROUP}" "${INSTALL_DIR}/data"
+    find "$INSTALL_DIR" -mindepth 1 -maxdepth 1 ! -name data -exec chown -R root:root {} +
+    # Trailing slash dereferences a relocated data symlink; the symlink itself
+    # must stay root-owned or the strip above removes it on the next upgrade.
+    chown -R "${APP_USER}:${APP_GROUP}" "${INSTALL_DIR}/data/"
     if [[ -f "${INSTALL_DIR}/.env" ]]; then
         chown "root:${APP_GROUP}" "${INSTALL_DIR}/.env"
         chmod 640 "${INSTALL_DIR}/.env"

--- a/scripts/installers/linux/install.sh
+++ b/scripts/installers/linux/install.sh
@@ -147,10 +147,10 @@ install_files() {
 
     mkdir -p "$INSTALL_DIR"
 
-    # Strip symlinks planted directly in INSTALL_DIR so cp -a and the .env chown/chmod
-    # cannot follow one out of the tree. mindepth 1 spares INSTALL_DIR itself in case
-    # it is a user relocation symlink; maxdepth 1 leaves user symlinks under data/ alone.
-    find "$INSTALL_DIR" -mindepth 1 -maxdepth 1 -type l -delete
+    # Own before stripping so the copy below can't follow a symlink left in a
+    # previously writable INSTALL_DIR; a root-owned data symlink is kept.
+    chown root:root "$INSTALL_DIR"
+    find "$INSTALL_DIR" -mindepth 1 -maxdepth 1 -type l ! \( -name data -user root \) -delete
 
     find "$(dirname "$INSTALL_DIR")" -maxdepth 1 -name "$(basename "$INSTALL_DIR").staging.*" -mmin +60 -exec rm -rf {} + 2>/dev/null || true
     staging="$(mktemp -d "${INSTALL_DIR}.staging.XXXXXX")" || die "Failed to create staging directory"

--- a/scripts/installers/linux/install.sh
+++ b/scripts/installers/linux/install.sh
@@ -147,6 +147,11 @@ install_files() {
 
     mkdir -p "$INSTALL_DIR"
 
+    # Strip symlinks planted directly in INSTALL_DIR so cp -a and the .env chown/chmod
+    # cannot follow one out of the tree. mindepth 1 spares INSTALL_DIR itself in case
+    # it is a user relocation symlink; maxdepth 1 leaves user symlinks under data/ alone.
+    find "$INSTALL_DIR" -mindepth 1 -maxdepth 1 -type l -delete
+
     find "$(dirname "$INSTALL_DIR")" -maxdepth 1 -name "$(basename "$INSTALL_DIR").staging.*" -mmin +60 -exec rm -rf {} + 2>/dev/null || true
     staging="$(mktemp -d "${INSTALL_DIR}.staging.XXXXXX")" || die "Failed to create staging directory"
     [[ -d "$staging" ]] || die "Staging directory was not created"

--- a/scripts/installers/linux/install.sh
+++ b/scripts/installers/linux/install.sh
@@ -152,6 +152,9 @@ install_files() {
     # data symlink is kept.
     chown root:root "$INSTALL_DIR"
     chmod 755 "$INSTALL_DIR"
+    if [[ -L "${INSTALL_DIR}/data" ]] && [[ "$(stat -c %u "${INSTALL_DIR}/data")" != 0 ]]; then
+        die "${INSTALL_DIR}/data is a symlink not owned by root (older installers left it this way). If you relocated data intentionally, run 'chown -h root:root ${INSTALL_DIR}/data' and re-run this installer. If you did not create this symlink, remove it and investigate before upgrading."
+    fi
     find "$INSTALL_DIR" -mindepth 1 -maxdepth 1 -type l ! \( -name data -user root \) -delete
 
     find "$(dirname "$INSTALL_DIR")" -maxdepth 1 -name "$(basename "$INSTALL_DIR").staging.*" -mmin +60 -exec rm -rf {} + 2>/dev/null || true

--- a/scripts/installers/windows/pulsarr-baseline.iss
+++ b/scripts/installers/windows/pulsarr-baseline.iss
@@ -133,11 +133,42 @@ begin
     WizardForm.DirEdit.Text := ExpandConstant('{autopf}\{#MyAppName}');
 end;
 
+{ A locked bun.exe means Pulsarr is still running. Returns '' when the
+  file is absent or free. }
+function CheckBunLocked(BunPath: String): String;
+var
+  ProbePath: String;
+  I, J: Integer;
+begin
+  Result := '';
+  if not FileExists(BunPath) then
+    Exit;
+  ProbePath := BunPath + '.locktest';
+  { A stale probe file from an interrupted run blocks the rename below }
+  DeleteFile(ProbePath);
+  for I := 1 to 5 do
+  begin
+    if RenameFile(BunPath, ProbePath) then
+    begin
+      { Retry the restore; AV scanners can briefly lock a renamed file }
+      for J := 1 to 5 do
+      begin
+        if RenameFile(ProbePath, BunPath) then
+          Exit;
+        Sleep(1000);
+      end;
+      Result := 'Setup could not restore bun.exe. Rename ' + ProbePath + ' back to bun.exe, then run Setup again.';
+      Exit;
+    end;
+    Sleep(2000);
+  end;
+  Result := 'Pulsarr appears to be running. Stop the Pulsarr service or close the Pulsarr window, then run Setup again.';
+end;
+
 function PrepareToInstall(var NeedsRestart: Boolean): String;
 var
   ResultCode: Integer;
-  OldServiceExe, BunPath, ProbePath: String;
-  I, J: Integer;
+  OldServiceExe: String;
 begin
   Result := '';
 
@@ -159,32 +190,12 @@ begin
     Sleep(2000);
   end;
 
-  { A locked bun.exe means Pulsarr is still running. Abort here, before
-    InstallDelete wipes the code dirs with no rollback. }
-  BunPath := ExpandConstant('{app}\bun.exe');
-  if FileExists(BunPath) then
-  begin
-    ProbePath := BunPath + '.locktest';
-    { A stale probe file from an interrupted run blocks the rename below }
-    DeleteFile(ProbePath);
-    for I := 1 to 5 do
-    begin
-      if RenameFile(BunPath, ProbePath) then
-      begin
-        { Retry the restore; AV scanners can briefly lock a renamed file }
-        for J := 1 to 5 do
-        begin
-          if RenameFile(ProbePath, BunPath) then
-            Exit;
-          Sleep(1000);
-        end;
-        Result := 'Setup could not restore bun.exe. Rename ' + ProbePath + ' back to bun.exe, then run Setup again.';
-        Exit;
-      end;
-      Sleep(2000);
-    end;
-    Result := 'Pulsarr appears to be running. Stop the Pulsarr service or close the Pulsarr window, then run Setup again.';
-  end;
+  { Abort here, before InstallDelete wipes the code dirs with no rollback.
+    Check the legacy data-dir copy too: a compact install never registered
+    the service, so nothing above stops an instance still running there. }
+  Result := CheckBunLocked(ExpandConstant('{app}\bun.exe'));
+  if (Result = '') and (CompareText(ExpandConstant('{#MyAppDataDir}'), ExpandConstant('{app}')) <> 0) then
+    Result := CheckBunLocked(ExpandConstant('{#MyAppDataDir}\bun.exe'));
 end;
 
 procedure CurStepChanged(CurStep: TSetupStep);

--- a/scripts/installers/windows/pulsarr-baseline.iss
+++ b/scripts/installers/windows/pulsarr-baseline.iss
@@ -23,9 +23,6 @@ AppSupportURL={#MyAppURL}/issues
 AppUpdatesURL={#MyAppURL}/releases
 ; Code goes to Program Files (admin-only). User data stays in {#MyAppDataDir}.
 DefaultDirName={autopf}\{#MyAppName}
-; Older installers put code in the user-writable data dir. Ignore that stored
-; path so upgrades relocate the code out of it.
-UsePreviousAppDir=no
 DefaultGroupName={#MyAppName}
 AllowNoIcons=yes
 LicenseFile=license.txt
@@ -67,8 +64,7 @@ Type: filesandordirs; Name: "{app}\packages"
 Type: files; Name: "{app}\README.txt"
 ; Leftover lock probe from an interrupted run
 Type: files; Name: "{app}\bun.exe.locktest"
-; Older installers kept code in the user-writable data dir. Remove those copies so
-; a non-admin can't swap them under the service. .env, db and logs are left alone.
+; Older installers put code in the data dir; remove those copies (keep .env, db, logs).
 Type: filesandordirs; Name: "{#MyAppDataDir}\dist"
 Type: filesandordirs; Name: "{#MyAppDataDir}\node_modules"
 Type: filesandordirs; Name: "{#MyAppDataDir}\migrations"
@@ -93,9 +89,7 @@ Source: "build\*"; DestDir: "{app}"; Excludes: "update.bat,README.txt"; Flags: i
 Source: "pulsarr.ico"; DestDir: "{app}"; Flags: ignoreversion; Components: main
 
 [Dirs]
-; {app} keeps its default Program Files ACL (admins write, users read/execute).
-; Granting users write here would let a non-admin replace code the LocalSystem
-; service runs. Only the data dir below is user-writable.
+; No user-write on {app}: the LocalSystem service runs this code. Only data below.
 Name: "{#MyAppDataDir}"; Permissions: users-full
 Name: "{#MyAppDataDir}\db"; Permissions: users-full
 Name: "{#MyAppDataDir}\logs"; Permissions: users-full
@@ -132,6 +126,13 @@ Type: files; Name: "{app}\pulsarr-service.err.log"
 const
   CRLF = #13#10;
 
+procedure InitializeWizard;
+begin
+  { Relocate legacy data-dir installs to the default; keep a custom directory. }
+  if CompareText(WizardDirValue, ExpandConstant('{#MyAppDataDir}')) = 0 then
+    WizardForm.DirEdit.Text := ExpandConstant('{autopf}\{#MyAppName}');
+end;
+
 function PrepareToInstall(var NeedsRestart: Boolean): String;
 var
   ResultCode: Integer;
@@ -140,9 +141,8 @@ var
 begin
   Result := '';
 
-  { Older installers ran the service from the data dir. Stop and unregister that
-    copy before installing the Program Files one, or winsw install hits a name
-    clash and the old bun.exe stays locked against InstallDelete. }
+  { Old install ran the service from the data dir; remove it first or winsw
+    install name-clashes and the old bun.exe stays locked. }
   OldServiceExe := ExpandConstant('{#MyAppDataDir}\pulsarr-service.exe');
   if (CompareText(ExpandConstant('{#MyAppDataDir}'), ExpandConstant('{app}')) <> 0) and FileExists(OldServiceExe) then
   begin

--- a/scripts/installers/windows/pulsarr-baseline.iss
+++ b/scripts/installers/windows/pulsarr-baseline.iss
@@ -182,6 +182,14 @@ begin
     Exec(ExpandConstant('{sys}\sc.exe'), 'stop pulsarr', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
     Sleep(2000);
     Exec(ExpandConstant('{sys}\sc.exe'), 'delete pulsarr', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+    { 1060 = never registered (compact installs). Anything else leaves a stale
+      entry that InstallDelete would orphan and the winsw install below would
+      collide with. }
+    if (ResultCode <> 0) and (ResultCode <> 1060) then
+    begin
+      Result := 'Setup could not remove the old Pulsarr service (error ' + IntToStr(ResultCode) + '). Close the Services console if it is open, then run Setup again.';
+      Exit;
+    end;
     Sleep(1000);
   end;
 

--- a/scripts/installers/windows/pulsarr-baseline.iss
+++ b/scripts/installers/windows/pulsarr-baseline.iss
@@ -173,13 +173,15 @@ begin
   Result := '';
 
   { Old install ran the service from the data dir; remove it first or winsw
-    install name-clashes and the old bun.exe stays locked. }
+    install name-clashes and the old bun.exe stays locked. Go through the
+    SCM by service name: the data dir is user-writable, so binaries there
+    must never run elevated. }
   OldServiceExe := ExpandConstant('{#MyAppDataDir}\pulsarr-service.exe');
   if (CompareText(ExpandConstant('{#MyAppDataDir}'), ExpandConstant('{app}')) <> 0) and FileExists(OldServiceExe) then
   begin
-    Exec(OldServiceExe, 'stop', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+    Exec(ExpandConstant('{sys}\sc.exe'), 'stop pulsarr', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
     Sleep(2000);
-    Exec(OldServiceExe, 'uninstall', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+    Exec(ExpandConstant('{sys}\sc.exe'), 'delete pulsarr', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
     Sleep(1000);
   end;
 

--- a/scripts/installers/windows/pulsarr-baseline.iss
+++ b/scripts/installers/windows/pulsarr-baseline.iss
@@ -183,6 +183,7 @@ end;
 function PrepareToInstall(var NeedsRestart: Boolean): String;
 var
   ResultCode: Integer;
+  I: Integer;
 begin
   Result := '';
 
@@ -203,7 +204,19 @@ begin
       Result := 'Setup could not remove the old Pulsarr service (error ' + IntToStr(ResultCode) + '). Close the Services console if it is open, then run Setup again.';
       Exit;
     end;
-    Sleep(1000);
+    { SCM drops the entry only after the service stops and all handles close }
+    for I := 1 to 10 do
+    begin
+      Exec(ExpandConstant('{sys}\sc.exe'), 'query pulsarr', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+      if ResultCode = 1060 then
+        Break;
+      Sleep(1000);
+    end;
+    if ResultCode <> 1060 then
+    begin
+      Result := 'The old Pulsarr service has not finished being removed. Close the Services console if it is open, then run Setup again.';
+      Exit;
+    end;
   end;
 
   if FileExists(ExpandConstant('{app}\pulsarr-service.exe')) then

--- a/scripts/installers/windows/pulsarr-baseline.iss
+++ b/scripts/installers/windows/pulsarr-baseline.iss
@@ -165,10 +165,24 @@ begin
   Result := 'Pulsarr appears to be running. Stop the Pulsarr service or close the Pulsarr window, then run Setup again.';
 end;
 
+{ True when the registered pulsarr service runs from the data dir. The
+  registry is admin-writable only, so user-writable files can't spoof this. }
+function LegacyServiceInDataDir(): Boolean;
+var
+  ImagePath, DataDir: String;
+begin
+  Result := False;
+  if not RegQueryStringValue(HKLM, 'SYSTEM\CurrentControlSet\Services\pulsarr', 'ImagePath', ImagePath) then
+    Exit;
+  if (ImagePath <> '') and (ImagePath[1] = '"') then
+    Delete(ImagePath, 1, 1);
+  DataDir := ExpandConstant('{#MyAppDataDir}\');
+  Result := CompareText(Copy(ImagePath, 1, Length(DataDir)), DataDir) = 0;
+end;
+
 function PrepareToInstall(var NeedsRestart: Boolean): String;
 var
   ResultCode: Integer;
-  OldServiceExe: String;
 begin
   Result := '';
 
@@ -176,8 +190,7 @@ begin
     install name-clashes and the old bun.exe stays locked. Go through the
     SCM by service name: the data dir is user-writable, so binaries there
     must never run elevated. }
-  OldServiceExe := ExpandConstant('{#MyAppDataDir}\pulsarr-service.exe');
-  if (CompareText(ExpandConstant('{#MyAppDataDir}'), ExpandConstant('{app}')) <> 0) and FileExists(OldServiceExe) then
+  if (CompareText(ExpandConstant('{#MyAppDataDir}'), ExpandConstant('{app}')) <> 0) and LegacyServiceInDataDir() then
   begin
     Exec(ExpandConstant('{sys}\sc.exe'), 'stop pulsarr', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
     Sleep(2000);

--- a/scripts/installers/windows/pulsarr-baseline.iss
+++ b/scripts/installers/windows/pulsarr-baseline.iss
@@ -180,43 +180,52 @@ begin
   Result := CompareText(Copy(ImagePath, 1, Length(DataDir)), DataDir) = 0;
 end;
 
+function RemoveService(): String;
+var
+  ResultCode, I: Integer;
+begin
+  Result := '';
+  if not RegKeyExists(HKLM, 'SYSTEM\CurrentControlSet\Services\pulsarr') then
+    Exit;
+  Exec(ExpandConstant('{sys}\sc.exe'), 'stop pulsarr', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+  Sleep(2000);
+  Exec(ExpandConstant('{sys}\sc.exe'), 'delete pulsarr', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+  { 1060 = ERROR_SERVICE_DOES_NOT_EXIST; any other code left a stale entry. }
+  if (ResultCode <> 0) and (ResultCode <> 1060) then
+  begin
+    Result := 'Setup could not remove the old Pulsarr service (error ' + IntToStr(ResultCode) + '). Close the Services console if it is open, then run Setup again.';
+    Exit;
+  end;
+  { SCM drops the entry only after the service stops and all handles close }
+  for I := 1 to 10 do
+  begin
+    Exec(ExpandConstant('{sys}\sc.exe'), 'query pulsarr', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+    if ResultCode = 1060 then
+      Break;
+    Sleep(1000);
+  end;
+  if ResultCode <> 1060 then
+    Result := 'The old Pulsarr service has not finished being removed. Close the Services console if it is open, then run Setup again.';
+end;
+
 function PrepareToInstall(var NeedsRestart: Boolean): String;
 var
   ResultCode: Integer;
-  I: Integer;
 begin
   Result := '';
 
-  { Old install ran the service from the data dir; remove it first or winsw
-    install name-clashes and the old bun.exe stays locked. Go through the
-    SCM by service name: the data dir is user-writable, so binaries there
-    must never run elevated. }
-  if (CompareText(ExpandConstant('{#MyAppDataDir}'), ExpandConstant('{app}')) <> 0) and LegacyServiceInDataDir() then
+  if not IsComponentSelected('service') then
   begin
-    Exec(ExpandConstant('{sys}\sc.exe'), 'stop pulsarr', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
-    Sleep(2000);
-    Exec(ExpandConstant('{sys}\sc.exe'), 'delete pulsarr', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
-    { 1060 = never registered (compact installs). Anything else leaves a stale
-      entry that InstallDelete would orphan and the winsw install below would
-      collide with. }
-    if (ResultCode <> 0) and (ResultCode <> 1060) then
-    begin
-      Result := 'Setup could not remove the old Pulsarr service (error ' + IntToStr(ResultCode) + '). Close the Services console if it is open, then run Setup again.';
+    Result := RemoveService();
+    if Result <> '' then
       Exit;
-    end;
-    { SCM drops the entry only after the service stops and all handles close }
-    for I := 1 to 10 do
-    begin
-      Exec(ExpandConstant('{sys}\sc.exe'), 'query pulsarr', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
-      if ResultCode = 1060 then
-        Break;
-      Sleep(1000);
-    end;
-    if ResultCode <> 1060 then
-    begin
-      Result := 'The old Pulsarr service has not finished being removed. Close the Services console if it is open, then run Setup again.';
+  end
+  else if (CompareText(ExpandConstant('{#MyAppDataDir}'), ExpandConstant('{app}')) <> 0) and LegacyServiceInDataDir() then
+  begin
+    { Remove via SCM so [Run] reinstalls it from {app}. }
+    Result := RemoveService();
+    if Result <> '' then
       Exit;
-    end;
   end;
 
   if FileExists(ExpandConstant('{app}\pulsarr-service.exe')) then

--- a/scripts/installers/windows/pulsarr-baseline.iss
+++ b/scripts/installers/windows/pulsarr-baseline.iss
@@ -21,7 +21,11 @@ AppPublisher={#MyAppPublisher}
 AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}/issues
 AppUpdatesURL={#MyAppURL}/releases
-DefaultDirName={commonappdata}\{#MyAppName}
+; Code goes to Program Files (admin-only). User data stays in {#MyAppDataDir}.
+DefaultDirName={autopf}\{#MyAppName}
+; Older installers put code in the user-writable data dir. Ignore that stored
+; path so upgrades relocate the code out of it.
+UsePreviousAppDir=no
 DefaultGroupName={#MyAppName}
 AllowNoIcons=yes
 LicenseFile=license.txt
@@ -54,9 +58,7 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 Name: "startafterinstall"; Description: "Start Pulsarr after installation"; GroupDescription: "Startup:"; Flags: checkedonce
 
 [InstallDelete]
-; Clear the code dirs before copying so files removed between releases can't
-; linger. {app} and {#MyAppDataDir} are the same folder, so db/logs/.env sit
-; alongside these and are left untouched.
+; Clear the code dirs before copying so files removed between releases can't linger.
 Type: filesandordirs; Name: "{app}\dist"
 Type: filesandordirs; Name: "{app}\node_modules"
 Type: filesandordirs; Name: "{app}\migrations"
@@ -65,6 +67,23 @@ Type: filesandordirs; Name: "{app}\packages"
 Type: files; Name: "{app}\README.txt"
 ; Leftover lock probe from an interrupted run
 Type: files; Name: "{app}\bun.exe.locktest"
+; Older installers kept code in the user-writable data dir. Remove those copies so
+; a non-admin can't swap them under the service. .env, db and logs are left alone.
+Type: filesandordirs; Name: "{#MyAppDataDir}\dist"
+Type: filesandordirs; Name: "{#MyAppDataDir}\node_modules"
+Type: filesandordirs; Name: "{#MyAppDataDir}\migrations"
+Type: filesandordirs; Name: "{#MyAppDataDir}\packages"
+Type: files; Name: "{#MyAppDataDir}\bun.exe"
+Type: files; Name: "{#MyAppDataDir}\start.bat"
+Type: files; Name: "{#MyAppDataDir}\pulsarr-service.exe"
+Type: files; Name: "{#MyAppDataDir}\pulsarr-service.xml"
+Type: files; Name: "{#MyAppDataDir}\pulsarr-service.wrapper.log"
+Type: files; Name: "{#MyAppDataDir}\pulsarr-service.out.log"
+Type: files; Name: "{#MyAppDataDir}\pulsarr-service.err.log"
+Type: files; Name: "{#MyAppDataDir}\.env.example"
+Type: files; Name: "{#MyAppDataDir}\pulsarr.ico"
+Type: files; Name: "{#MyAppDataDir}\README.txt"
+Type: files; Name: "{#MyAppDataDir}\bun.exe.locktest"
 
 [Files]
 ; Main application files (from extracted native build zip).
@@ -74,9 +93,9 @@ Source: "build\*"; DestDir: "{app}"; Excludes: "update.bat,README.txt"; Flags: i
 Source: "pulsarr.ico"; DestDir: "{app}"; Flags: ignoreversion; Components: main
 
 [Dirs]
-; App directory permissions for non-admin user access
-Name: "{app}"; Permissions: users-modify
-; Create data directory with full permissions
+; {app} keeps its default Program Files ACL (admins write, users read/execute).
+; Granting users write here would let a non-admin replace code the LocalSystem
+; service runs. Only the data dir below is user-writable.
 Name: "{#MyAppDataDir}"; Permissions: users-full
 Name: "{#MyAppDataDir}\db"; Permissions: users-full
 Name: "{#MyAppDataDir}\logs"; Permissions: users-full
@@ -116,10 +135,23 @@ const
 function PrepareToInstall(var NeedsRestart: Boolean): String;
 var
   ResultCode: Integer;
-  BunPath, ProbePath: String;
+  OldServiceExe, BunPath, ProbePath: String;
   I, J: Integer;
 begin
   Result := '';
+
+  { Older installers ran the service from the data dir. Stop and unregister that
+    copy before installing the Program Files one, or winsw install hits a name
+    clash and the old bun.exe stays locked against InstallDelete. }
+  OldServiceExe := ExpandConstant('{#MyAppDataDir}\pulsarr-service.exe');
+  if (CompareText(ExpandConstant('{#MyAppDataDir}'), ExpandConstant('{app}')) <> 0) and FileExists(OldServiceExe) then
+  begin
+    Exec(OldServiceExe, 'stop', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+    Sleep(2000);
+    Exec(OldServiceExe, 'uninstall', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+    Sleep(1000);
+  end;
+
   if FileExists(ExpandConstant('{app}\pulsarr-service.exe')) then
   begin
     Exec(ExpandConstant('{app}\pulsarr-service.exe'), 'stop', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);

--- a/scripts/installers/windows/pulsarr.iss
+++ b/scripts/installers/windows/pulsarr.iss
@@ -133,11 +133,42 @@ begin
     WizardForm.DirEdit.Text := ExpandConstant('{autopf}\{#MyAppName}');
 end;
 
+{ A locked bun.exe means Pulsarr is still running. Returns '' when the
+  file is absent or free. }
+function CheckBunLocked(BunPath: String): String;
+var
+  ProbePath: String;
+  I, J: Integer;
+begin
+  Result := '';
+  if not FileExists(BunPath) then
+    Exit;
+  ProbePath := BunPath + '.locktest';
+  { A stale probe file from an interrupted run blocks the rename below }
+  DeleteFile(ProbePath);
+  for I := 1 to 5 do
+  begin
+    if RenameFile(BunPath, ProbePath) then
+    begin
+      { Retry the restore; AV scanners can briefly lock a renamed file }
+      for J := 1 to 5 do
+      begin
+        if RenameFile(ProbePath, BunPath) then
+          Exit;
+        Sleep(1000);
+      end;
+      Result := 'Setup could not restore bun.exe. Rename ' + ProbePath + ' back to bun.exe, then run Setup again.';
+      Exit;
+    end;
+    Sleep(2000);
+  end;
+  Result := 'Pulsarr appears to be running. Stop the Pulsarr service or close the Pulsarr window, then run Setup again.';
+end;
+
 function PrepareToInstall(var NeedsRestart: Boolean): String;
 var
   ResultCode: Integer;
-  OldServiceExe, BunPath, ProbePath: String;
-  I, J: Integer;
+  OldServiceExe: String;
 begin
   Result := '';
 
@@ -159,32 +190,12 @@ begin
     Sleep(2000);
   end;
 
-  { A locked bun.exe means Pulsarr is still running. Abort here, before
-    InstallDelete wipes the code dirs with no rollback. }
-  BunPath := ExpandConstant('{app}\bun.exe');
-  if FileExists(BunPath) then
-  begin
-    ProbePath := BunPath + '.locktest';
-    { A stale probe file from an interrupted run blocks the rename below }
-    DeleteFile(ProbePath);
-    for I := 1 to 5 do
-    begin
-      if RenameFile(BunPath, ProbePath) then
-      begin
-        { Retry the restore; AV scanners can briefly lock a renamed file }
-        for J := 1 to 5 do
-        begin
-          if RenameFile(ProbePath, BunPath) then
-            Exit;
-          Sleep(1000);
-        end;
-        Result := 'Setup could not restore bun.exe. Rename ' + ProbePath + ' back to bun.exe, then run Setup again.';
-        Exit;
-      end;
-      Sleep(2000);
-    end;
-    Result := 'Pulsarr appears to be running. Stop the Pulsarr service or close the Pulsarr window, then run Setup again.';
-  end;
+  { Abort here, before InstallDelete wipes the code dirs with no rollback.
+    Check the legacy data-dir copy too: a compact install never registered
+    the service, so nothing above stops an instance still running there. }
+  Result := CheckBunLocked(ExpandConstant('{app}\bun.exe'));
+  if (Result = '') and (CompareText(ExpandConstant('{#MyAppDataDir}'), ExpandConstant('{app}')) <> 0) then
+    Result := CheckBunLocked(ExpandConstant('{#MyAppDataDir}\bun.exe'));
 end;
 
 procedure CurStepChanged(CurStep: TSetupStep);

--- a/scripts/installers/windows/pulsarr.iss
+++ b/scripts/installers/windows/pulsarr.iss
@@ -23,9 +23,6 @@ AppSupportURL={#MyAppURL}/issues
 AppUpdatesURL={#MyAppURL}/releases
 ; Code goes to Program Files (admin-only). User data stays in {#MyAppDataDir}.
 DefaultDirName={autopf}\{#MyAppName}
-; Older installers put code in the user-writable data dir. Ignore that stored
-; path so upgrades relocate the code out of it.
-UsePreviousAppDir=no
 DefaultGroupName={#MyAppName}
 AllowNoIcons=yes
 LicenseFile=license.txt
@@ -67,8 +64,7 @@ Type: filesandordirs; Name: "{app}\packages"
 Type: files; Name: "{app}\README.txt"
 ; Leftover lock probe from an interrupted run
 Type: files; Name: "{app}\bun.exe.locktest"
-; Older installers kept code in the user-writable data dir. Remove those copies so
-; a non-admin can't swap them under the service. .env, db and logs are left alone.
+; Older installers put code in the data dir; remove those copies (keep .env, db, logs).
 Type: filesandordirs; Name: "{#MyAppDataDir}\dist"
 Type: filesandordirs; Name: "{#MyAppDataDir}\node_modules"
 Type: filesandordirs; Name: "{#MyAppDataDir}\migrations"
@@ -93,9 +89,7 @@ Source: "build\*"; DestDir: "{app}"; Excludes: "update.bat,README.txt"; Flags: i
 Source: "pulsarr.ico"; DestDir: "{app}"; Flags: ignoreversion; Components: main
 
 [Dirs]
-; {app} keeps its default Program Files ACL (admins write, users read/execute).
-; Granting users write here would let a non-admin replace code the LocalSystem
-; service runs. Only the data dir below is user-writable.
+; No user-write on {app}: the LocalSystem service runs this code. Only data below.
 Name: "{#MyAppDataDir}"; Permissions: users-full
 Name: "{#MyAppDataDir}\db"; Permissions: users-full
 Name: "{#MyAppDataDir}\logs"; Permissions: users-full
@@ -132,6 +126,13 @@ Type: files; Name: "{app}\pulsarr-service.err.log"
 const
   CRLF = #13#10;
 
+procedure InitializeWizard;
+begin
+  { Relocate legacy data-dir installs to the default; keep a custom directory. }
+  if CompareText(WizardDirValue, ExpandConstant('{#MyAppDataDir}')) = 0 then
+    WizardForm.DirEdit.Text := ExpandConstant('{autopf}\{#MyAppName}');
+end;
+
 function PrepareToInstall(var NeedsRestart: Boolean): String;
 var
   ResultCode: Integer;
@@ -140,9 +141,8 @@ var
 begin
   Result := '';
 
-  { Older installers ran the service from the data dir. Stop and unregister that
-    copy before installing the Program Files one, or winsw install hits a name
-    clash and the old bun.exe stays locked against InstallDelete. }
+  { Old install ran the service from the data dir; remove it first or winsw
+    install name-clashes and the old bun.exe stays locked. }
   OldServiceExe := ExpandConstant('{#MyAppDataDir}\pulsarr-service.exe');
   if (CompareText(ExpandConstant('{#MyAppDataDir}'), ExpandConstant('{app}')) <> 0) and FileExists(OldServiceExe) then
   begin

--- a/scripts/installers/windows/pulsarr.iss
+++ b/scripts/installers/windows/pulsarr.iss
@@ -182,6 +182,14 @@ begin
     Exec(ExpandConstant('{sys}\sc.exe'), 'stop pulsarr', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
     Sleep(2000);
     Exec(ExpandConstant('{sys}\sc.exe'), 'delete pulsarr', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+    { 1060 = never registered (compact installs). Anything else leaves a stale
+      entry that InstallDelete would orphan and the winsw install below would
+      collide with. }
+    if (ResultCode <> 0) and (ResultCode <> 1060) then
+    begin
+      Result := 'Setup could not remove the old Pulsarr service (error ' + IntToStr(ResultCode) + '). Close the Services console if it is open, then run Setup again.';
+      Exit;
+    end;
     Sleep(1000);
   end;
 

--- a/scripts/installers/windows/pulsarr.iss
+++ b/scripts/installers/windows/pulsarr.iss
@@ -173,13 +173,15 @@ begin
   Result := '';
 
   { Old install ran the service from the data dir; remove it first or winsw
-    install name-clashes and the old bun.exe stays locked. }
+    install name-clashes and the old bun.exe stays locked. Go through the
+    SCM by service name: the data dir is user-writable, so binaries there
+    must never run elevated. }
   OldServiceExe := ExpandConstant('{#MyAppDataDir}\pulsarr-service.exe');
   if (CompareText(ExpandConstant('{#MyAppDataDir}'), ExpandConstant('{app}')) <> 0) and FileExists(OldServiceExe) then
   begin
-    Exec(OldServiceExe, 'stop', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+    Exec(ExpandConstant('{sys}\sc.exe'), 'stop pulsarr', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
     Sleep(2000);
-    Exec(OldServiceExe, 'uninstall', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+    Exec(ExpandConstant('{sys}\sc.exe'), 'delete pulsarr', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
     Sleep(1000);
   end;
 

--- a/scripts/installers/windows/pulsarr.iss
+++ b/scripts/installers/windows/pulsarr.iss
@@ -183,6 +183,7 @@ end;
 function PrepareToInstall(var NeedsRestart: Boolean): String;
 var
   ResultCode: Integer;
+  I: Integer;
 begin
   Result := '';
 
@@ -203,7 +204,19 @@ begin
       Result := 'Setup could not remove the old Pulsarr service (error ' + IntToStr(ResultCode) + '). Close the Services console if it is open, then run Setup again.';
       Exit;
     end;
-    Sleep(1000);
+    { SCM drops the entry only after the service stops and all handles close }
+    for I := 1 to 10 do
+    begin
+      Exec(ExpandConstant('{sys}\sc.exe'), 'query pulsarr', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+      if ResultCode = 1060 then
+        Break;
+      Sleep(1000);
+    end;
+    if ResultCode <> 1060 then
+    begin
+      Result := 'The old Pulsarr service has not finished being removed. Close the Services console if it is open, then run Setup again.';
+      Exit;
+    end;
   end;
 
   if FileExists(ExpandConstant('{app}\pulsarr-service.exe')) then

--- a/scripts/installers/windows/pulsarr.iss
+++ b/scripts/installers/windows/pulsarr.iss
@@ -165,10 +165,24 @@ begin
   Result := 'Pulsarr appears to be running. Stop the Pulsarr service or close the Pulsarr window, then run Setup again.';
 end;
 
+{ True when the registered pulsarr service runs from the data dir. The
+  registry is admin-writable only, so user-writable files can't spoof this. }
+function LegacyServiceInDataDir(): Boolean;
+var
+  ImagePath, DataDir: String;
+begin
+  Result := False;
+  if not RegQueryStringValue(HKLM, 'SYSTEM\CurrentControlSet\Services\pulsarr', 'ImagePath', ImagePath) then
+    Exit;
+  if (ImagePath <> '') and (ImagePath[1] = '"') then
+    Delete(ImagePath, 1, 1);
+  DataDir := ExpandConstant('{#MyAppDataDir}\');
+  Result := CompareText(Copy(ImagePath, 1, Length(DataDir)), DataDir) = 0;
+end;
+
 function PrepareToInstall(var NeedsRestart: Boolean): String;
 var
   ResultCode: Integer;
-  OldServiceExe: String;
 begin
   Result := '';
 
@@ -176,8 +190,7 @@ begin
     install name-clashes and the old bun.exe stays locked. Go through the
     SCM by service name: the data dir is user-writable, so binaries there
     must never run elevated. }
-  OldServiceExe := ExpandConstant('{#MyAppDataDir}\pulsarr-service.exe');
-  if (CompareText(ExpandConstant('{#MyAppDataDir}'), ExpandConstant('{app}')) <> 0) and FileExists(OldServiceExe) then
+  if (CompareText(ExpandConstant('{#MyAppDataDir}'), ExpandConstant('{app}')) <> 0) and LegacyServiceInDataDir() then
   begin
     Exec(ExpandConstant('{sys}\sc.exe'), 'stop pulsarr', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
     Sleep(2000);

--- a/scripts/installers/windows/pulsarr.iss
+++ b/scripts/installers/windows/pulsarr.iss
@@ -180,43 +180,52 @@ begin
   Result := CompareText(Copy(ImagePath, 1, Length(DataDir)), DataDir) = 0;
 end;
 
+function RemoveService(): String;
+var
+  ResultCode, I: Integer;
+begin
+  Result := '';
+  if not RegKeyExists(HKLM, 'SYSTEM\CurrentControlSet\Services\pulsarr') then
+    Exit;
+  Exec(ExpandConstant('{sys}\sc.exe'), 'stop pulsarr', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+  Sleep(2000);
+  Exec(ExpandConstant('{sys}\sc.exe'), 'delete pulsarr', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+  { 1060 = ERROR_SERVICE_DOES_NOT_EXIST; any other code left a stale entry. }
+  if (ResultCode <> 0) and (ResultCode <> 1060) then
+  begin
+    Result := 'Setup could not remove the old Pulsarr service (error ' + IntToStr(ResultCode) + '). Close the Services console if it is open, then run Setup again.';
+    Exit;
+  end;
+  { SCM drops the entry only after the service stops and all handles close }
+  for I := 1 to 10 do
+  begin
+    Exec(ExpandConstant('{sys}\sc.exe'), 'query pulsarr', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+    if ResultCode = 1060 then
+      Break;
+    Sleep(1000);
+  end;
+  if ResultCode <> 1060 then
+    Result := 'The old Pulsarr service has not finished being removed. Close the Services console if it is open, then run Setup again.';
+end;
+
 function PrepareToInstall(var NeedsRestart: Boolean): String;
 var
   ResultCode: Integer;
-  I: Integer;
 begin
   Result := '';
 
-  { Old install ran the service from the data dir; remove it first or winsw
-    install name-clashes and the old bun.exe stays locked. Go through the
-    SCM by service name: the data dir is user-writable, so binaries there
-    must never run elevated. }
-  if (CompareText(ExpandConstant('{#MyAppDataDir}'), ExpandConstant('{app}')) <> 0) and LegacyServiceInDataDir() then
+  if not IsComponentSelected('service') then
   begin
-    Exec(ExpandConstant('{sys}\sc.exe'), 'stop pulsarr', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
-    Sleep(2000);
-    Exec(ExpandConstant('{sys}\sc.exe'), 'delete pulsarr', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
-    { 1060 = never registered (compact installs). Anything else leaves a stale
-      entry that InstallDelete would orphan and the winsw install below would
-      collide with. }
-    if (ResultCode <> 0) and (ResultCode <> 1060) then
-    begin
-      Result := 'Setup could not remove the old Pulsarr service (error ' + IntToStr(ResultCode) + '). Close the Services console if it is open, then run Setup again.';
+    Result := RemoveService();
+    if Result <> '' then
       Exit;
-    end;
-    { SCM drops the entry only after the service stops and all handles close }
-    for I := 1 to 10 do
-    begin
-      Exec(ExpandConstant('{sys}\sc.exe'), 'query pulsarr', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
-      if ResultCode = 1060 then
-        Break;
-      Sleep(1000);
-    end;
-    if ResultCode <> 1060 then
-    begin
-      Result := 'The old Pulsarr service has not finished being removed. Close the Services console if it is open, then run Setup again.';
+  end
+  else if (CompareText(ExpandConstant('{#MyAppDataDir}'), ExpandConstant('{app}')) <> 0) and LegacyServiceInDataDir() then
+  begin
+    { Remove via SCM so [Run] reinstalls it from {app}. }
+    Result := RemoveService();
+    if Result <> '' then
       Exit;
-    end;
   end;
 
   if FileExists(ExpandConstant('{app}\pulsarr-service.exe')) then

--- a/scripts/installers/windows/pulsarr.iss
+++ b/scripts/installers/windows/pulsarr.iss
@@ -21,7 +21,11 @@ AppPublisher={#MyAppPublisher}
 AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}/issues
 AppUpdatesURL={#MyAppURL}/releases
-DefaultDirName={commonappdata}\{#MyAppName}
+; Code goes to Program Files (admin-only). User data stays in {#MyAppDataDir}.
+DefaultDirName={autopf}\{#MyAppName}
+; Older installers put code in the user-writable data dir. Ignore that stored
+; path so upgrades relocate the code out of it.
+UsePreviousAppDir=no
 DefaultGroupName={#MyAppName}
 AllowNoIcons=yes
 LicenseFile=license.txt
@@ -54,9 +58,7 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 Name: "startafterinstall"; Description: "Start Pulsarr after installation"; GroupDescription: "Startup:"; Flags: checkedonce
 
 [InstallDelete]
-; Clear the code dirs before copying so files removed between releases can't
-; linger. {app} and {#MyAppDataDir} are the same folder, so db/logs/.env sit
-; alongside these and are left untouched.
+; Clear the code dirs before copying so files removed between releases can't linger.
 Type: filesandordirs; Name: "{app}\dist"
 Type: filesandordirs; Name: "{app}\node_modules"
 Type: filesandordirs; Name: "{app}\migrations"
@@ -65,6 +67,23 @@ Type: filesandordirs; Name: "{app}\packages"
 Type: files; Name: "{app}\README.txt"
 ; Leftover lock probe from an interrupted run
 Type: files; Name: "{app}\bun.exe.locktest"
+; Older installers kept code in the user-writable data dir. Remove those copies so
+; a non-admin can't swap them under the service. .env, db and logs are left alone.
+Type: filesandordirs; Name: "{#MyAppDataDir}\dist"
+Type: filesandordirs; Name: "{#MyAppDataDir}\node_modules"
+Type: filesandordirs; Name: "{#MyAppDataDir}\migrations"
+Type: filesandordirs; Name: "{#MyAppDataDir}\packages"
+Type: files; Name: "{#MyAppDataDir}\bun.exe"
+Type: files; Name: "{#MyAppDataDir}\start.bat"
+Type: files; Name: "{#MyAppDataDir}\pulsarr-service.exe"
+Type: files; Name: "{#MyAppDataDir}\pulsarr-service.xml"
+Type: files; Name: "{#MyAppDataDir}\pulsarr-service.wrapper.log"
+Type: files; Name: "{#MyAppDataDir}\pulsarr-service.out.log"
+Type: files; Name: "{#MyAppDataDir}\pulsarr-service.err.log"
+Type: files; Name: "{#MyAppDataDir}\.env.example"
+Type: files; Name: "{#MyAppDataDir}\pulsarr.ico"
+Type: files; Name: "{#MyAppDataDir}\README.txt"
+Type: files; Name: "{#MyAppDataDir}\bun.exe.locktest"
 
 [Files]
 ; Main application files (from extracted native build zip).
@@ -74,9 +93,9 @@ Source: "build\*"; DestDir: "{app}"; Excludes: "update.bat,README.txt"; Flags: i
 Source: "pulsarr.ico"; DestDir: "{app}"; Flags: ignoreversion; Components: main
 
 [Dirs]
-; App directory permissions for non-admin user access
-Name: "{app}"; Permissions: users-modify
-; Create data directory with full permissions
+; {app} keeps its default Program Files ACL (admins write, users read/execute).
+; Granting users write here would let a non-admin replace code the LocalSystem
+; service runs. Only the data dir below is user-writable.
 Name: "{#MyAppDataDir}"; Permissions: users-full
 Name: "{#MyAppDataDir}\db"; Permissions: users-full
 Name: "{#MyAppDataDir}\logs"; Permissions: users-full
@@ -116,10 +135,23 @@ const
 function PrepareToInstall(var NeedsRestart: Boolean): String;
 var
   ResultCode: Integer;
-  BunPath, ProbePath: String;
+  OldServiceExe, BunPath, ProbePath: String;
   I, J: Integer;
 begin
   Result := '';
+
+  { Older installers ran the service from the data dir. Stop and unregister that
+    copy before installing the Program Files one, or winsw install hits a name
+    clash and the old bun.exe stays locked against InstallDelete. }
+  OldServiceExe := ExpandConstant('{#MyAppDataDir}\pulsarr-service.exe');
+  if (CompareText(ExpandConstant('{#MyAppDataDir}'), ExpandConstant('{app}')) <> 0) and FileExists(OldServiceExe) then
+  begin
+    Exec(OldServiceExe, 'stop', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+    Sleep(2000);
+    Exec(OldServiceExe, 'uninstall', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+    Sleep(1000);
+  end;
+
   if FileExists(ExpandConstant('{app}\pulsarr-service.exe')) then
   begin
     Exec(ExpandConstant('{app}\pulsarr-service.exe'), 'stop', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);


### PR DESCRIPTION
…escalation

## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened Linux installation: tighter ownership/permissions, safer cleanup of shipped symlinks, and improved handling of shipped `.env`; service access is now limited to the data directory.
  * Updated Windows installers to install application code in admin-only Program Files while keeping persistent data in the separate data directory, with tightened directory permissions.
  * Improved Windows upgrades/uninstalls: remove legacy shipped artifacts from older locations, remap paths when needed, stop legacy services when applicable, and abort installation when `bun.exe` appears locked or running.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->