### PR TITLE
fix(installers): add windows firewall rule and poll SCM for service s…

### DIFF
--- a/scripts/build-native.ts
+++ b/scripts/build-native.ts
@@ -479,9 +479,10 @@ if %ERRORLEVEL% EQU 0 (
     echo Existing Pulsarr service detected, updating...
     echo Stopping service...
     pulsarr-service.exe stop
+    call :waitstop
     echo Removing old service registration...
     pulsarr-service.exe uninstall
-    timeout /t 2 /nobreak >nul
+    call :waitgone
 )
 
 echo Installing Pulsarr as a Windows service...
@@ -495,13 +496,31 @@ echo   pulsarr-service.exe stop
 echo   pulsarr-service.exe start
 echo   pulsarr-service.exe restart
 pause
+exit /b
+
+rem WinSW stop returns before the service reports STOPPED; poll SCM instead of sleeping
+:waitstop
+for /l %%I in (1,1,30) do (
+    sc query pulsarr >nul 2>&1 || exit /b
+    sc query pulsarr | find "STOPPED" >nul && exit /b
+    timeout /t 1 /nobreak >nul
+)
+exit /b
+
+rem SCM drops the registration only after all handles close
+:waitgone
+for /l %%I in (1,1,10) do (
+    sc query pulsarr >nul 2>&1 || exit /b
+    timeout /t 1 /nobreak >nul
+)
+exit /b
 `
 
 const UNINSTALL_SERVICE_BAT = `@echo off
 cd /d "%~dp0"
 echo Stopping Pulsarr service...
 pulsarr-service.exe stop
-timeout /t 2 /nobreak >nul
+call :waitstop
 echo Uninstalling Pulsarr service...
 pulsarr-service.exe uninstall
 if errorlevel 1 (
@@ -512,6 +531,16 @@ if errorlevel 1 (
 echo.
 echo Pulsarr service has been removed.
 pause
+exit /b
+
+rem WinSW stop returns before the service reports STOPPED; poll SCM instead of sleeping
+:waitstop
+for /l %%I in (1,1,30) do (
+    sc query pulsarr >nul 2>&1 || exit /b
+    sc query pulsarr | find "STOPPED" >nul && exit /b
+    timeout /t 1 /nobreak >nul
+)
+exit /b
 `
 
 const README_LINUX = `# Pulsarr - Native Install (Linux)

--- a/scripts/installers/windows/pulsarr-baseline.iss
+++ b/scripts/installers/windows/pulsarr-baseline.iss
@@ -53,6 +53,7 @@ Name: "service"; Description: "Install as Windows Service"; Types: full
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 Name: "startafterinstall"; Description: "Start Pulsarr after installation"; GroupDescription: "Startup:"; Flags: checkedonce
+Name: "firewall"; Description: "Allow access from other devices on your network (adds a Windows Firewall rule)"; GroupDescription: "Network Access:"; Flags: checkedonce
 
 [InstallDelete]
 ; Clear the code dirs before copying so files removed between releases can't linger.
@@ -109,6 +110,12 @@ Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; WorkingDi
 [Run]
 ; Create .env from template if it doesn't exist
 Filename: "cmd.exe"; Parameters: "/c if not exist ""{#MyAppDataDir}\.env"" copy ""{app}\.env.example"" ""{#MyAppDataDir}\.env"""; Flags: runhidden
+; Services never get the firewall consent prompt, so remote access needs an
+; explicit rule. netsh add stacks duplicates by name; delete clears all matches.
+Filename: "{sys}\netsh.exe"; Parameters: "advfirewall firewall delete rule name=""Pulsarr"""; Flags: runhidden; Tasks: firewall
+Filename: "{sys}\netsh.exe"; Parameters: "advfirewall firewall add rule name=""Pulsarr"" dir=in action=allow program=""{app}\bun.exe"" protocol=TCP profile=private,domain remoteip=localsubnet"; Flags: runhidden; Tasks: firewall
+; Task-gated entries only run when selected; unchecking must remove the old rule
+Filename: "{sys}\netsh.exe"; Parameters: "advfirewall firewall delete rule name=""Pulsarr"""; Flags: runhidden; Check: not WizardIsTaskSelected('firewall')
 ; Install and start service
 Filename: "{app}\pulsarr-service.exe"; Parameters: "install"; StatusMsg: "Installing Windows service..."; Flags: runhidden; Components: service
 Filename: "{app}\pulsarr-service.exe"; Parameters: "start"; StatusMsg: "Starting Pulsarr service..."; Flags: runhidden; Components: service; Tasks: startafterinstall
@@ -121,6 +128,7 @@ Filename: "{app}\pulsarr-service.exe"; Parameters: "stop"; Flags: runhidden; Run
 ; WinSW stop can return before the process tree exits
 Filename: "cmd.exe"; Parameters: "/c timeout /t 2 /nobreak"; Flags: runhidden; RunOnceId: "StopSettle"
 Filename: "{app}\pulsarr-service.exe"; Parameters: "uninstall"; Flags: runhidden; RunOnceId: "UninstallService"
+Filename: "{sys}\netsh.exe"; Parameters: "advfirewall firewall delete rule name=""Pulsarr"""; Flags: runhidden; RunOnceId: "RemoveFirewallRule"
 
 [UninstallDelete]
 ; Clean up service wrapper logs if any

--- a/scripts/installers/windows/pulsarr-baseline.iss
+++ b/scripts/installers/windows/pulsarr-baseline.iss
@@ -53,7 +53,7 @@ Name: "service"; Description: "Install as Windows Service"; Types: full
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 Name: "startafterinstall"; Description: "Start Pulsarr after installation"; GroupDescription: "Startup:"; Flags: checkedonce
-Name: "firewall"; Description: "Allow access from other devices on your network (adds a Windows Firewall rule)"; GroupDescription: "Network Access:"; Flags: checkedonce
+Name: "firewall"; Description: "Allow access from other devices on your network (adds a Windows Firewall rule)"; GroupDescription: "Network Access:"
 
 [InstallDelete]
 ; Clear the code dirs before copying so files removed between releases can't linger.

--- a/scripts/installers/windows/pulsarr.iss
+++ b/scripts/installers/windows/pulsarr.iss
@@ -53,6 +53,7 @@ Name: "service"; Description: "Install as Windows Service"; Types: full
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 Name: "startafterinstall"; Description: "Start Pulsarr after installation"; GroupDescription: "Startup:"; Flags: checkedonce
+Name: "firewall"; Description: "Allow access from other devices on your network (adds a Windows Firewall rule)"; GroupDescription: "Network Access:"; Flags: checkedonce
 
 [InstallDelete]
 ; Clear the code dirs before copying so files removed between releases can't linger.
@@ -109,6 +110,12 @@ Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; WorkingDi
 [Run]
 ; Create .env from template if it doesn't exist
 Filename: "cmd.exe"; Parameters: "/c if not exist ""{#MyAppDataDir}\.env"" copy ""{app}\.env.example"" ""{#MyAppDataDir}\.env"""; Flags: runhidden
+; Services never get the firewall consent prompt, so remote access needs an
+; explicit rule. netsh add stacks duplicates by name; delete clears all matches.
+Filename: "{sys}\netsh.exe"; Parameters: "advfirewall firewall delete rule name=""Pulsarr"""; Flags: runhidden; Tasks: firewall
+Filename: "{sys}\netsh.exe"; Parameters: "advfirewall firewall add rule name=""Pulsarr"" dir=in action=allow program=""{app}\bun.exe"" protocol=TCP profile=private,domain remoteip=localsubnet"; Flags: runhidden; Tasks: firewall
+; Task-gated entries only run when selected; unchecking must remove the old rule
+Filename: "{sys}\netsh.exe"; Parameters: "advfirewall firewall delete rule name=""Pulsarr"""; Flags: runhidden; Check: not WizardIsTaskSelected('firewall')
 ; Install and start service
 Filename: "{app}\pulsarr-service.exe"; Parameters: "install"; StatusMsg: "Installing Windows service..."; Flags: runhidden; Components: service
 Filename: "{app}\pulsarr-service.exe"; Parameters: "start"; StatusMsg: "Starting Pulsarr service..."; Flags: runhidden; Components: service; Tasks: startafterinstall
@@ -121,6 +128,7 @@ Filename: "{app}\pulsarr-service.exe"; Parameters: "stop"; Flags: runhidden; Run
 ; WinSW stop can return before the process tree exits
 Filename: "cmd.exe"; Parameters: "/c timeout /t 2 /nobreak"; Flags: runhidden; RunOnceId: "StopSettle"
 Filename: "{app}\pulsarr-service.exe"; Parameters: "uninstall"; Flags: runhidden; RunOnceId: "UninstallService"
+Filename: "{sys}\netsh.exe"; Parameters: "advfirewall firewall delete rule name=""Pulsarr"""; Flags: runhidden; RunOnceId: "RemoveFirewallRule"
 
 [UninstallDelete]
 ; Clean up service wrapper logs if any

--- a/scripts/installers/windows/pulsarr.iss
+++ b/scripts/installers/windows/pulsarr.iss
@@ -53,7 +53,7 @@ Name: "service"; Description: "Install as Windows Service"; Types: full
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 Name: "startafterinstall"; Description: "Start Pulsarr after installation"; GroupDescription: "Startup:"; Flags: checkedonce
-Name: "firewall"; Description: "Allow access from other devices on your network (adds a Windows Firewall rule)"; GroupDescription: "Network Access:"; Flags: checkedonce
+Name: "firewall"; Description: "Allow access from other devices on your network (adds a Windows Firewall rule)"; GroupDescription: "Network Access:"
 
 [InstallDelete]
 ; Clear the code dirs before copying so files removed between releases can't linger.


### PR DESCRIPTION
…top in bat scripts

## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional Windows Firewall “Network Access” setting during installation to allow inbound TCP traffic to the app on the local subnet (private/domain profiles).
  * When enabled, the installer creates a Pulsarr firewall allow rule; when disabled, any existing rule is removed. Uninstallation also removes the rule.
* **Bug Fixes**
  * Improved Windows service installation and removal by waiting for the service to fully stop and unregister (replacing fixed delays), reducing timing-related failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->