### PR TITLE
fix(better-sqlite3-bun): align shim defaults and statement semantics …

### DIFF
--- a/packages/better-sqlite3-bun/index.ts
+++ b/packages/better-sqlite3-bun/index.ts
@@ -2,6 +2,7 @@ import { Database as BunDatabase } from 'bun:sqlite'
 
 interface DatabaseOptions {
   readonly?: boolean
+  fileMustExist?: boolean
   timeout?: number
   verbose?: (sql: string) => void
 }
@@ -15,29 +16,36 @@ class Statement {
   private stmt: ReturnType<BunDatabase['prepare']>
   private verbose?: (sql: string) => void
   private boundParams?: unknown[]
-  private rawMode: boolean
+  private rawMode = false
 
   constructor(
     stmt: ReturnType<BunDatabase['prepare']>,
     verbose?: (sql: string) => void,
-    boundParams?: unknown[],
-    rawMode = false,
   ) {
     this.stmt = stmt
     this.verbose = verbose
-    this.boundParams = boundParams
-    this.rawMode = rawMode
   }
 
   get reader(): boolean {
     return this.stmt.columnNames.length > 0
   }
 
+  // better-sqlite3 treats params passed after bind() as an error
+  private resolveParams(params: unknown[]): unknown[] {
+    if (this.boundParams) {
+      if (params.length > 0) {
+        throw new TypeError('This statement already has bound parameters')
+      }
+      return this.boundParams
+    }
+    return params
+  }
+
   run(...params: unknown[]): RunResult {
     if (this.verbose) {
       this.verbose(this.stmt.toString())
     }
-    const finalParams = this.boundParams || params
+    const finalParams = this.resolveParams(params)
     const result = this.stmt.run(...finalParams)
     return {
       changes: result.changes,
@@ -49,7 +57,7 @@ class Statement {
     if (this.verbose) {
       this.verbose(this.stmt.toString())
     }
-    const finalParams = this.boundParams || params
+    const finalParams = this.resolveParams(params)
     if (this.rawMode) {
       const results = this.stmt.values(...finalParams) as unknown[][]
       return results[0]
@@ -61,7 +69,7 @@ class Statement {
     if (this.verbose) {
       this.verbose(this.stmt.toString())
     }
-    const finalParams = this.boundParams || params
+    const finalParams = this.resolveParams(params)
     if (this.rawMode) {
       return this.stmt.values(...finalParams) as unknown[][]
     }
@@ -74,7 +82,7 @@ class Statement {
     if (this.verbose) {
       this.verbose(this.stmt.toString())
     }
-    const finalParams = this.boundParams || params
+    const finalParams = this.resolveParams(params)
     if (this.rawMode) {
       // Bun has no streaming API for arrays - must buffer
       const results = this.stmt.values(...finalParams) as unknown[][]
@@ -89,38 +97,56 @@ class Statement {
     }
   }
 
-  bind(...params: unknown[]): Statement {
-    return new Statement(this.stmt, this.verbose, params, this.rawMode)
+  bind(...params: unknown[]): this {
+    if (this.boundParams) {
+      throw new TypeError(
+        'The bind() method can only be invoked once per statement object',
+      )
+    }
+    this.boundParams = params
+    return this
   }
 
-  raw(enabled = true): Statement {
-    return new Statement(this.stmt, this.verbose, this.boundParams, enabled)
+  raw(toggle = true): this {
+    this.rawMode = toggle !== false
+    return this
+  }
+
+  safeIntegers(toggle = true): this {
+    this.stmt.safeIntegers(toggle !== false)
+    return this
   }
 }
 
 class Database {
   private db: BunDatabase
   private verbose?: (sql: string) => void
+  private safeIntegersDefault = false
 
   constructor(path: string, options: DatabaseOptions = {}) {
     this.db = new BunDatabase(path, {
       readwrite: !options.readonly,
       readonly: options.readonly,
-      create: true,
+      // better-sqlite3 never creates in readonly mode and throws on a
+      // missing file when fileMustExist is set
+      create: !options.readonly && !options.fileMustExist,
     })
     this.verbose = options.verbose
 
-    // Apply busy timeout via PRAGMA (Bun's constructor doesn't support timeout directly)
-    if (options.timeout !== undefined) {
-      if (!Number.isFinite(options.timeout) || options.timeout < 0) {
-        throw new TypeError('timeout must be a non-negative finite number')
-      }
-      this.db.exec(`PRAGMA busy_timeout = ${options.timeout}`)
+    // better-sqlite3 defaults to a 5s busy timeout; Bun's constructor has
+    // no timeout option and its busy_timeout default is 0
+    const timeout = options.timeout ?? 5000
+    if (!Number.isFinite(timeout) || timeout < 0) {
+      throw new TypeError('timeout must be a non-negative finite number')
     }
+    this.db.exec(`PRAGMA busy_timeout = ${timeout}`)
   }
 
   prepare(sql: string): Statement {
     const stmt = this.db.prepare(sql)
+    if (this.safeIntegersDefault) {
+      stmt.safeIntegers(true)
+    }
     return new Statement(stmt, this.verbose)
   }
 
@@ -139,6 +165,11 @@ class Database {
 
   transaction<T extends (...args: unknown[]) => unknown>(fn: T): T {
     return this.db.transaction(fn) as unknown as T
+  }
+
+  defaultSafeIntegers(toggle = true): this {
+    this.safeIntegersDefault = toggle !== false
+    return this
   }
 }
 

--- a/packages/better-sqlite3-bun/index.ts
+++ b/packages/better-sqlite3-bun/index.ts
@@ -124,6 +124,13 @@ class Database {
   private safeIntegersDefault = false
 
   constructor(path: string, options: DatabaseOptions = {}) {
+    // better-sqlite3 defaults to a 5s busy timeout; Bun's constructor has
+    // no timeout option and its busy_timeout default is 0
+    const timeout = options.timeout ?? 5000
+    if (!Number.isFinite(timeout) || timeout < 0) {
+      throw new TypeError('timeout must be a non-negative finite number')
+    }
+
     this.db = new BunDatabase(path, {
       readwrite: !options.readonly,
       readonly: options.readonly,
@@ -133,12 +140,6 @@ class Database {
     })
     this.verbose = options.verbose
 
-    // better-sqlite3 defaults to a 5s busy timeout; Bun's constructor has
-    // no timeout option and its busy_timeout default is 0
-    const timeout = options.timeout ?? 5000
-    if (!Number.isFinite(timeout) || timeout < 0) {
-      throw new TypeError('timeout must be a non-negative finite number')
-    }
     this.db.exec(`PRAGMA busy_timeout = ${timeout}`)
   }
 

--- a/test/unit/packages/better-sqlite3-bun.test.ts
+++ b/test/unit/packages/better-sqlite3-bun.test.ts
@@ -1,0 +1,173 @@
+import { existsSync, rmSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+interface ShimStatement {
+  reader: boolean
+  run(...params: unknown[]): {
+    changes: number
+    lastInsertRowid: number | bigint
+  }
+  get(...params: unknown[]): unknown
+  all(...params: unknown[]): unknown[]
+  bind(...params: unknown[]): ShimStatement
+  raw(toggle?: boolean): ShimStatement
+  safeIntegers(toggle?: boolean): ShimStatement
+}
+
+interface ShimDatabase {
+  prepare(sql: string): ShimStatement
+  exec(sql: string): ShimDatabase
+  close(): ShimDatabase
+  defaultSafeIntegers(toggle?: boolean): ShimDatabase
+}
+
+interface ShimDatabaseConstructor {
+  new (
+    path: string,
+    options?: {
+      readonly?: boolean
+      fileMustExist?: boolean
+      timeout?: number
+    },
+  ): ShimDatabase
+}
+
+// Not a static import - that would pull bun:sqlite types this tsconfig lacks
+const require = createRequire(import.meta.url)
+const Database =
+  require('../../../packages/better-sqlite3-bun/index.js') as ShimDatabaseConstructor
+
+describe('better-sqlite3-bun shim', () => {
+  const tempFiles: string[] = []
+
+  const tempPath = () => {
+    const p = join(tmpdir(), `shim-test-${process.pid}-${tempFiles.length}.db`)
+    tempFiles.push(p)
+    return p
+  }
+
+  afterEach(() => {
+    for (const p of tempFiles.splice(0)) {
+      for (const suffix of ['', '-wal', '-shm']) {
+        if (existsSync(p + suffix)) rmSync(p + suffix)
+      }
+    }
+  })
+
+  describe('constructor', () => {
+    it('defaults busy_timeout to 5000 like better-sqlite3', () => {
+      const db = new Database(':memory:')
+      expect(db.prepare('PRAGMA busy_timeout').get()).toEqual({ timeout: 5000 })
+      db.close()
+    })
+
+    it('applies an explicit timeout option', () => {
+      const db = new Database(':memory:', { timeout: 250 })
+      expect(db.prepare('PRAGMA busy_timeout').get()).toEqual({ timeout: 250 })
+      db.close()
+    })
+
+    it('rejects invalid timeout values', () => {
+      expect(() => new Database(':memory:', { timeout: -1 })).toThrow(TypeError)
+      expect(() => new Database(':memory:', { timeout: Number.NaN })).toThrow(
+        TypeError,
+      )
+    })
+
+    it('throws on a missing file when fileMustExist is set', () => {
+      expect(() => new Database(tempPath(), { fileMustExist: true })).toThrow()
+    })
+
+    it('does not create a missing file in readonly mode', () => {
+      const p = tempPath()
+      expect(() => new Database(p, { readonly: true })).toThrow()
+      expect(existsSync(p)).toBe(false)
+    })
+
+    it('creates a missing file by default', () => {
+      const p = tempPath()
+      const db = new Database(p)
+      db.exec('CREATE TABLE t (id INTEGER)')
+      db.close()
+      expect(existsSync(p)).toBe(true)
+    })
+  })
+
+  describe('statement', () => {
+    it('reports run() result shape and reader flag', () => {
+      const db = new Database(':memory:')
+      db.exec('CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)')
+      const insert = db.prepare('INSERT INTO t (name) VALUES (?)')
+      expect(insert.reader).toBe(false)
+
+      const result = insert.run('a')
+      expect(result.changes).toBe(1)
+      expect(result.lastInsertRowid).toBe(1)
+
+      const select = db.prepare('SELECT * FROM t')
+      expect(select.reader).toBe(true)
+      db.close()
+    })
+
+    it('bind() locks parameters in place', () => {
+      const db = new Database(':memory:')
+      const stmt = db.prepare('SELECT ? as a').bind(7)
+      expect(stmt.get()).toEqual({ a: 7 })
+      db.close()
+    })
+
+    it('bind() throws when invoked twice', () => {
+      const db = new Database(':memory:')
+      const stmt = db.prepare('SELECT ? as a').bind(7)
+      expect(() => stmt.bind(8)).toThrow(TypeError)
+      db.close()
+    })
+
+    it('throws when params are passed after bind()', () => {
+      const db = new Database(':memory:')
+      const stmt = db.prepare('SELECT ? as a').bind(7)
+      expect(() => stmt.get(8)).toThrow(TypeError)
+      expect(() => stmt.all(8)).toThrow(TypeError)
+      db.close()
+    })
+
+    it('raw() mutates the statement in place', () => {
+      const db = new Database(':memory:')
+      const stmt = db.prepare('SELECT 1 as a, 2 as b')
+      stmt.raw()
+      expect(stmt.all()).toEqual([[1, 2]])
+      expect(stmt.get()).toEqual([1, 2])
+      stmt.raw(false)
+      expect(stmt.get()).toEqual({ a: 1, b: 2 })
+      db.close()
+    })
+
+    it('safeIntegers() returns bigints per statement', () => {
+      const db = new Database(':memory:')
+      const stmt = db.prepare('SELECT 9007199254740993 as big').safeIntegers()
+      expect(stmt.get()).toEqual({ big: 9007199254740993n })
+      db.close()
+    })
+  })
+
+  describe('database', () => {
+    it('defaultSafeIntegers() applies to subsequently prepared statements', () => {
+      const db = new Database(':memory:')
+      db.defaultSafeIntegers()
+      expect(db.prepare('SELECT 2 as x').get()).toEqual({ x: 2n })
+
+      db.defaultSafeIntegers(false)
+      expect(db.prepare('SELECT 2 as x').get()).toEqual({ x: 2 })
+      db.close()
+    })
+
+    it('exec() and close() are chainable', () => {
+      const db = new Database(':memory:')
+      expect(db.exec('CREATE TABLE t (id INTEGER)')).toBe(db)
+      expect(db.close()).toBe(db)
+    })
+  })
+})


### PR DESCRIPTION
…with better-sqlite3

## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added options to require existing database files and configure read-only access.
  * Added safe-integer handling at both database and statement levels.
  * Improved statement parameter binding and method chaining.
  * Added validation for busy timeout settings.

* **Bug Fixes**
  * Improved database creation behavior and parameter validation.
  * Updated statement execution methods for more consistent bound-parameter handling.

* **Tests**
  * Added comprehensive coverage for configuration, execution, binding, integer handling, and chainable methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->