### PR TITLE
chore(deps): pin codegen typescript to 5.9.3 and block majors in renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -289,6 +289,16 @@
       "allowedVersions": "< 7.0.0"
     },
     {
+      "description": "codegen typescript must satisfy openapi-typescript's ^5.x peer (TS5 JS compiler API; native TS has none until 7.1) - root typescript is unaffected",
+      "matchFileNames": [
+        "scripts/openapi-codegen/package.json"
+      ],
+      "matchPackageNames": [
+        "typescript"
+      ],
+      "allowedVersions": "< 6.0.0"
+    },
+    {
       "description": "Ignore regular updates for docs dependencies but keep security alerts",
       "matchFileNames": [
         "docs/**"

--- a/scripts/openapi-codegen/bun.lock
+++ b/scripts/openapi-codegen/bun.lock
@@ -6,7 +6,7 @@
       "name": "openapi-codegen",
       "dependencies": {
         "openapi-typescript": "^7.13.0",
-        "typescript": "^5.9.0",
+        "typescript": "5.9.3",
       },
     },
   },

--- a/scripts/openapi-codegen/package.json
+++ b/scripts/openapi-codegen/package.json
@@ -7,6 +7,6 @@
   },
   "dependencies": {
     "openapi-typescript": "^7.13.0",
-    "typescript": "^5.9.0"
+    "typescript": "5.9.3"
   }
 }


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [x] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned OpenAPI code generation tooling to TypeScript 5.9.3.
  * Restricted automated TypeScript updates to versions below 6.0.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->