### PR TITLE
fix(error-handler): preserve deliberate 5xx status codes

### DIFF
--- a/src/plugins/custom/error-handler.ts
+++ b/src/plugins/custom/error-handler.ts
@@ -9,15 +9,15 @@ import fp from 'fastify-plugin'
  */
 async function errorHandler(fastify: FastifyInstance) {
   fastify.setErrorHandler((err: FastifyError, request, reply) => {
-    const sc = err.statusCode
-    // Only a well-formed 4xx is safe to pass through - anything else could leak internals
-    const isClientError =
-      typeof sc === 'number' &&
-      Number.isInteger(sc) &&
-      sc >= 400 &&
-      sc < 500 &&
-      typeof err.message === 'string' &&
-      err.message.length > 0
+    const raw = err.statusCode
+    const statusCode =
+      typeof raw === 'number' &&
+      Number.isInteger(raw) &&
+      raw >= 400 &&
+      raw < 600
+        ? raw
+        : 500
+    const statusText = STATUS_CODES[statusCode] ?? 'Error'
 
     // Avoid logging query/params to prevent leaking tokens/PII
     const logData = {
@@ -31,28 +31,27 @@ async function errorHandler(fastify: FastifyInstance) {
       },
     }
 
-    // Use appropriate log level based on status code
-    if (isClientError && sc === 401) {
+    if (statusCode === 401) {
       request.log.warn(logData, 'Authentication required')
-    } else if (isClientError) {
+    } else if (statusCode < 500) {
       request.log.warn(logData, 'Client error occurred')
     } else {
       request.log.error(logData, 'Internal server error occurred')
     }
 
-    const payload: ErrorResponse = isClientError
-      ? {
-          statusCode: sc,
-          error: STATUS_CODES[sc] ?? 'Error',
-          message: err.message,
-        }
-      : {
-          statusCode: 500,
-          error: 'Internal Server Error',
-          message: 'Internal Server Error',
-        }
+    // only 4xx string messages are safe to echo; anything else may leak internals
+    const safeMessage =
+      statusCode < 500 && typeof err.message === 'string' && err.message
+        ? err.message
+        : statusText
 
-    reply.code(payload.statusCode)
+    const payload: ErrorResponse = {
+      statusCode,
+      error: statusText,
+      message: safeMessage,
+    }
+
+    reply.code(statusCode)
     return payload
   })
 }

--- a/test/integration/plugins/error-handler.test.ts
+++ b/test/integration/plugins/error-handler.test.ts
@@ -49,6 +49,20 @@ describe('error handler', () => {
     app.get('/boom/object-message', () => {
       throw makeError({ statusCode: 400, message: { detail: 'not a string' } })
     })
+    app.get('/boom/unavailable', (_req, reply) =>
+      reply.serviceUnavailable(
+        'TMDB responded with 500 at http://internal:8080',
+      ),
+    )
+    app.get('/boom/timeout', (_req, reply) =>
+      reply.gatewayTimeout('upstream timed out'),
+    )
+    app.get('/boom/bad-gateway', () => {
+      throw makeError({
+        statusCode: 502,
+        message: 'driver crashed at /srv/db.sqlite',
+      })
+    })
 
     await app.ready()
   })
@@ -118,13 +132,41 @@ describe('error handler', () => {
     })
   })
 
-  it('masks 4xx errors with an empty or non-string message as 500', async () => {
+  it('falls back to status text when a 4xx message is empty or not a string', async () => {
     const empty = await app.inject({ url: '/boom/empty-message' })
     const object = await app.inject({ url: '/boom/object-message' })
 
-    expect(empty.statusCode).toBe(500)
-    expect(empty.json().message).toBe('Internal Server Error')
-    expect(object.statusCode).toBe(500)
-    expect(object.json().message).toBe('Internal Server Error')
+    expect(empty.statusCode).toBe(400)
+    expect(empty.json().message).toBe('Bad Request')
+    expect(object.statusCode).toBe(400)
+    expect(object.json().message).toBe('Bad Request')
+    expect(object.body).not.toContain('not a string')
+  })
+
+  it('preserves a deliberate 503 while masking its message', async () => {
+    const res = await app.inject({ url: '/boom/unavailable' })
+
+    expect(res.statusCode).toBe(503)
+    expect(res.json()).toEqual({
+      statusCode: 503,
+      error: 'Service Unavailable',
+      message: 'Service Unavailable',
+    })
+    expect(res.body).not.toContain('internal:8080')
+  })
+
+  it('preserves a deliberate 504', async () => {
+    const res = await app.inject({ url: '/boom/timeout' })
+
+    expect(res.statusCode).toBe(504)
+    expect(res.json().error).toBe('Gateway Timeout')
+  })
+
+  it('preserves a thrown 502 while masking its message', async () => {
+    const res = await app.inject({ url: '/boom/bad-gateway' })
+
+    expect(res.statusCode).toBe(502)
+    expect(res.json().message).toBe('Bad Gateway')
+    expect(res.body).not.toContain('db.sqlite')
   })
 })


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP error handling for status codes from 400 through 599.
  * Preserved valid server error statuses, including 502, 503, and 504.
  * Replaced empty, invalid, or sensitive error messages with standard HTTP status text.
  * Ensured invalid status values safely fall back to a 500 response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->