### PR TITLE
fix(content-router): clear stale tags on rule type switch

### DIFF
--- a/src/routes/v1/content-router/content-router-management.ts
+++ b/src/routes/v1/content-router/content-router-management.ts
@@ -445,11 +445,12 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (fastify) => {
           } else {
             updatesAsRouterRule.monitor = null
           }
-          // Profile and folder ids belong to the old service unless resupplied
+          // Profile, folder, and tag ids belong to the old service unless resupplied
           if (updates.quality_profile === undefined)
             updatesAsRouterRule.quality_profile = null
           if (updates.root_folder === undefined)
             updatesAsRouterRule.root_folder = null
+          if (updates.tags === undefined) updatesAsRouterRule.tags = []
         }
 
         if (updates.condition) {

--- a/src/services/sonarr-manager.service.ts
+++ b/src/services/sonarr-manager.service.ts
@@ -412,12 +412,6 @@ export class SonarrManagerService {
   }
 
   /**
-   * Get a specific Sonarr service instance by ID
-   * @param instanceId The ID of the Sonarr instance
-   * @returns The SonarrService instance or undefined if not found
-   */
-
-  /**
    * Efficiently check if a series exists using TVDB lookup
    * @param instanceId - The Sonarr instance ID
    * @param tvdbId - The TVDB ID to check

--- a/test/integration/routes/content-router.test.ts
+++ b/test/integration/routes/content-router.test.ts
@@ -242,7 +242,7 @@ describe('Content Router Rules API', () => {
       expect(row.series_type).toBeNull()
     })
 
-    it('clears quality profile and root folder on a type switch when not resupplied', async () => {
+    it('clears quality profile, root folder, and tags on a type switch when not resupplied', async () => {
       const createRes = await app.inject({
         method: 'POST',
         url: '/v1/content-router/rules',
@@ -250,6 +250,7 @@ describe('Content Router Rules API', () => {
           ...sonarrRule,
           quality_profile: 5,
           root_folder: '/data/shows',
+          tags: ['10', '20'],
         },
       })
       const id = createRes.json().rule.id
@@ -265,6 +266,7 @@ describe('Content Router Rules API', () => {
       const row = await knex('router_rules').where({ id }).first()
       expect(row.quality_profile).toBeNull()
       expect(row.root_folder).toBeNull()
+      expect(JSON.parse(row.tags)).toEqual([])
     })
 
     it('clears monitor when a rule switches to sonarr', async () => {


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Content Router rules so tags are cleared when switching the target type unless new tags are provided.
  - Prevents outdated tags and other target-specific settings from carrying over after a rule type change.

- **Tests**
  - Expanded integration coverage to verify tags are reset correctly when switching target types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->