### PR TITLE
fix: rate-limit key guard, health schema idiom, and pref key reload

### DIFF
--- a/src/client/lib/prefs.ts
+++ b/src/client/lib/prefs.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 /**
  * A persisted UI preference: a storage key, a typed fallback, and a
@@ -42,6 +42,11 @@ export function writePref<T>(def: PrefDef<T>, value: T): void {
  */
 export function usePref<T>(def: PrefDef<T>): [T, (value: T) => void] {
   const [value, setValue] = useState<T>(() => readPref(def))
+
+  // useState initializes only once - reload when the def changes keys
+  useEffect(() => {
+    setValue(readPref(def))
+  }, [def])
 
   const set = useCallback(
     (next: T) => {

--- a/src/plugins/external/rate-limit.ts
+++ b/src/plugins/external/rate-limit.ts
@@ -6,6 +6,8 @@ const createRateLimitConfig = (fastify: FastifyInstance) => {
   return {
     max: fastify.config.rateLimitMax,
     timeWindow: '1 minute',
+    // the default generator crashes on aborted sockets where req.ip is undefined
+    keyGenerator: (req: FastifyRequest) => req.ip ?? 'unknown',
     allowList: (req: FastifyRequest) => {
       // Skip rate limiting for static assets (handles both root and prefixed paths)
       // Use pathname only to prevent query string manipulation bypasses

--- a/src/schemas/health/health.schema.ts
+++ b/src/schemas/health/health.schema.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 export const HealthCheckResponseSchema = z.object({
   status: z.enum(['healthy', 'unhealthy']),
-  timestamp: z.string().datetime(),
+  timestamp: z.iso.datetime(),
   checks: z.object({
     database: z.enum(['ok', 'failed']),
   }),


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preference settings now reload correctly when their definitions change.
  * Improved rate-limit handling for requests with missing connection information.
  * Health check timestamps now use stricter ISO datetime validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->