### PR TITLE
fix(renovate): disable digest pinning for trivy version input

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -242,6 +242,13 @@
       "pinDigests": true
     },
     {
+      "description": "Trivy is a version input on setup-trivy/trivy-action, not a uses ref - digest pinning cannot be written there and errors the branch",
+      "matchDepNames": [
+        "aquasecurity/trivy"
+      ],
+      "pinDigests": false
+    },
+    {
       "description": "Auto-merge patch/minor GitHub Actions updates after stability period",
       "matchManagers": [
         "github-actions"


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency maintenance settings to handle Trivy version updates correctly.
  * Prevented update errors for Trivy configurations supplied as version inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->