### PR TITLE
feat(ui): move Network Settings to Radarr and Sonarr Instances pages

### DIFF
--- a/src/client/components/AppSidebar.tsx
+++ b/src/client/components/AppSidebar.tsx
@@ -179,7 +179,7 @@ const data = {
       items: [
         {
           title: 'Network Settings',
-          action: 'open-network-settings',
+          action: 'open-network-settings' as const,
         },
         {
           title: 'API Keys',

--- a/src/client/components/AppSidebar.tsx
+++ b/src/client/components/AppSidebar.tsx
@@ -178,10 +178,6 @@ const data = {
       icon: Wrench,
       items: [
         {
-          title: 'Network Settings',
-          action: 'open-network-settings' as const,
-        },
-        {
           title: 'API Keys',
           url: '/utilities/api-keys',
         },
@@ -192,6 +188,10 @@ const data = {
         {
           title: 'Log Viewer',
           url: '/utilities/log-viewer',
+        },
+        {
+          title: 'Network Settings',
+          action: 'open-network-settings' as const,
         },
         {
           title: 'New User Defaults',

--- a/src/client/components/AppSidebar.tsx
+++ b/src/client/components/AppSidebar.tsx
@@ -24,7 +24,6 @@ import * as React from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import pulsarrLogo from '@/assets/images/pulsarr.svg'
 import { DiscordIcon } from '@/components/icons/DiscordIcon'
-import { NetworkConfigCredenza } from '@/components/network-config-credenza'
 import { useSettings } from '@/components/settings-provider'
 import { useTheme } from '@/components/theme-provider'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
@@ -60,14 +59,6 @@ import {
 } from '@/components/ui/sidebar'
 import { UserAvatarSkeleton } from '@/components/ui/user-avatar-skeleton'
 import { useConfigStore } from '@/stores/configStore'
-
-type NavSubItemAction = 'open-network-settings'
-
-type NavSubItem = {
-  title: string
-  url?: string
-  action?: NavSubItemAction
-}
 
 // Navigation data
 const data = {
@@ -190,10 +181,6 @@ const data = {
           url: '/utilities/log-viewer',
         },
         {
-          title: 'Network Settings',
-          action: 'open-network-settings' as const,
-        },
-        {
           title: 'New User Defaults',
           url: '/utilities/new-user-defaults',
         },
@@ -275,7 +262,6 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
     setFullscreenEnabled,
   } = useSettings()
   const [showLogoutAlert, setShowLogoutAlert] = React.useState(false)
-  const [showNetworkConfig, setShowNetworkConfig] = React.useState(false)
   const { currentUser, currentUserLoading, fetchCurrentUser } = useConfigStore()
 
   // Memoized default sections to avoid recalculation
@@ -412,24 +398,6 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
     [navigate, location.pathname, isMobile, setOpenMobile],
   )
 
-  const handleSubItemClick = React.useCallback(
-    (subItem: NavSubItem, e: React.MouseEvent) => {
-      if (subItem.action === 'open-network-settings') {
-        e.preventDefault()
-        setShowNetworkConfig(true)
-        if (isMobile) {
-          setOpenMobile(false)
-        }
-        return
-      }
-
-      if (subItem.url) {
-        handleNavigation(subItem.url, e)
-      }
-    },
-    [handleNavigation, isMobile, setOpenMobile],
-  )
-
   // Memoized navigation items rendering
   const navigationItems = React.useMemo(() => {
     return data.navMain.map((item) =>
@@ -458,13 +426,11 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                   <SidebarMenuSubItem key={subItem.title}>
                     <SidebarMenuSubButton
                       asChild
-                      isActive={
-                        subItem.url ? isActiveRoute(subItem.url) : false
-                      }
+                      isActive={isActiveRoute(subItem.url)}
                     >
                       <a
-                        href={subItem.url ?? '#'}
-                        onClick={(e) => handleSubItemClick(subItem, e)}
+                        href={subItem.url}
+                        onClick={(e) => handleNavigation(subItem.url, e)}
                       >
                         <span>{subItem.title}</span>
                       </a>
@@ -490,7 +456,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         </SidebarMenuItem>
       ),
     )
-  }, [openSections, isActiveRoute, handleSubItemClick, toggleSection])
+  }, [openSections, isActiveRoute, handleNavigation, toggleSection])
 
   // Memoized help resources rendering
   const helpResourceItems = React.useMemo(() => {
@@ -700,10 +666,6 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
       </Sidebar>
 
       <LogoutAlert open={showLogoutAlert} onOpenChange={setShowLogoutAlert} />
-      <NetworkConfigCredenza
-        open={showNetworkConfig}
-        onOpenChange={setShowNetworkConfig}
-      />
     </>
   )
 }

--- a/src/client/components/AppSidebar.tsx
+++ b/src/client/components/AppSidebar.tsx
@@ -40,6 +40,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { NetworkConfigCredenza } from '@/components/network-config-credenza'
 import { LogoutAlert } from '@/components/ui/logout-alert'
 import {
   Sidebar,
@@ -59,6 +60,14 @@ import {
 } from '@/components/ui/sidebar'
 import { UserAvatarSkeleton } from '@/components/ui/user-avatar-skeleton'
 import { useConfigStore } from '@/stores/configStore'
+
+type NavSubItemAction = 'open-network-settings'
+
+type NavSubItem = {
+  title: string
+  url?: string
+  action?: NavSubItemAction
+}
 
 // Navigation data
 const data = {
@@ -169,6 +178,10 @@ const data = {
       icon: Wrench,
       items: [
         {
+          title: 'Network Settings',
+          action: 'open-network-settings',
+        },
+        {
           title: 'API Keys',
           url: '/utilities/api-keys',
         },
@@ -262,6 +275,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
     setFullscreenEnabled,
   } = useSettings()
   const [showLogoutAlert, setShowLogoutAlert] = React.useState(false)
+  const [showNetworkConfig, setShowNetworkConfig] = React.useState(false)
   const { currentUser, currentUserLoading, fetchCurrentUser } = useConfigStore()
 
   // Memoized default sections to avoid recalculation
@@ -398,6 +412,24 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
     [navigate, location.pathname, isMobile, setOpenMobile],
   )
 
+  const handleSubItemClick = React.useCallback(
+    (subItem: NavSubItem, e: React.MouseEvent) => {
+      if (subItem.action === 'open-network-settings') {
+        e.preventDefault()
+        setShowNetworkConfig(true)
+        if (isMobile) {
+          setOpenMobile(false)
+        }
+        return
+      }
+
+      if (subItem.url) {
+        handleNavigation(subItem.url, e)
+      }
+    },
+    [handleNavigation, isMobile, setOpenMobile],
+  )
+
   // Memoized navigation items rendering
   const navigationItems = React.useMemo(() => {
     return data.navMain.map((item) =>
@@ -426,11 +458,13 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                   <SidebarMenuSubItem key={subItem.title}>
                     <SidebarMenuSubButton
                       asChild
-                      isActive={isActiveRoute(subItem.url)}
+                      isActive={
+                        subItem.url ? isActiveRoute(subItem.url) : false
+                      }
                     >
                       <a
-                        href={subItem.url}
-                        onClick={(e) => handleNavigation(subItem.url, e)}
+                        href={subItem.url ?? '#'}
+                        onClick={(e) => handleSubItemClick(subItem, e)}
                       >
                         <span>{subItem.title}</span>
                       </a>
@@ -456,7 +490,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         </SidebarMenuItem>
       ),
     )
-  }, [openSections, isActiveRoute, handleNavigation, toggleSection])
+  }, [openSections, isActiveRoute, handleSubItemClick, toggleSection])
 
   // Memoized help resources rendering
   const helpResourceItems = React.useMemo(() => {
@@ -666,6 +700,10 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
       </Sidebar>
 
       <LogoutAlert open={showLogoutAlert} onOpenChange={setShowLogoutAlert} />
+      <NetworkConfigCredenza
+        open={showNetworkConfig}
+        onOpenChange={setShowNetworkConfig}
+      />
     </>
   )
 }

--- a/src/client/components/AppSidebar.tsx
+++ b/src/client/components/AppSidebar.tsx
@@ -24,6 +24,7 @@ import * as React from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import pulsarrLogo from '@/assets/images/pulsarr.svg'
 import { DiscordIcon } from '@/components/icons/DiscordIcon'
+import { NetworkConfigCredenza } from '@/components/network-config-credenza'
 import { useSettings } from '@/components/settings-provider'
 import { useTheme } from '@/components/theme-provider'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
@@ -40,7 +41,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { NetworkConfigCredenza } from '@/components/network-config-credenza'
 import { LogoutAlert } from '@/components/ui/logout-alert'
 import {
   Sidebar,

--- a/src/client/components/network-config-credenza.tsx
+++ b/src/client/components/network-config-credenza.tsx
@@ -1,3 +1,7 @@
+import type {
+  WebhookResyncInstanceResult,
+  WebhookResyncResponse,
+} from '@root/schemas/config/resync-arr-webhooks.schema'
 import { AlertCircle, Check, Loader2 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
@@ -21,6 +25,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { api } from '@/lib/api'
 import { MIN_LOADING_DELAY } from '@/lib/constants'
 import { useConfigStore } from '@/stores/configStore'
 
@@ -78,9 +83,23 @@ interface NetworkConfigCredenzaProps {
   errorMessage?: string
 }
 
+async function resyncArrWebhooks(): Promise<WebhookResyncResponse> {
+  const response = await fetch(api('/v1/config/resync-arr-webhooks'), {
+    method: 'POST',
+  })
+  if (!response.ok) {
+    throw new Error('Failed to update webhooks in Radarr and Sonarr')
+  }
+  return (await response.json()) as WebhookResyncResponse
+}
+
+type ResyncFailure = WebhookResyncInstanceResult & { app: string }
+
 /**
  * Responsive modal for configuring Pulsarr's network settings (baseUrl and port).
- * Opens when Radarr/Sonarr webhook callbacks fail due to connectivity issues.
+ * Opens automatically when Radarr/Sonarr webhook callbacks fail, or manually from
+ * the instance pages. Saving re-registers the webhook in every configured instance
+ * so the arrs pick up the new address.
  */
 export function NetworkConfigCredenza({
   open,
@@ -97,6 +116,7 @@ export function NetworkConfigCredenza({
   const [saveStatus, setSaveStatus] = useState<'idle' | 'loading' | 'success'>(
     'idle',
   )
+  const [resyncFailures, setResyncFailures] = useState<ResyncFailure[]>([])
 
   // Sync local state when config changes or modal opens
   useEffect(() => {
@@ -121,6 +141,7 @@ export function NetworkConfigCredenza({
 
   const handleSave = async () => {
     setSaveStatus('loading')
+    setResyncFailures([])
     try {
       const minimumLoadingTime = new Promise((resolve) =>
         setTimeout(resolve, MIN_LOADING_DELAY),
@@ -128,10 +149,24 @@ export function NetworkConfigCredenza({
 
       await Promise.all([updateConfig({ baseUrl, port }), minimumLoadingTime])
 
+      // re-register webhooks so the arrs point at the new address; registration fires a test callback
+      const resync = await resyncArrWebhooks()
+      const failures = [
+        ...resync.radarr.map((result) => ({ ...result, app: 'Radarr' })),
+        ...resync.sonarr.map((result) => ({ ...result, app: 'Sonarr' })),
+      ].filter((result) => !result.success)
+
+      if (failures.length > 0) {
+        setResyncFailures(failures)
+        toast.error('Settings saved, but some webhooks could not be updated')
+        setSaveStatus('idle')
+        return
+      }
+
       setSaveStatus('success')
       toast.success('Network settings saved')
 
-      // Show success state briefly before retrying
+      // Show success state briefly before retrying or closing
       await new Promise((resolve) => setTimeout(resolve, MIN_LOADING_DELAY / 2))
 
       // If retry callback provided, attempt to retry the connection
@@ -140,11 +175,12 @@ export function NetworkConfigCredenza({
       // If retry fails with webhook error, webhookError gets set and credenza stays open
       if (onRetry) {
         await onRetry()
+        setSaveStatus('idle')
+      } else {
+        setSaveStatus('idle')
+        onOpenChange(false)
       }
-
-      setSaveStatus('idle')
     } catch (error) {
-      // Config save failed
       toast.error(
         error instanceof Error ? error.message : 'Failed to save settings',
       )
@@ -158,6 +194,7 @@ export function NetworkConfigCredenza({
     onOpenChange(newOpen)
     if (!newOpen) {
       setSaveStatus('idle')
+      setResyncFailures([])
     }
   }
 
@@ -169,9 +206,9 @@ export function NetworkConfigCredenza({
             Configure Network Settings
           </CredenzaTitle>
           <CredenzaDescription>
-            Radarr/Sonarr couldn't reach Pulsarr's webhook endpoint. Configure
-            the address below that Radarr/Sonarr should use to reach Pulsarr
-            (must be resolvable from their perspective, not your browser).
+            {errorMessage || onRetry
+              ? "Radarr/Sonarr couldn't reach Pulsarr's webhook endpoint. Configure the address below that Radarr/Sonarr should use to reach Pulsarr (must be resolvable from their perspective, not your browser)."
+              : 'Configure the address that Radarr/Sonarr should use to reach Pulsarr (must be resolvable from their perspective, not your browser). Saving re-registers the webhook in every configured instance.'}
           </CredenzaDescription>
         </CredenzaHeader>
 
@@ -181,6 +218,22 @@ export function NetworkConfigCredenza({
               <AlertCircle className="h-4 w-4" />
               <AlertTitle>Connection Failed</AlertTitle>
               <AlertDescription>{errorMessage}</AlertDescription>
+            </Alert>
+          )}
+
+          {resyncFailures.length > 0 && (
+            <Alert variant="error">
+              <AlertCircle className="h-4 w-4" />
+              <AlertTitle>Webhook Update Failed</AlertTitle>
+              <AlertDescription>
+                <ul className="list-disc pl-4">
+                  {resyncFailures.map((failure) => (
+                    <li key={`${failure.app}-${failure.instanceId}`}>
+                      {failure.app} - {failure.name}: {failure.message}
+                    </li>
+                  ))}
+                </ul>
+              </AlertDescription>
             </Alert>
           )}
 

--- a/src/client/components/network-config-credenza.tsx
+++ b/src/client/components/network-config-credenza.tsx
@@ -271,8 +271,10 @@ export function NetworkConfigCredenza({
                 <Check className="h-4 w-4" />
                 Saved
               </>
-            ) : (
+            ) : onRetry ? (
               'Save & Retry'
+            ) : (
+              'Save'
             )}
           </Button>
         </CredenzaFooter>

--- a/src/client/components/ui/button.tsx
+++ b/src/client/components/ui/button.tsx
@@ -24,6 +24,8 @@ const buttonVariants = cva(
             'text-main-foreground bg-fun border-2 border-border shadow-shadow hover:translate-x-boxShadowX hover:translate-y-boxShadowY hover:shadow-none',
         error: 'text-main-foreground bg-error border-2 border-border',
         blue:
+            'text-main-foreground bg-blue border-2 border-border shadow-shadow hover:translate-x-boxShadowX hover:translate-y-boxShadowY hover:shadow-none',
+        bluenoShadow:
             'text-main-foreground bg-blue border-2 border-border',
         plex:
             'text-main-foreground bg-plex border-2 border-border shadow-shadow hover:translate-x-boxShadowX hover:translate-y-boxShadowY hover:shadow-none',

--- a/src/client/components/ui/editable-card-header.tsx
+++ b/src/client/components/ui/editable-card-header.tsx
@@ -115,7 +115,7 @@ const EditableCardHeader = ({
               </Button>
             )}
             <Button
-              variant="blue"
+              variant="bluenoShadow"
               onClick={onSave}
               className="flex items-center gap-2"
               disabled={!isDirty || !isValid || isSaving}
@@ -149,7 +149,7 @@ const EditableCardHeader = ({
           {/* Mobile buttons - vertical layout */}
           <div className={`flex flex-col gap-2 ${isMobile ? "flex" : "hidden"}`}>
             <Button
-              variant="blue"
+              variant="bluenoShadow"
               onClick={onSave}
               className="flex items-center justify-center"
               disabled={!isDirty || !isValid || isSaving}

--- a/src/client/components/ui/route-card-header.tsx
+++ b/src/client/components/ui/route-card-header.tsx
@@ -130,7 +130,7 @@ const RouteCardHeader = ({
               </Button>
             )}
             <Button
-              variant="blue"
+              variant="bluenoShadow"
               onClick={onSave}
               className="flex items-center gap-2"
               disabled={!isDirty || !isValid || isSaving}
@@ -164,7 +164,7 @@ const RouteCardHeader = ({
           {/* Mobile buttons - vertical layout */}
           <div className={`flex flex-col gap-2 ${isMobile ? "flex" : "hidden"}`}>
             <Button
-              variant="blue"
+              variant="bluenoShadow"
               onClick={onSave}
               className="flex items-center justify-center"
               disabled={!isDirty || !isValid || isSaving}

--- a/src/client/features/approvals/components/approval-table-toolbar.tsx
+++ b/src/client/features/approvals/components/approval-table-toolbar.tsx
@@ -117,7 +117,7 @@ export function ApprovalTableToolbar({
         {/* Bulk actions button */}
         {table.getSelectedRowModel().rows.length > 0 && onBulkActions && (
           <Button
-            variant="blue"
+            variant="bluenoShadow"
             size="sm"
             className="flex items-center gap-2 h-10"
             onClick={() => {

--- a/src/client/features/approvals/pages/approval-settings.tsx
+++ b/src/client/features/approvals/pages/approval-settings.tsx
@@ -574,7 +574,7 @@ export default function ApprovalSettingsPage() {
                 type="submit"
                 disabled={isSaving || !form.formState.isDirty}
                 className="flex items-center gap-2"
-                variant="blue"
+                variant="bluenoShadow"
               >
                 {isSaving ? (
                   <Loader2 className="h-4 w-4 animate-spin" />

--- a/src/client/features/approvals/pages/quota-settings.tsx
+++ b/src/client/features/approvals/pages/quota-settings.tsx
@@ -655,7 +655,7 @@ export default function QuotaSettingsPage() {
                 type="submit"
                 disabled={isSaving || !form.formState.isDirty}
                 className="flex items-center gap-2"
-                variant="blue"
+                variant="bluenoShadow"
               >
                 {isSaving ? (
                   <Loader2 className="h-4 w-4 animate-spin" />

--- a/src/client/features/content-router/components/accordion-route-card.tsx
+++ b/src/client/features/content-router/components/accordion-route-card.tsx
@@ -910,7 +910,7 @@ const AccordionRouteCard = ({
 
                       {/* Save, cancel and delete buttons */}
                       <Button
-                        variant="blue"
+                        variant="bluenoShadow"
                         onClick={form.handleSubmit(handleSubmit)}
                         className="flex items-center gap-2 h-8"
                         disabled={!isDirty || !isValid || isSaving}

--- a/src/client/features/notifications/components/apprise/apprise-form.tsx
+++ b/src/client/features/notifications/components/apprise/apprise-form.tsx
@@ -307,7 +307,7 @@ export function AppriseForm({ isInitialized }: AppriseFormProps) {
                 !isInitialized
               }
               className="flex items-center gap-2"
-              variant="blue"
+              variant="bluenoShadow"
             >
               {appriseStatus === 'loading' ? (
                 <>

--- a/src/client/features/notifications/components/discord/discord-bot-form.tsx
+++ b/src/client/features/notifications/components/discord/discord-bot-form.tsx
@@ -293,7 +293,7 @@ export function DiscordBotForm({ isInitialized }: DiscordBotFormProps) {
                 !isInitialized
               }
               className="flex items-center gap-2"
-              variant="blue"
+              variant="bluenoShadow"
             >
               {discordBotStatus === 'loading' ? (
                 <>

--- a/src/client/features/notifications/components/discord/discord-webhook-form.tsx
+++ b/src/client/features/notifications/components/discord/discord-webhook-form.tsx
@@ -503,7 +503,7 @@ export function DiscordWebhookForm({ isInitialized }: DiscordWebhookFormProps) {
                 !webhookTestValid // Disable if test hasn't passed
               }
               className="flex items-center gap-2"
-              variant="blue"
+              variant="bluenoShadow"
             >
               {webhookStatus === 'loading' ? (
                 <>

--- a/src/client/features/notifications/components/general/general-settings-form.tsx
+++ b/src/client/features/notifications/components/general/general-settings-form.tsx
@@ -467,7 +467,7 @@ export function GeneralSettingsForm({
                 generalStatus === 'loading' || !isDirty || !isInitialized
               }
               className="flex items-center gap-2"
-              variant="blue"
+              variant="bluenoShadow"
             >
               {generalStatus === 'loading' ? (
                 <>

--- a/src/client/features/notifications/components/public-content/public-content-form.tsx
+++ b/src/client/features/notifications/components/public-content/public-content-form.tsx
@@ -526,7 +526,7 @@ export function PublicContentForm({ isInitialized }: PublicContentFormProps) {
                     !isInitialized
                   }
                   className="flex items-center gap-2"
-                  variant="blue"
+                  variant="bluenoShadow"
                 >
                   {isSubmitting ? (
                     <Loader2 className="h-4 w-4 animate-spin" />

--- a/src/client/features/notifications/components/webhooks/webhook-endpoints-section.tsx
+++ b/src/client/features/notifications/components/webhooks/webhook-endpoints-section.tsx
@@ -83,7 +83,7 @@ export function WebhookEndpointsSection() {
           {/* Button at top when endpoints exist */}
           <Button
             onClick={openCreateModal}
-            variant="blue"
+            variant="bluenoShadow"
             className="flex items-center gap-2"
           >
             <Webhook className="h-4 w-4" />
@@ -117,7 +117,7 @@ export function WebhookEndpointsSection() {
           <p>No webhook endpoints configured</p>
           <Button
             onClick={openCreateModal}
-            variant="blue"
+            variant="bluenoShadow"
             className="mt-4 flex items-center gap-2 mx-auto"
           >
             <Webhook className="h-4 w-4" />

--- a/src/client/features/plex/components/user/user-table.tsx
+++ b/src/client/features/plex/components/user/user-table.tsx
@@ -517,7 +517,7 @@ export default function UserTable({
             <div className="pb-4 flex gap-2">
               {onBulkEdit && (
                 <Button
-                  variant="blue"
+                  variant="bluenoShadow"
                   size="sm"
                   className="flex items-center gap-2"
                   onClick={() => {

--- a/src/client/features/plex/pages/configuration.tsx
+++ b/src/client/features/plex/pages/configuration.tsx
@@ -676,7 +676,7 @@ export default function PlexConfigurationPage() {
                         <div className="mt-auto px-4 pb-3">
                           <Button
                             type="button"
-                            variant="blue"
+                            variant="bluenoShadow"
                             size="sm"
                             className="w-full"
                             onClick={() => {
@@ -722,7 +722,7 @@ export default function PlexConfigurationPage() {
                       !existenceCheckForm.formState.isDirty
                     }
                     className="flex items-center gap-2"
-                    variant="blue"
+                    variant="bluenoShadow"
                   >
                     {isExistenceCheckSaving ? (
                       <Loader2 className="h-4 w-4 animate-spin" />

--- a/src/client/features/radarr/pages/radarr-instances.tsx
+++ b/src/client/features/radarr/pages/radarr-instances.tsx
@@ -1,4 +1,6 @@
+import { Network } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
+import { NetworkConfigCredenza } from '@/components/network-config-credenza'
 import { Button } from '@/components/ui/button'
 import RadarrPageSkeleton from '@/features/radarr/components/instance/radarr-card-skeleton'
 import { InstanceCard as RadarrInstanceCard } from '@/features/radarr/components/instance/radarr-instance-card'
@@ -20,6 +22,7 @@ export default function RadarrInstancesPage() {
 
   const hasInitializedRef = useRef(false)
   const [showInstanceCard, setShowInstanceCard] = useState(false)
+  const [showNetworkConfig, setShowNetworkConfig] = useState(false)
 
   useEffect(() => {
     if (!hasInitializedRef.current) {
@@ -60,14 +63,30 @@ export default function RadarrInstancesPage() {
         {isPlaceholderInstance && !showInstanceCard ? (
           <div className="text-center py-8 text-foreground">
             <p>No Radarr instances configured</p>
-            <Button onClick={addInstance} className="mt-4">
-              Add Your First Instance
-            </Button>
+            <div className="flex justify-center gap-2 mt-4">
+              <Button onClick={addInstance}>Add Your First Instance</Button>
+              <Button
+                variant="blue"
+                className="shadow-shadow hover:translate-x-boxShadowX hover:translate-y-boxShadowY hover:shadow-none"
+                onClick={() => setShowNetworkConfig(true)}
+              >
+                <Network />
+                Network Settings
+              </Button>
+            </div>
           </div>
         ) : (
           <div className="grid gap-6">
-            <div className="flex justify-between items-center">
+            <div className="flex items-center gap-2">
               <Button onClick={addInstance}>Add Instance</Button>
+              <Button
+                variant="blue"
+                className="shadow-shadow hover:translate-x-boxShadowX hover:translate-y-boxShadowY hover:shadow-none"
+                onClick={() => setShowNetworkConfig(true)}
+              >
+                <Network />
+                Network Settings
+              </Button>
             </div>
             <div className="grid gap-4">
               {instances.map((instance) =>
@@ -100,6 +119,11 @@ export default function RadarrInstancesPage() {
           </div>
         )}
       </div>
+
+      <NetworkConfigCredenza
+        open={showNetworkConfig}
+        onOpenChange={setShowNetworkConfig}
+      />
     </div>
   )
 }

--- a/src/client/features/radarr/pages/radarr-instances.tsx
+++ b/src/client/features/radarr/pages/radarr-instances.tsx
@@ -65,11 +65,7 @@ export default function RadarrInstancesPage() {
             <p>No Radarr instances configured</p>
             <div className="flex justify-center gap-2 mt-4">
               <Button onClick={addInstance}>Add Your First Instance</Button>
-              <Button
-                variant="blue"
-                className="shadow-shadow hover:translate-x-boxShadowX hover:translate-y-boxShadowY hover:shadow-none"
-                onClick={() => setShowNetworkConfig(true)}
-              >
+              <Button variant="blue" onClick={() => setShowNetworkConfig(true)}>
                 <Network />
                 Network Settings
               </Button>
@@ -79,11 +75,7 @@ export default function RadarrInstancesPage() {
           <div className="grid gap-6">
             <div className="flex items-center gap-2">
               <Button onClick={addInstance}>Add Instance</Button>
-              <Button
-                variant="blue"
-                className="shadow-shadow hover:translate-x-boxShadowX hover:translate-y-boxShadowY hover:shadow-none"
-                onClick={() => setShowNetworkConfig(true)}
-              >
+              <Button variant="blue" onClick={() => setShowNetworkConfig(true)}>
                 <Network />
                 Network Settings
               </Button>

--- a/src/client/features/sonarr/pages/sonarr-instances.tsx
+++ b/src/client/features/sonarr/pages/sonarr-instances.tsx
@@ -1,4 +1,6 @@
+import { Network } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
+import { NetworkConfigCredenza } from '@/components/network-config-credenza'
 import { Button } from '@/components/ui/button'
 import SonarrPageSkeleton from '@/features/sonarr/components/instance/sonarr-card-skeleton'
 import { InstanceCard } from '@/features/sonarr/components/instance/sonarr-instance-card'
@@ -24,6 +26,7 @@ export default function SonarrInstancesPage() {
 
   const hasInitializedRef = useRef(false)
   const [showInstanceCard, setShowInstanceCard] = useState(false)
+  const [showNetworkConfig, setShowNetworkConfig] = useState(false)
 
   useEffect(() => {
     if (!hasInitializedRef.current) {
@@ -65,14 +68,30 @@ export default function SonarrInstancesPage() {
         {isPlaceholderInstance && !showInstanceCard ? (
           <div className="text-center py-8 text-foreground">
             <p>No Sonarr instances configured</p>
-            <Button onClick={addInstance} className="mt-4">
-              Add Your First Instance
-            </Button>
+            <div className="flex justify-center gap-2 mt-4">
+              <Button onClick={addInstance}>Add Your First Instance</Button>
+              <Button
+                variant="blue"
+                className="shadow-shadow hover:translate-x-boxShadowX hover:translate-y-boxShadowY hover:shadow-none"
+                onClick={() => setShowNetworkConfig(true)}
+              >
+                <Network />
+                Network Settings
+              </Button>
+            </div>
           </div>
         ) : (
           <div className="grid gap-6">
-            <div className="flex justify-between items-center">
+            <div className="flex items-center gap-2">
               <Button onClick={addInstance}>Add Instance</Button>
+              <Button
+                variant="blue"
+                className="shadow-shadow hover:translate-x-boxShadowX hover:translate-y-boxShadowY hover:shadow-none"
+                onClick={() => setShowNetworkConfig(true)}
+              >
+                <Network />
+                Network Settings
+              </Button>
             </div>
             <div className="grid gap-4">
               {instances.map((instance) =>
@@ -107,6 +126,11 @@ export default function SonarrInstancesPage() {
           </div>
         )}
       </div>
+
+      <NetworkConfigCredenza
+        open={showNetworkConfig}
+        onOpenChange={setShowNetworkConfig}
+      />
     </div>
   )
 }

--- a/src/client/features/sonarr/pages/sonarr-instances.tsx
+++ b/src/client/features/sonarr/pages/sonarr-instances.tsx
@@ -70,11 +70,7 @@ export default function SonarrInstancesPage() {
             <p>No Sonarr instances configured</p>
             <div className="flex justify-center gap-2 mt-4">
               <Button onClick={addInstance}>Add Your First Instance</Button>
-              <Button
-                variant="blue"
-                className="shadow-shadow hover:translate-x-boxShadowX hover:translate-y-boxShadowY hover:shadow-none"
-                onClick={() => setShowNetworkConfig(true)}
-              >
+              <Button variant="blue" onClick={() => setShowNetworkConfig(true)}>
                 <Network />
                 Network Settings
               </Button>
@@ -84,11 +80,7 @@ export default function SonarrInstancesPage() {
           <div className="grid gap-6">
             <div className="flex items-center gap-2">
               <Button onClick={addInstance}>Add Instance</Button>
-              <Button
-                variant="blue"
-                className="shadow-shadow hover:translate-x-boxShadowX hover:translate-y-boxShadowY hover:shadow-none"
-                onClick={() => setShowNetworkConfig(true)}
-              >
+              <Button variant="blue" onClick={() => setShowNetworkConfig(true)}>
                 <Network />
                 Network Settings
               </Button>

--- a/src/client/features/utilities/components/api-keys/api-keys-form.tsx
+++ b/src/client/features/utilities/components/api-keys/api-keys-form.tsx
@@ -86,7 +86,7 @@ export function ApiKeysForm({
               type="submit"
               disabled={isCreating || !form.watch('name')?.trim()}
               className="flex items-center gap-2"
-              variant="blue"
+              variant="bluenoShadow"
             >
               <Key className="h-4 w-4" />
               {isCreating ? 'Generating...' : 'Generate API Key'}

--- a/src/client/features/utilities/components/watchlist-exclusions/watchlist-exclusions-table-toolbar.tsx
+++ b/src/client/features/utilities/components/watchlist-exclusions/watchlist-exclusions-table-toolbar.tsx
@@ -79,7 +79,7 @@ export function WatchlistExclusionsTableToolbar({
         <div className="flex items-center justify-start gap-2 flex-wrap">
           {onBulkExclude && excludableSelected.length > 0 && (
             <Button
-              variant="blue"
+              variant="bluenoShadow"
               size="sm"
               className="flex items-center gap-2 h-10"
               onClick={() => onBulkExclude(excludableSelected)}

--- a/src/client/features/utilities/pages/delete-sync.tsx
+++ b/src/client/features/utilities/pages/delete-sync.tsx
@@ -1002,7 +1002,7 @@ export default function DeleteSyncPage() {
                 type="submit"
                 disabled={isSaving || !form.formState.isDirty}
                 className="flex items-center gap-2"
-                variant="blue"
+                variant="bluenoShadow"
               >
                 {isSaving ? (
                   <Loader2 className="h-4 w-4 animate-spin" />

--- a/src/client/features/utilities/pages/new-user-defaults.tsx
+++ b/src/client/features/utilities/pages/new-user-defaults.tsx
@@ -782,7 +782,7 @@ export default function NewUserDefaultsPage() {
                 type="submit"
                 disabled={isSubmitting || !form.formState.isDirty}
                 className="flex items-center gap-2"
-                variant="blue"
+                variant="bluenoShadow"
               >
                 {isSubmitting ? (
                   <Loader2 className="h-4 w-4 animate-spin" />

--- a/src/client/features/utilities/pages/plex-labels.tsx
+++ b/src/client/features/utilities/pages/plex-labels.tsx
@@ -1107,7 +1107,7 @@ export function PlexLabelsPage() {
                     !form.formState.isValid
                   }
                   className="flex items-center gap-2"
-                  variant="blue"
+                  variant="bluenoShadow"
                 >
                   {isSaving ? (
                     <Loader2 className="h-4 w-4 animate-spin" />

--- a/src/client/features/utilities/pages/plex-notifications.tsx
+++ b/src/client/features/utilities/pages/plex-notifications.tsx
@@ -255,7 +255,7 @@ export default function PlexNotificationsPage() {
                         <div className="mt-auto px-4 pb-3">
                           <Button
                             type="button"
-                            variant="blue"
+                            variant="bluenoShadow"
                             size="sm"
                             className="w-full"
                             onClick={() => {
@@ -369,7 +369,7 @@ export default function PlexNotificationsPage() {
                 type="submit"
                 disabled={isSubmitting || !form.formState.isDirty}
                 className="flex items-center gap-2"
-                variant="blue"
+                variant="bluenoShadow"
               >
                 {isSubmitting ? (
                   <Loader2 className="h-4 w-4 animate-spin" />

--- a/src/client/features/utilities/pages/plex-session-monitoring.tsx
+++ b/src/client/features/utilities/pages/plex-session-monitoring.tsx
@@ -215,7 +215,7 @@ export default function PlexSessionMonitoringPage() {
                   type="submit"
                   disabled={isSaving || !form.formState.isDirty}
                   className="flex items-center gap-2"
-                  variant="blue"
+                  variant="bluenoShadow"
                   aria-busy={isSaving}
                 >
                   {isSaving ? (

--- a/src/client/features/utilities/pages/user-tags.tsx
+++ b/src/client/features/utilities/pages/user-tags.tsx
@@ -891,7 +891,7 @@ export function UserTagsPage() {
                   type="submit"
                   disabled={isSaving || !form.formState.isDirty}
                   className="flex items-center gap-2"
-                  variant="blue"
+                  variant="bluenoShadow"
                 >
                   {isSaving ? (
                     <Loader2 className="h-4 w-4 animate-spin" />

--- a/src/routes/v1/config/resync-arr-webhooks.ts
+++ b/src/routes/v1/config/resync-arr-webhooks.ts
@@ -1,0 +1,52 @@
+import {
+  ErrorSchema,
+  WebhookResyncResponseSchema,
+} from '@root/schemas/config/resync-arr-webhooks.schema.js'
+import { logRouteError, stripArrApiErrorPrefix } from '@utils/route-errors.js'
+import type { FastifyPluginAsyncZodOpenApi } from 'fastify-zod-openapi'
+
+const plugin: FastifyPluginAsyncZodOpenApi = async (fastify) => {
+  fastify.post(
+    '/resync-arr-webhooks',
+    {
+      schema: {
+        summary: 'Resync arr webhooks',
+        operationId: 'resyncArrWebhooks',
+        description:
+          'Re-register Pulsarr webhooks in all configured Radarr and Sonarr instances using the current network settings',
+        response: {
+          200: WebhookResyncResponseSchema,
+          500: ErrorSchema,
+        },
+        tags: ['Config'],
+      },
+    },
+    async (request, reply) => {
+      try {
+        const [radarr, sonarr] = await Promise.all([
+          fastify.radarrManager.resyncWebhooks(),
+          fastify.sonarrManager.resyncWebhooks(),
+        ])
+
+        return {
+          success: [...radarr, ...sonarr].every((result) => result.success),
+          radarr: radarr.map((result) => ({
+            ...result,
+            message: stripArrApiErrorPrefix('radarr', result.message),
+          })),
+          sonarr: sonarr.map((result) => ({
+            ...result,
+            message: stripArrApiErrorPrefix('sonarr', result.message),
+          })),
+        }
+      } catch (error) {
+        logRouteError(fastify.log, request, error, {
+          message: 'Error resyncing arr webhooks',
+        })
+        return reply.internalServerError('Unable to resync arr webhooks')
+      }
+    },
+  )
+}
+
+export default plugin

--- a/src/routes/v1/plex/configure-notifications.ts
+++ b/src/routes/v1/plex/configure-notifications.ts
@@ -1,5 +1,5 @@
 import { plexConfigNotificationSchema } from '@schemas/plex/configure-notifications.schema.js'
-import { logRouteError } from '@utils/route-errors.js'
+import { logRouteError, stripArrApiErrorPrefix } from '@utils/route-errors.js'
 import type { FastifyPluginAsyncZodOpenApi } from 'fastify-zod-openapi'
 
 const plugin: FastifyPluginAsyncZodOpenApi = async (fastify, _opts) => {
@@ -88,7 +88,10 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (fastify, _opts) => {
               id: instance.id,
               name: instance.name,
               success: false,
-              message: error instanceof Error ? error.message : 'Unknown error',
+              message:
+                error instanceof Error
+                  ? stripArrApiErrorPrefix('radarr', error.message)
+                  : 'Unknown error',
             })
           }
         }
@@ -148,7 +151,10 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (fastify, _opts) => {
               id: instance.id,
               name: instance.name,
               success: false,
-              message: error instanceof Error ? error.message : 'Unknown error',
+              message:
+                error instanceof Error
+                  ? stripArrApiErrorPrefix('sonarr', error.message)
+                  : 'Unknown error',
             })
           }
         }

--- a/src/routes/v1/plex/get-notification-status.ts
+++ b/src/routes/v1/plex/get-notification-status.ts
@@ -1,7 +1,7 @@
 import type { WebhookNotification } from '@root/types/radarr.types.js'
 import type { WebhookNotification as SonarrWebhookNotification } from '@root/types/sonarr.types.js'
 import { plexGetNotificationStatusSchema } from '@schemas/plex/get-notification-status.schema.js'
-import { logRouteError } from '@utils/route-errors.js'
+import { logRouteError, stripArrApiErrorPrefix } from '@utils/route-errors.js'
 import type { FastifyPluginAsyncZodOpenApi } from 'fastify-zod-openapi'
 
 const plugin: FastifyPluginAsyncZodOpenApi = async (fastify, _opts) => {
@@ -74,7 +74,10 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (fastify, _opts) => {
               id: instance.id,
               name: instance.name,
               success: false,
-              message: error instanceof Error ? error.message : 'Unknown error',
+              message:
+                error instanceof Error
+                  ? stripArrApiErrorPrefix('radarr', error.message)
+                  : 'Unknown error',
             })
           }
         }
@@ -120,7 +123,10 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (fastify, _opts) => {
               id: instance.id,
               name: instance.name,
               success: false,
-              message: error instanceof Error ? error.message : 'Unknown error',
+              message:
+                error instanceof Error
+                  ? stripArrApiErrorPrefix('sonarr', error.message)
+                  : 'Unknown error',
             })
           }
         }

--- a/src/routes/v1/plex/remove-notifications.ts
+++ b/src/routes/v1/plex/remove-notifications.ts
@@ -1,5 +1,5 @@
 import { plexRemoveNotificationSchema } from '@schemas/plex/remove-notifications.schema.js'
-import { logRouteError } from '@utils/route-errors.js'
+import { logRouteError, stripArrApiErrorPrefix } from '@utils/route-errors.js'
 import type { FastifyPluginAsyncZodOpenApi } from 'fastify-zod-openapi'
 
 const plugin: FastifyPluginAsyncZodOpenApi = async (fastify, _opts) => {
@@ -64,7 +64,10 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (fastify, _opts) => {
               id: instance.id,
               name: instance.name,
               success: false,
-              message: error instanceof Error ? error.message : 'Unknown error',
+              message:
+                error instanceof Error
+                  ? stripArrApiErrorPrefix('radarr', error.message)
+                  : 'Unknown error',
             })
           }
         }
@@ -102,7 +105,10 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (fastify, _opts) => {
               id: instance.id,
               name: instance.name,
               success: false,
-              message: error instanceof Error ? error.message : 'Unknown error',
+              message:
+                error instanceof Error
+                  ? stripArrApiErrorPrefix('sonarr', error.message)
+                  : 'Unknown error',
             })
           }
         }

--- a/src/routes/v1/radarr/test-connection.ts
+++ b/src/routes/v1/radarr/test-connection.ts
@@ -3,7 +3,7 @@ import {
   TestConnectionBodySchema,
   TestConnectionResponseSchema,
 } from '@schemas/radarr/test-connection.schema.js'
-import { logRouteError } from '@utils/route-errors.js'
+import { logRouteError, stripArrApiErrorPrefix } from '@utils/route-errors.js'
 import type { FastifyPluginAsyncZodOpenApi } from 'fastify-zod-openapi'
 
 const plugin: FastifyPluginAsyncZodOpenApi = async (fastify) => {
@@ -46,7 +46,7 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (fastify) => {
             : 'Unable to test Radarr connection'
 
         return reply.internalServerError(
-          errorMessage.replace(/Radarr API error: /, ''),
+          stripArrApiErrorPrefix('radarr', errorMessage),
         )
       }
     },

--- a/src/routes/v1/sonarr/test-connection.ts
+++ b/src/routes/v1/sonarr/test-connection.ts
@@ -3,7 +3,7 @@ import {
   TestConnectionBodySchema,
   TestConnectionResponseSchema,
 } from '@schemas/sonarr/test-connection.schema.js'
-import { logRouteError } from '@utils/route-errors.js'
+import { logRouteError, stripArrApiErrorPrefix } from '@utils/route-errors.js'
 import type { FastifyPluginAsyncZodOpenApi } from 'fastify-zod-openapi'
 
 const plugin: FastifyPluginAsyncZodOpenApi = async (fastify) => {
@@ -46,7 +46,7 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (fastify) => {
             : 'Unable to test Sonarr connection'
 
         return reply.internalServerError(
-          errorMessage.replace(/Sonarr API error: /, ''),
+          stripArrApiErrorPrefix('sonarr', errorMessage),
         )
       }
     },

--- a/src/schemas/config/resync-arr-webhooks.schema.ts
+++ b/src/schemas/config/resync-arr-webhooks.schema.ts
@@ -1,0 +1,22 @@
+import { ErrorSchema } from '@root/schemas/common/error.schema.js'
+import { z } from 'zod'
+
+export const WebhookResyncInstanceResultSchema = z.object({
+  instanceId: z.number(),
+  name: z.string(),
+  success: z.boolean(),
+  message: z.string(),
+})
+
+export const WebhookResyncResponseSchema = z.object({
+  success: z.boolean(),
+  radarr: z.array(WebhookResyncInstanceResultSchema),
+  sonarr: z.array(WebhookResyncInstanceResultSchema),
+})
+
+export type WebhookResyncInstanceResult = z.infer<
+  typeof WebhookResyncInstanceResultSchema
+>
+export type WebhookResyncResponse = z.infer<typeof WebhookResyncResponseSchema>
+
+export { ErrorSchema }

--- a/src/services/radarr-manager.service.ts
+++ b/src/services/radarr-manager.service.ts
@@ -1,3 +1,4 @@
+import type { WebhookResyncInstanceResult } from '@root/schemas/config/resync-arr-webhooks.schema.js'
 import type {
   ConnectionTestResult,
   MinimumAvailability,
@@ -18,6 +19,9 @@ import {
   normalizeEndpointWithPath,
 } from '@utils/url.js'
 import type { FastifyBaseLogger, FastifyInstance } from 'fastify'
+import pLimit from 'p-limit'
+
+const WEBHOOK_RESYNC_CONCURRENCY = 4
 
 export class RadarrManagerService {
   private radarrServices: Map<number, RadarrService> = new Map()
@@ -573,5 +577,62 @@ export class RadarrManagerService {
             : 'Unknown error testing connection',
       }
     }
+  }
+
+  async resyncWebhooks(): Promise<WebhookResyncInstanceResult[]> {
+    const instances = await this.fastify.db.getAllRadarrInstances()
+    const limit = pLimit(WEBHOOK_RESYNC_CONCURRENCY)
+
+    return Promise.all(
+      instances
+        .filter((instance) => instance.apiKey !== 'placeholder')
+        .map((instance) =>
+          limit(async (): Promise<WebhookResyncInstanceResult> => {
+            // old service still holds the prior baseUrl/port, so this deletes the stale webhook name
+            const oldService = this.radarrServices.get(instance.id)
+            if (oldService) {
+              try {
+                await oldService.removeWebhook()
+              } catch (error) {
+                this.log.warn(
+                  { error, instanceId: instance.id },
+                  'Failed to remove stale webhook during resync',
+                )
+              }
+            }
+
+            try {
+              const radarrService = new RadarrService(
+                this.baseLog,
+                this.appBaseUrl,
+                this.port,
+                this.fastify,
+              )
+              await radarrService.initialize(instance)
+              this.radarrServices.set(instance.id, radarrService)
+              return {
+                instanceId: instance.id,
+                name: instance.name,
+                success: true,
+                message: 'Webhook re-registered',
+              }
+            } catch (error) {
+              this.log.error(
+                { error, instanceId: instance.id },
+                'Failed to re-register webhook during resync',
+              )
+              return {
+                instanceId: instance.id,
+                name: instance.name,
+                success: false,
+                message:
+                  error instanceof Error
+                    ? error.message
+                    : 'Failed to re-register webhook',
+              }
+            }
+          }),
+        ),
+    )
   }
 }

--- a/src/services/sonarr-manager.service.ts
+++ b/src/services/sonarr-manager.service.ts
@@ -1,3 +1,4 @@
+import type { WebhookResyncInstanceResult } from '@root/schemas/config/resync-arr-webhooks.schema.js'
 import type {
   ExistenceCheckResult,
   InstanceHealthResult,
@@ -17,6 +18,9 @@ import {
   normalizeEndpointWithPath,
 } from '@utils/url.js'
 import type { FastifyBaseLogger, FastifyInstance } from 'fastify'
+import pLimit from 'p-limit'
+
+const WEBHOOK_RESYNC_CONCURRENCY = 4
 
 export class SonarrManagerService {
   private sonarrServices: Map<number, SonarrService> = new Map()
@@ -656,5 +660,62 @@ export class SonarrManagerService {
 
   getSonarrService(id: number): SonarrService | undefined {
     return this.sonarrServices.get(id)
+  }
+
+  async resyncWebhooks(): Promise<WebhookResyncInstanceResult[]> {
+    const instances = await this.fastify.db.getAllSonarrInstances()
+    const limit = pLimit(WEBHOOK_RESYNC_CONCURRENCY)
+
+    return Promise.all(
+      instances
+        .filter((instance) => instance.apiKey !== 'placeholder')
+        .map((instance) =>
+          limit(async (): Promise<WebhookResyncInstanceResult> => {
+            // old service still holds the prior baseUrl/port, so this deletes the stale webhook name
+            const oldService = this.sonarrServices.get(instance.id)
+            if (oldService) {
+              try {
+                await oldService.removeWebhook()
+              } catch (error) {
+                this.log.warn(
+                  { error, instanceId: instance.id },
+                  'Failed to remove stale webhook during resync',
+                )
+              }
+            }
+
+            try {
+              const sonarrService = new SonarrService(
+                this.baseLog,
+                this.appBaseUrl,
+                this.port,
+                this.fastify,
+              )
+              await sonarrService.initialize(instance)
+              this.sonarrServices.set(instance.id, sonarrService)
+              return {
+                instanceId: instance.id,
+                name: instance.name,
+                success: true,
+                message: 'Webhook re-registered',
+              }
+            } catch (error) {
+              this.log.error(
+                { error, instanceId: instance.id },
+                'Failed to re-register webhook during resync',
+              )
+              return {
+                instanceId: instance.id,
+                name: instance.name,
+                success: false,
+                message:
+                  error instanceof Error
+                    ? error.message
+                    : 'Failed to re-register webhook',
+              }
+            }
+          }),
+        ),
+    )
   }
 }

--- a/src/utils/route-errors.ts
+++ b/src/utils/route-errors.ts
@@ -107,6 +107,16 @@ const INIT_FAILURE_PREFIX: Record<ArrService, RegExp> = {
   sonarr: /Failed to initialize Sonarr instance/,
 }
 
+/**
+ * Strip the internal `<Service> API error: ` prefix for user-facing display
+ */
+export function stripArrApiErrorPrefix(
+  service: ArrService,
+  message: string,
+): string {
+  return message.replace(API_ERROR_PREFIX[service], '')
+}
+
 interface ArrInstanceErrorOptions {
   /** The service type for message cleanup */
   service: ArrService
@@ -129,9 +139,10 @@ export function handleArrInstanceError(
 
   if (error instanceof Error) {
     // Clean up error message for user display
-    const userMessage = error.message
-      .replace(API_ERROR_PREFIX[service], '')
-      .replace(INIT_FAILURE_PREFIX[service], 'Failed to save settings')
+    const userMessage = stripArrApiErrorPrefix(service, error.message).replace(
+      INIT_FAILURE_PREFIX[service],
+      'Failed to save settings',
+    )
 
     if (error.message.includes('Authentication')) {
       return reply.unauthorized(userMessage)


### PR DESCRIPTION
Make the existing network config dialog reachable without a webhook failure, and show Save instead of Save & Retry when opened without a retry callback.

Previously you could only edit these settings after a connection test failed. This adds a manual entry point on the Radarr and Sonarr Instances pages, next to **Add Instance**, where that configuration is most relevant.

## Description
- Add a **Network Settings** button (blue, with network icon) next to **Add Instance** on both Radarr and Sonarr Instances pages, including the empty state
- Open the existing `NetworkConfigCredenza` from that button so users can configure Pulsarr’s webhook base URL/port without waiting for a failure
- Remove **Network Settings** from the Utilities sidebar
- Keep the automatic dialog that still appears on webhook connection test failures from instance cards (with Save & Retry)

## Type of Change
- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)

<img width="1800" height="1169" alt="image" src="https://github.com/user-attachments/assets/8bac0e65-ee44-4116-bad2-6696b4f952c4" />


## Testing Performed
- [x] Open Radarr → Instances and confirm Network Settings appears to the right of Add Instance
- [x] Open Sonarr → Instances and confirm the same
- [x] Click Network Settings and verify the dialog opens with Save (not Save & Retry)
- [x] Confirm Network Settings is no longer under Utilities in the sidebar
- [x] With no instances configured, confirm both empty-state buttons work
- [x] Trigger a webhook connection failure and confirm the error-driven dialog with Save & Retry still appears

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a “Network Settings” workflow to Radarr and Sonarr instance pages (including empty and populated states).
  * Saving network settings now triggers webhook re-registration, using a dedicated webhook resync flow.

* **Bug Fixes**
  * Improved save feedback with clearer success timing, optional “Save & Retry,” and a “Webhook Update Failed” alert listing per-instance issues.
  * Standardized user-facing error messages by removing service-specific API prefixes.

* **Style**
  * Updated primary/submit button styling across the UI to use `bluenoShadow` instead of `blue`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->