### PR TITLE
fix(sync): never overwrite stored usernames with token fallback names

### DIFF
--- a/src/services/plex-watchlist/users/token-users.ts
+++ b/src/services/plex-watchlist/users/token-users.ts
@@ -66,6 +66,7 @@ export async function ensureTokenUsers(
     deps.config.plexTokens.map(async (token, index) => {
       // Fetch the actual Plex username for this token
       let plexUsername = `token${index + 1}` // Fallback name
+      let usernameVerified = false
       let plexAvatar: string | null = null
       let plexUuid: string | null = null
       const isPrimary = index === 0 // First token is primary
@@ -95,6 +96,7 @@ export async function ensureTokenUsers(
           }
           if (userData?.username) {
             plexUsername = userData.username
+            usernameVerified = true
             deps.logger.debug(
               `Using actual Plex username: ${plexUsername} for token${index + 1}`,
             )
@@ -132,6 +134,14 @@ export async function ensureTokenUsers(
         clearTimeout(timeoutId)
       }
 
+      // Primary still proceeds unverified so a fresh install can bootstrap offline
+      if (!isPrimary && !usernameVerified) {
+        deps.logger.warn(
+          `Skipping user sync for token${index + 1}: could not verify Plex username`,
+        )
+        return
+      }
+
       // Variable to hold our user
       let user: User | undefined
 
@@ -154,7 +164,8 @@ export async function ensureTokenUsers(
         // Build updates for any changed fields
         const updates: Partial<Omit<User, 'id' | 'created_at' | 'updated_at'>> =
           {}
-        if (user.name !== plexUsername) {
+        // Never overwrite a stored name with the fallback from a failed fetch
+        if (usernameVerified && user.name !== plexUsername) {
           updates.name = plexUsername
         }
         if (plexAvatar && user.avatar !== plexAvatar) {


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Plex watchlist user synchronization when username verification fails.
  * Prevented non-primary token users from being added without a verified username.
  * Preserved existing usernames when Plex cannot verify updated account information.
  * Continued supporting primary token synchronization using its fallback name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->