### PR TITLE
fix(session-monitor): isolate per-instance failures in rolling fan-out

### DIFF
--- a/src/services/plex-session-monitor.service.ts
+++ b/src/services/plex-session-monitor.service.ts
@@ -239,13 +239,28 @@ export class PlexSessionMonitorService {
       return
     }
 
+    // Isolate per instance so one failure does not skip the rest.
     for (const rollingShow of rollingShows) {
-      await this.handleRollingMonitoredShow(
-        session,
-        rollingShow,
-        result,
-        canTriggerActions,
-      )
+      try {
+        await this.handleRollingMonitoredShow(
+          session,
+          rollingShow,
+          result,
+          canTriggerActions,
+        )
+      } catch (error) {
+        this.log.error(
+          {
+            error,
+            showTitle: rollingShow.show_title,
+            instanceId: rollingShow.sonarr_instance_id,
+          },
+          'Error processing rolling monitored show',
+        )
+        result.errors.push(
+          `Error processing rolling monitored show ${rollingShow.show_title} on instance ${rollingShow.sonarr_instance_id}`,
+        )
+      }
     }
   }
 
@@ -487,20 +502,33 @@ export class PlexSessionMonitorService {
           `Creating per-user rolling show entry for ${globalShow.show_title} on instance ${globalShow.sonarr_instance_id} for user ${session.User.title}`,
         )
 
-        const userEntryId = await this.db.createOrFindUserRollingMonitoredShow(
-          globalShow,
-          session.User.id,
-          session.User.title,
-        )
+        try {
+          const userEntryId =
+            await this.db.createOrFindUserRollingMonitoredShow(
+              globalShow,
+              session.User.id,
+              session.User.title,
+            )
 
-        const byId = await this.db.getRollingMonitoredShowById(userEntryId)
-        if (!byId) {
-          this.log.warn(
-            `Per-user entry (ID: ${userEntryId}) not found after createOrFind for ${globalShow.show_title} (${session.User.title})`,
+          const byId = await this.db.getRollingMonitoredShowById(userEntryId)
+          if (!byId) {
+            this.log.warn(
+              `Per-user entry (ID: ${userEntryId}) not found after createOrFind for ${globalShow.show_title} (${session.User.title})`,
+            )
+            continue
+          }
+          resolved.push(byId)
+        } catch (error) {
+          // Keep entries already resolved on other instances.
+          this.log.error(
+            {
+              error,
+              showTitle: globalShow.show_title,
+              instanceId: globalShow.sonarr_instance_id,
+            },
+            'Error resolving per-user rolling show entry',
           )
-          continue
         }
-        resolved.push(byId)
       }
 
       return resolved

--- a/test/integration/services/plex-session-monitor/progressive-cleanup-workflow.test.ts
+++ b/test/integration/services/plex-session-monitor/progressive-cleanup-workflow.test.ts
@@ -1358,6 +1358,107 @@ describe('Progressive Cleanup → Multi-User Safety Integration', () => {
         2,
       )
     })
+
+    it('keeps processing other instances when one instance fails', async () => {
+      const knex = getTestDatabase()
+
+      await app.updateConfig({
+        plexSessionMonitoring: {
+          enabled: true,
+          filterUsers: [],
+          enableAutoReset: false,
+          remainingEpisodes: 2,
+          inactivityResetDays: 7,
+          autoResetIntervalHours: 24,
+          pollingIntervalMinutes: 15,
+          enableProgressiveCleanup: false,
+        },
+      })
+
+      await knex('sonarr_instances').insert({
+        id: 2,
+        name: '4K Sonarr',
+        base_url: 'http://test-sonarr-4k:8989',
+        api_key: 'test_sonarr_4k_api_key_1234567890abcdef',
+        quality_profile: '1',
+        root_folder: '/data/shows-4k',
+        bypass_ignored: false,
+        season_monitoring: 'firstSeasonRolling',
+        monitor_new_items: 'all',
+        search_on_add: true,
+        tags: JSON.stringify([]),
+        is_default: false,
+        is_enabled: true,
+        synced_instances: JSON.stringify([]),
+        series_type: 'standard',
+        create_season_folders: false,
+      })
+
+      await insertRollingShow(knex, {
+        show_title: 'Stella',
+        monitoring_type: 'firstSeasonRolling',
+        sonarr_series_id: 1566,
+        sonarr_instance_id: 1,
+        tvdb_id: '90210',
+      })
+      await insertRollingShow(knex, {
+        show_title: 'Stella',
+        monitoring_type: 'firstSeasonRolling',
+        sonarr_series_id: 9999,
+        sonarr_instance_id: 2,
+        tvdb_id: '90210',
+      })
+
+      app.plexServerService.getActiveSessions = vi
+        .fn()
+        .mockResolvedValue([makeEpisodeSession({ season: 1, episode: 15 })])
+      app.plexServerService.getShowMetadata = vi
+        .fn()
+        .mockResolvedValue(makeShowMetadata('90210'))
+
+      const healthySonarr = {
+        getSeriesByTvdbId: vi.fn().mockResolvedValue(makeSonarrSeries(9999, 2)),
+        getEpisodes: vi
+          .fn()
+          .mockResolvedValue(makeEpisodesSeason2Unmonitored(9999)),
+        updateSeasonMonitoring: vi.fn().mockResolvedValue(true),
+        updateEpisodesMonitoring: vi.fn().mockResolvedValue(true),
+        deleteEpisodeFiles: vi.fn().mockResolvedValue(true),
+        searchSeason: vi.fn().mockResolvedValue(true),
+      }
+      const failingSonarr = {
+        ...healthySonarr,
+        getSeriesByTvdbId: vi
+          .fn()
+          .mockRejectedValue(new Error('instance 1 unreachable')),
+        searchSeason: vi.fn().mockResolvedValue(true),
+      }
+
+      const sonarrByInstance = new Map([
+        [1, failingSonarr],
+        [2, healthySonarr],
+      ])
+
+      app.sonarrManager.getAllInstances = vi.fn().mockResolvedValue([
+        { id: 1, name: '1080p', baseUrl: 'http://x', apiKey: 'k' },
+        { id: 2, name: '4K', baseUrl: 'http://y', apiKey: 'k' },
+      ])
+      app.sonarrManager.getSonarrService = vi
+        .fn()
+        .mockImplementation(
+          (id: number) =>
+            sonarrByInstance.get(id) as unknown as ReturnType<
+              typeof app.sonarrManager.getSonarrService
+            >,
+        )
+
+      const result = await app.plexSessionMonitor.monitorSessions()
+
+      expect(result.triggeredSearches).toBe(1)
+      expect(result.errors).toHaveLength(1)
+      expect(failingSonarr.searchSeason).not.toHaveBeenCalled()
+      expect(healthySonarr.searchSeason).toHaveBeenCalledWith(9999, 2)
+    })
   })
 })
 


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved monitoring reliability by isolating errors when processing multiple monitored shows.
  * Failures for one show or media service instance no longer prevent other eligible shows and instances from being processed.
  * Added clearer error tracking while allowing healthy instances to continue their searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->