### PR TITLE
fix(session-monitor): derive rolling reset baseline from the master row

### DIFF
--- a/src/services/database/methods/session.ts
+++ b/src/services/database/methods/session.ts
@@ -403,6 +403,21 @@ export async function resetRollingMonitoredShowToOriginal(
       if (!show) {
         return 0
       }
+
+      // Master row owns monitoring_type; a user row's copy can be stale.
+      const masterQuery = trx('rolling_monitored_shows')
+        .where({
+          sonarr_series_id: show.sonarr_series_id,
+          sonarr_instance_id: show.sonarr_instance_id,
+        })
+        .whereNull('plex_user_id')
+      if (this.isPostgres) masterQuery.forUpdate() // row-level lock only on PG
+      const master = await masterQuery.first()
+
+      if (!master) {
+        return 0
+      }
+
       // Delete all user entries (keep only master record)
       const deletedUserEntries = await trx('rolling_monitored_shows')
         .where({
@@ -421,7 +436,7 @@ export async function resetRollingMonitoredShowToOriginal(
         .whereNull('plex_user_id') // Only update master record
         .update({
           current_monitored_season:
-            show.monitoring_type === 'allSeasonPilotRolling' ? 0 : 1,
+            master.monitoring_type === 'allSeasonPilotRolling' ? 0 : 1,
           last_watched_season: 0,
           last_watched_episode: 0,
           updated_at: this.timestamp,
@@ -429,7 +444,7 @@ export async function resetRollingMonitoredShowToOriginal(
         })
 
       this.log.info(
-        `Reset ${show.show_title} to original state: removed ${deletedUserEntries} user entries, reset master record (series_id: ${show.sonarr_series_id}, instance_id: ${show.sonarr_instance_id})`,
+        `Reset ${master.show_title} to original state: removed ${deletedUserEntries} user entries, reset master record (series_id: ${show.sonarr_series_id}, instance_id: ${show.sonarr_instance_id})`,
       )
 
       return deletedUserEntries

--- a/test/integration/routes/session-monitoring.test.ts
+++ b/test/integration/routes/session-monitoring.test.ts
@@ -174,6 +174,39 @@ describe('Session Monitoring Routes - bulk manage', () => {
     expect(master.current_monitored_season).toBe(0)
   })
 
+  it('resets the master to its own baseline when a stale user row has a different type', async () => {
+    const knex = getTestDatabase()
+    const masterId = await insertRollingShow(knex, {
+      show_title: 'Test Show 100',
+      monitoring_type: 'allSeasonPilotRolling',
+      sonarr_series_id: 100,
+      sonarr_instance_id: 1,
+      tvdb_id: '100456',
+      current_monitored_season: 3,
+    })
+    const staleUserId = await insertRollingShow(knex, {
+      show_title: 'Test Show 100',
+      monitoring_type: 'pilotRolling',
+      sonarr_series_id: 100,
+      sonarr_instance_id: 1,
+      tvdb_id: '100456',
+      plex_user_id: 'user-1',
+      plex_username: 'Alice',
+    })
+
+    await app.db.resetRollingMonitoredShowToOriginal(staleUserId)
+
+    const master = await knex('rolling_monitored_shows')
+      .where({ id: masterId })
+      .first()
+    expect(master.current_monitored_season).toBe(0)
+
+    const userEntry = await knex('rolling_monitored_shows')
+      .where({ id: staleUserId })
+      .first()
+    expect(userEntry).toBeUndefined()
+  })
+
   it('changes type without touching Sonarr when reset is not requested', async () => {
     const { masterId, userId } = await seedEnrolledShow()
 


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed rolling monitored show resets to consistently use the master show’s monitoring settings.
  - Ensured stale user-specific entries are removed while the master show’s season tracking resets to the correct baseline.

- **Tests**
  - Added coverage for resets involving outdated user-specific monitoring settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->