### PR TITLE
refactor(watchlist-workflow): drop config latch for one-shot boot aut…

### DIFF
--- a/scripts/openapi-app.ts
+++ b/scripts/openapi-app.ts
@@ -96,10 +96,6 @@ export default async function openapiApp(
       } catch {}
       try {
         // @ts-expect-error Stub for OpenAPI generation
-        fastify.decorate('markConfigReady', () => {})
-      } catch {}
-      try {
-        // @ts-expect-error Stub for OpenAPI generation
         fastify.decorate('compare', () => {})
       } catch {}
       try {

--- a/src/client/components/ui/workflow-status-badge.tsx
+++ b/src/client/components/ui/workflow-status-badge.tsx
@@ -51,13 +51,7 @@ export function WatchlistStatusBadge() {
   const handleAutoStartChange = useCallback(async (checked: boolean) => {
     setIsTogglingAutoStart(true)
     try {
-      const minimumLoadingTime = new Promise((resolve) =>
-        setTimeout(resolve, 500),
-      )
-      await Promise.all([
-        updateConfig({ _isReady: checked }),
-        minimumLoadingTime,
-      ])
+      await updateConfig({ _isReady: checked })
       toast.success(`Auto-Start ${checked ? 'enabled' : 'disabled'}`)
     } catch {
       toast.error(`Failed to ${checked ? 'enable' : 'disable'} Auto-Start`)

--- a/src/plugins/custom/database.ts
+++ b/src/plugins/custom/database.ts
@@ -80,13 +80,6 @@ export default fp(
 
           await fastify.updateConfig(mergedConfig)
 
-          if (dbConfig._isReady) {
-            fastify.log.debug('DB config was ready, enabling boot auto-start')
-            fastify.markConfigReady()
-          } else {
-            fastify.log.debug('DB config was not ready')
-          }
-
           const [existingSonarrInstances, existingRadarrInstances] =
             await Promise.all([
               dbService.getAllSonarrInstances(),

--- a/src/plugins/custom/watchlist-workflow.ts
+++ b/src/plugins/custom/watchlist-workflow.ts
@@ -47,13 +47,14 @@ export default fp(
       clearInterval(statusInterval)
     })
 
-    // Auto-start workflow when config is ready
     const startWorkflow = async () => {
       try {
-        fastify.log.debug('Waiting for config to be ready...')
-        await fastify.waitForConfig()
+        // _isReady is final here - the database plugin loads config before this plugin registers
+        if (!fastify.config._isReady) {
+          fastify.log.debug('Auto-start disabled, skipping workflow start')
+          return
+        }
 
-        // Check if workflow is already running or starting before attempting to start
         const currentStatus = watchlistWorkflow.getStatus()
         if (currentStatus === 'running' || currentStatus === 'starting') {
           fastify.log.info(

--- a/src/plugins/external/env.ts
+++ b/src/plugins/external/env.ts
@@ -508,19 +508,11 @@ declare module 'fastify' {
   interface FastifyInstance {
     config: Config
     updateConfig(config: Partial<Config>): Promise<Config>
-    /** Resolves waitForConfig when _isReady was true at boot. Not for runtime API updates. */
-    markConfigReady(): void
-    waitForConfig(): Promise<void>
   }
 }
 
 export default fp(
   async (fastify: FastifyInstance) => {
-    let resolveReady: (() => void) | null = null
-    const readyPromise = new Promise<void>((resolve) => {
-      resolveReady = resolve
-    })
-
     await fastify.register(env, {
       confKey: 'config',
       schema,
@@ -708,23 +700,6 @@ export default fp(
       const updatedConfig = { ...fastify.config, ...newConfig }
       fastify.config = updatedConfig
       return updatedConfig
-    })
-
-    fastify.decorate('markConfigReady', () => {
-      if (resolveReady) {
-        fastify.log.info(
-          'Config is ready at boot, resolving waitForConfig promise',
-        )
-        resolveReady()
-        resolveReady = null
-      }
-    })
-
-    fastify.decorate('waitForConfig', () => {
-      if (fastify.config._isReady) {
-        return Promise.resolve()
-      }
-      return readyPromise
     })
   },
   {

--- a/test/integration/plugins/watchlist-workflow-boot.test.ts
+++ b/test/integration/plugins/watchlist-workflow-boot.test.ts
@@ -1,0 +1,83 @@
+import type { FastifyInstance } from 'fastify'
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+import { build } from '../../helpers/app.js'
+import {
+  getTestDatabase,
+  initializeTestDatabase,
+  resetDatabase,
+} from '../../helpers/database.js'
+import { seedConfig } from '../../helpers/seeds/config.js'
+
+// Each test boots the app to exercise the boot auto-start path. Booting the
+// full app takes 7-10s on loaded CI runners, so the global 10s timeout has no
+// headroom.
+describe('watchlist workflow boot auto-start', { timeout: 30_000 }, () => {
+  let app: FastifyInstance | undefined
+
+  beforeAll(async () => {
+    await initializeTestDatabase()
+  })
+
+  beforeEach(async () => {
+    await resetDatabase()
+  })
+
+  afterEach(async () => {
+    await app?.close()
+    app = undefined
+  })
+
+  async function seedWithReady(isReady: boolean) {
+    const knex = getTestDatabase()
+    await seedConfig(knex)
+    await knex('configs').where({ id: 1 }).update({ _isReady: isReady })
+  }
+
+  it('starts the workflow at boot when _isReady was persisted true', async () => {
+    await seedWithReady(true)
+    app = await build()
+    await app.ready()
+
+    const workflow = app.watchlistWorkflow
+    await vi.waitFor(
+      () => expect(['starting', 'running']).toContain(workflow.getStatus()),
+      { timeout: 15_000 },
+    )
+
+    app.config.authenticationMethod = 'disabled'
+    const stopRes = await app.inject({
+      method: 'POST',
+      url: '/v1/watchlist-workflow/stop',
+    })
+    expect(stopRes.statusCode).toBe(200)
+    await vi.waitFor(() => expect(workflow.getStatus()).toBe('stopped'), {
+      timeout: 15_000,
+    })
+  })
+
+  it('does not start the workflow at boot when _isReady was persisted false', async () => {
+    await seedWithReady(false)
+    app = await build()
+    await app.ready()
+
+    // the auto-start callback was queued during boot; queue behind it
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(app.watchlistWorkflow.getStatus()).toBe('stopped')
+  })
+
+  it('does not start the workflow at boot when no config row exists', async () => {
+    app = await build()
+    await app.ready()
+
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(app.watchlistWorkflow.getStatus()).toBe('stopped')
+  })
+})

--- a/test/integration/routes/config-is-ready.test.ts
+++ b/test/integration/routes/config-is-ready.test.ts
@@ -32,7 +32,7 @@ describe('Config _isReady persistence', () => {
   })
 
   it('persists _isReady: false via PUT /v1/config', async () => {
-    // The boot auto-start latch must not fire on runtime config writes
+    // runtime _isReady writes must never start the workflow
     app.watchlistWorkflow.startWorkflow = vi.fn().mockResolvedValue(undefined)
 
     const enableRes = await app.inject({
@@ -82,6 +82,60 @@ describe('Config _isReady persistence', () => {
       method: 'POST',
       url: '/v1/watchlist-workflow/start',
       payload: { autoStart: false },
+    })
+    expect(startRes.statusCode).toBe(200)
+    expect(app.watchlistWorkflow.startWorkflow).toHaveBeenCalledTimes(1)
+    expect(app.config._isReady).toBe(false)
+
+    const knex = getTestDatabase()
+    const row = await knex('configs').where({ id: 1 }).first()
+    expect(row).toBeDefined()
+    expect(Boolean(row?._isReady)).toBe(false)
+  })
+
+  it('persists _isReady: true when starting with autoStart: true', async () => {
+    const disableRes = await app.inject({
+      method: 'PUT',
+      url: '/v1/config',
+      payload: { _isReady: false },
+    })
+    expect(disableRes.statusCode).toBe(200)
+    expect(app.config._isReady).toBe(false)
+
+    app.watchlistWorkflow.getStatus = vi.fn().mockReturnValue('stopped')
+    app.watchlistWorkflow.startWorkflow = vi.fn().mockResolvedValue(undefined)
+
+    const startRes = await app.inject({
+      method: 'POST',
+      url: '/v1/watchlist-workflow/start',
+      payload: { autoStart: true },
+    })
+    expect(startRes.statusCode).toBe(200)
+    expect(app.watchlistWorkflow.startWorkflow).toHaveBeenCalledTimes(1)
+    expect(app.config._isReady).toBe(true)
+
+    const knex = getTestDatabase()
+    const row = await knex('configs').where({ id: 1 }).first()
+    expect(row).toBeDefined()
+    expect(Boolean(row?._isReady)).toBe(true)
+  })
+
+  it('leaves _isReady unchanged when starting without autoStart', async () => {
+    const disableRes = await app.inject({
+      method: 'PUT',
+      url: '/v1/config',
+      payload: { _isReady: false },
+    })
+    expect(disableRes.statusCode).toBe(200)
+    expect(app.config._isReady).toBe(false)
+
+    app.watchlistWorkflow.getStatus = vi.fn().mockReturnValue('stopped')
+    app.watchlistWorkflow.startWorkflow = vi.fn().mockResolvedValue(undefined)
+
+    const startRes = await app.inject({
+      method: 'POST',
+      url: '/v1/watchlist-workflow/start',
+      payload: {},
     })
     expect(startRes.statusCode).toBe(200)
     expect(app.watchlistWorkflow.startWorkflow).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
…o-start check

## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved watchlist workflow auto-start handling when configuration is ready or unavailable.
  * Removed unnecessary delays when updating the workflow auto-start setting.
  * Prevented configuration readiness updates from unintentionally starting workflows.

* **Tests**
  * Added coverage for workflow startup with ready, unready, and missing configurations.
  * Added verification of configuration readiness behavior when starting workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->