### PR TITLE
feat(users): enforce unique usernames with duplicate-merging migration

### DIFF
--- a/migrations/migrations/098_20260823_add_unique_user_name.ts
+++ b/migrations/migrations/098_20260823_add_unique_user_name.ts
@@ -1,0 +1,70 @@
+import type { Knex } from 'knex'
+
+// Child tables holding user_id, with the columns that are unique per user
+const CHILD_TABLES: { table: string; keys: string[] }[] = [
+  { table: 'watchlist_items', keys: ['key'] },
+  { table: 'notifications', keys: [] },
+  { table: 'user_quotas', keys: ['content_type'] },
+  { table: 'approval_requests', keys: ['content_key'] },
+  { table: 'quota_usage', keys: [] },
+  {
+    table: 'plex_label_tracking',
+    keys: ['content_guids', 'content_type', 'plex_rating_key'],
+  },
+  { table: 'watchlist_exclusions', keys: ['key'] },
+]
+
+export async function up(knex: Knex): Promise<void> {
+  // Same-name rows are one person inserted twice (Plex names are globally unique)
+  const dupeGroups = await knex('users')
+    .select('name')
+    .groupBy('name')
+    .havingRaw('count(*) > 1')
+
+  for (const { name } of dupeGroups) {
+    const rows = await knex('users')
+      .where({ name })
+      .orderBy([
+        { column: 'is_primary_token', order: 'desc' },
+        { column: 'id', order: 'asc' },
+      ])
+
+    const keeper = rows[0]
+    const dupes = rows.slice(1)
+
+    for (const dupe of dupes) {
+      for (const { table, keys } of CHILD_TABLES) {
+        if (keys.length > 0) {
+          const collision = keys
+            .map((k) => `c2.${k} = ${table}.${k}`)
+            .join(' AND ')
+          await knex.raw(
+            `UPDATE ${table} SET user_id = ? WHERE user_id = ?
+             AND NOT EXISTS (
+               SELECT 1 FROM ${table} c2 WHERE c2.user_id = ? AND ${collision}
+             )`,
+            [keeper.id, dupe.id, keeper.id],
+          )
+          // Rows colliding with the keeper's are the same data; drop them
+          await knex(table).where({ user_id: dupe.id }).delete()
+        } else {
+          await knex(table)
+            .where({ user_id: dupe.id })
+            .update({ user_id: keeper.id })
+        }
+      }
+
+      await knex('users').where({ id: dupe.id }).delete()
+    }
+  }
+
+  await knex.schema.alterTable('users', (table) => {
+    table.unique(['name'])
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('users', (table) => {
+    table.dropUnique(['name'])
+  })
+}

--- a/src/routes/v1/users/users.ts
+++ b/src/routes/v1/users/users.ts
@@ -4,6 +4,7 @@ import {
   UserErrorSchema,
   UserResponseSchema,
 } from '@schemas/users/users.schema.js'
+import { isUniqueViolation } from '@utils/db-errors.js'
 import { logRouteError } from '@utils/route-errors.js'
 import type { FastifyPluginAsyncZodOpenApi } from 'fastify-zod-openapi'
 import { z } from 'zod'
@@ -44,6 +45,10 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (fastify) => {
           user,
         }
       } catch (error) {
+        // A concurrent create can slip past the pre-check; report it as a 409
+        if (isUniqueViolation(error)) {
+          return reply.conflict('User with this name already exists')
+        }
         logRouteError(fastify.log, request, error, {
           message: 'Failed to create user',
         })
@@ -104,6 +109,9 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (fastify) => {
           user: updatedUser,
         }
       } catch (error) {
+        if (isUniqueViolation(error)) {
+          return reply.conflict('User with this name already exists')
+        }
         logRouteError(fastify.log, request, error, {
           message: 'Failed to update user',
         })

--- a/src/services/database/methods/api-keys.ts
+++ b/src/services/database/methods/api-keys.ts
@@ -2,6 +2,7 @@ import { randomBytes } from 'node:crypto'
 import type { ApiKey, ApiKeyCreate } from '@root/types/api-key.types.js'
 import type { Auth } from '@schemas/auth/auth.js'
 import type { DatabaseService } from '@services/database.service.js'
+import { isUniqueViolation } from '@utils/db-errors.js'
 
 /**
  * Generates a cryptographically secure API key as a 32-byte base64url-encoded string.
@@ -70,28 +71,8 @@ export async function createApiKey(
         is_active: Boolean(apiKey.is_active),
       }
     } catch (error) {
-      // Handle unique constraint violations for both PostgreSQL and better-sqlite3
-      const isUniqueViolation =
-        // PostgreSQL: SQLSTATE 23505
-        (error instanceof Error &&
-          'code' in error &&
-          error.code === '23505' &&
-          'constraint' in error &&
-          typeof error.constraint === 'string' &&
-          error.constraint.includes('key')) ||
-        // better-sqlite3: Error code SQLITE_CONSTRAINT_UNIQUE (19)
-        (error instanceof Error &&
-          'code' in error &&
-          error.code === 'SQLITE_CONSTRAINT_UNIQUE') ||
-        // better-sqlite3: Generic constraint error with UNIQUE in message
-        (error instanceof Error &&
-          'code' in error &&
-          error.code === 'SQLITE_CONSTRAINT' &&
-          error.message.includes('UNIQUE')) ||
-        (error instanceof Error &&
-          error.message.includes('UNIQUE constraint failed'))
-
-      if (isUniqueViolation) {
+      // key is the table's only unique constraint, so this is a key collision
+      if (isUniqueViolation(error)) {
         attempt++
         if (attempt >= MAX_RETRIES) {
           throw new Error(

--- a/src/services/database/methods/users.ts
+++ b/src/services/database/methods/users.ts
@@ -94,6 +94,37 @@ export async function createUser(
 }
 
 /**
+ * Fetches the user with the given name, inserting it first if it does not exist.
+ *
+ * Concurrency-safe: the insert ignores conflicts on the unique name constraint,
+ * so parallel callers converge on the same row instead of creating duplicates.
+ *
+ * @param userData - User information to store if no user with this name exists.
+ * @returns The existing or newly created user, and whether this call created it.
+ */
+export async function getOrCreateUser(
+  this: DatabaseService,
+  userData: Omit<User, 'id' | 'created_at' | 'updated_at'>,
+): Promise<{ user: User; created: boolean }> {
+  const inserted = await this.knex('users')
+    .insert({
+      ...userData,
+      created_at: this.timestamp,
+      updated_at: this.timestamp,
+    })
+    .onConflict('name')
+    .ignore()
+    .returning('id')
+
+  const user = await this.getUser(userData.name)
+  if (!user) {
+    throw new Error(`Failed to get or create user ${userData.name}`)
+  }
+
+  return { user, created: inserted.length > 0 }
+}
+
+/**
  * Retrieve a user by numeric ID or by username.
  *
  * Looks up a non-system user (id > 0) and returns the mapped User object if found.

--- a/src/services/database/types/user-methods.ts
+++ b/src/services/database/types/user-methods.ts
@@ -14,6 +14,16 @@ declare module '@services/database.service.js' {
     ): Promise<User>
 
     /**
+     * Fetches the user with the given name, inserting it first if missing.
+     * Safe under concurrency via the unique constraint on users.name.
+     * @param userData - User data to store if no user with this name exists
+     * @returns Promise resolving to the user and whether this call created it
+     */
+    getOrCreateUser(
+      userData: Omit<User, 'id' | 'created_at' | 'updated_at'>,
+    ): Promise<{ user: User; created: boolean }>
+
+    /**
      * Retrieves a user by ID or name
      * @param identifier - User ID (number) or username (string)
      * @returns Promise resolving to the user if found, undefined otherwise

--- a/src/services/plex-watchlist/users/friend-users.ts
+++ b/src/services/plex-watchlist/users/friend-users.ts
@@ -38,10 +38,31 @@ export async function ensureFriendUsers(
 
   await Promise.all(
     Array.from(friends).map(async ([friend]) => {
-      let user = await deps.db.getUser(friend.username)
-      const isNewUser = !user
+      const { user, created } = await deps.db.getOrCreateUser({
+        name: friend.username,
+        apprise: null,
+        alias: null,
+        discord_id: null,
+        notify_apprise: false,
+        notify_discord: false,
+        notify_discord_mention: true,
+        notify_plex_mobile: false,
+        can_sync: deps.config.newUserDefaultCanSync ?? true,
+        requires_approval: deps.config.newUserDefaultRequiresApproval ?? false,
+        is_primary_token: false,
+        plex_uuid: friend.watchlistId,
+        avatar: friend.avatar ?? null,
+        display_name: friend.displayName ?? null,
+        friend_created_at: friend.createdAt ?? null,
+      })
 
-      if (user) {
+      if (created) {
+        // Send native webhook notification for user creation (fire-and-forget)
+        void deps.fastify.notifications.sendUserCreated(user)
+
+        // Create default quotas for the new user
+        await createDefaultQuotasForUser(user.id, deps)
+      } else {
         const updates: Partial<Omit<User, 'id' | 'created_at' | 'updated_at'>> =
           {}
         if (friend.watchlistId && user.plex_uuid !== friend.watchlistId) {
@@ -67,33 +88,6 @@ export async function ensureFriendUsers(
         }
       }
 
-      if (!user) {
-        user = await deps.db.createUser({
-          name: friend.username,
-          apprise: null,
-          alias: null,
-          discord_id: null,
-          notify_apprise: false,
-          notify_discord: false,
-          notify_discord_mention: true,
-          notify_plex_mobile: false,
-          can_sync: deps.config.newUserDefaultCanSync ?? true,
-          requires_approval:
-            deps.config.newUserDefaultRequiresApproval ?? false,
-          is_primary_token: false,
-          plex_uuid: friend.watchlistId,
-          avatar: friend.avatar ?? null,
-          display_name: friend.displayName ?? null,
-          friend_created_at: friend.createdAt ?? null,
-        })
-
-        // Send native webhook notification for user creation (fire-and-forget)
-        void deps.fastify.notifications.sendUserCreated(user)
-
-        // Create default quotas for the new user
-        await createDefaultQuotasForUser(user.id, deps)
-      }
-
       if (!user.id) throw new Error(`No ID for user ${friend.username}`)
       userMap.set(friend.watchlistId, {
         userId: user.id,
@@ -101,7 +95,7 @@ export async function ensureFriendUsers(
       })
 
       // Track newly added users for ETag baseline establishment
-      if (isNewUser) {
+      if (created) {
         added.push({
           userId: user.id,
           username: friend.username,

--- a/src/services/plex-watchlist/users/token-users.ts
+++ b/src/services/plex-watchlist/users/token-users.ts
@@ -180,66 +180,43 @@ export async function ensureTokenUsers(
           user = await deps.db.getUser(user.id)
         }
       } else {
-        // If we're creating a primary user, ensure no other primaries exist
+        const { user: ensuredUser, created } = await deps.db.getOrCreateUser({
+          name: plexUsername,
+          apprise: null,
+          alias: null,
+          discord_id: null,
+          notify_apprise: false,
+          notify_discord: false,
+          notify_discord_mention: true,
+          notify_plex_mobile: false,
+          can_sync: deps.config.newUserDefaultCanSync ?? true,
+          requires_approval:
+            deps.config.newUserDefaultRequiresApproval ?? false,
+          is_primary_token: false, // Primary flag is set separately below
+          avatar: plexAvatar,
+          plex_uuid: plexUuid,
+        })
+        user = ensuredUser
+
         if (isPrimary) {
-          // Use the database service method to handle primary user setting
-          // We'll create the user first, then set it as primary
-          user = await deps.db.createUser({
-            name: plexUsername,
-            apprise: null,
-            alias: null,
-            discord_id: null,
-            notify_apprise: false,
-            notify_discord: false,
-            notify_discord_mention: true,
-            notify_plex_mobile: false,
-            can_sync: deps.config.newUserDefaultCanSync ?? true,
-            requires_approval:
-              deps.config.newUserDefaultRequiresApproval ?? false,
-            is_primary_token: false, // Initially false, will set to true next
-            avatar: plexAvatar,
-            plex_uuid: plexUuid,
-          })
-
-          // Now set as primary using the database service method
           await deps.db.setPrimaryUser(user.id)
+        }
 
-          // Reload to get updated data with is_primary_token = true
-          const updatedUser = await deps.db.getUser(user.id)
-          if (updatedUser) {
+        if (created) {
+          // Reload so the notification carries the final primary flag
+          const finalUser = await deps.db.getUser(user.id)
+          if (finalUser) {
             // Send native webhook notification for user creation (fire-and-forget)
-            void deps.fastify.notifications.sendUserCreated(updatedUser)
+            void deps.fastify.notifications.sendUserCreated(finalUser)
           }
 
           // Create default quotas for the new user
           await createDefaultQuotasForUser(user.id, deps)
+        }
 
-          // Reload to get final data
+        if (isPrimary) {
+          // Reload to get updated data with is_primary_token = true
           user = await deps.db.getUser(user.id)
-        } else {
-          // Create regular non-primary user
-          user = await deps.db.createUser({
-            name: plexUsername,
-            apprise: null,
-            alias: null,
-            discord_id: null,
-            notify_apprise: false,
-            notify_discord: false,
-            notify_discord_mention: true,
-            notify_plex_mobile: false,
-            can_sync: deps.config.newUserDefaultCanSync ?? true,
-            requires_approval:
-              deps.config.newUserDefaultRequiresApproval ?? false,
-            is_primary_token: false,
-            avatar: plexAvatar,
-            plex_uuid: plexUuid,
-          })
-
-          // Send native webhook notification for user creation (fire-and-forget)
-          void deps.fastify.notifications.sendUserCreated(user)
-
-          // Create default quotas for the new user
-          await createDefaultQuotasForUser(user.id, deps)
         }
       }
 

--- a/src/utils/db-errors.ts
+++ b/src/utils/db-errors.ts
@@ -1,0 +1,18 @@
+/**
+ * Detects a unique constraint violation from either supported database client.
+ *
+ * @param error - The thrown value to inspect
+ * @returns True if the error is a PostgreSQL or better-sqlite3 unique violation
+ */
+export function isUniqueViolation(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  const code = 'code' in error ? error.code : undefined
+  return (
+    // PostgreSQL: SQLSTATE 23505
+    code === '23505' ||
+    // better-sqlite3: SQLITE_CONSTRAINT_UNIQUE (19)
+    code === 'SQLITE_CONSTRAINT_UNIQUE' ||
+    (code === 'SQLITE_CONSTRAINT' && error.message.includes('UNIQUE')) ||
+    error.message.includes('UNIQUE constraint failed')
+  )
+}

--- a/test/integration/migrations/098-unique-user-name.test.ts
+++ b/test/integration/migrations/098-unique-user-name.test.ts
@@ -1,0 +1,259 @@
+import { isUniqueViolation } from '@utils/db-errors.js'
+import knex, { type Knex } from 'knex'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+// Dedicated in-memory DB: the shared test singleton is already migrated to
+// latest, so this suite drives its own connection to test 098 in isolation.
+describe('migration 098_add_unique_user_name', () => {
+  let db: Knex
+
+  beforeAll(async () => {
+    db = knex({
+      client: 'better-sqlite3',
+      connection: { filename: ':memory:' },
+      useNullAsDefault: true,
+      migrations: { directory: './migrations/migrations' },
+      pool: {
+        min: 1,
+        max: 1,
+        afterCreate: (
+          conn: unknown,
+          done: (err: Error | null, conn: unknown) => void,
+        ): void => {
+          const sqliteConn = conn as { exec: (sql: string) => void }
+          sqliteConn.exec('PRAGMA foreign_keys = ON;')
+          done(null, conn)
+        },
+      },
+    })
+
+    // Migrate to 097 so duplicates can be seeded before the constraint lands
+    let applied: string[]
+    do {
+      const [, files] = (await db.migrate.up()) as [number, string[]]
+      if (files.length === 0) {
+        throw new Error('Ran out of migrations before reaching 097')
+      }
+      applied = files
+    } while (!applied[0]?.startsWith('097'))
+
+    // alice: duplicate pair where the primary-token row is newer than the
+    // other; bob: duplicate pair with no primary; carol: no duplicates
+    await db('users').insert([
+      { id: 1, name: 'alice', is_primary_token: false },
+      { id: 2, name: 'alice', is_primary_token: true },
+      { id: 3, name: 'bob', is_primary_token: false },
+      { id: 4, name: 'bob', is_primary_token: false },
+      { id: 5, name: 'carol', is_primary_token: false },
+    ])
+
+    await db('watchlist_items').insert([
+      { id: 10, user_id: 2, key: 'shared', title: 'Shared', type: 'movie' },
+      { id: 11, user_id: 1, key: 'shared', title: 'Shared', type: 'movie' },
+      { id: 12, user_id: 1, key: 'solo', title: 'Solo', type: 'movie' },
+    ])
+
+    await db('notifications').insert([
+      { id: 20, user_id: 1, watchlist_item_id: 11, type: 'movie', title: 'A' },
+      { id: 21, user_id: 1, watchlist_item_id: 12, type: 'movie', title: 'B' },
+    ])
+
+    await db('user_quotas').insert([
+      {
+        user_id: 2,
+        content_type: 'movie',
+        quota_type: 'daily',
+        quota_limit: 5,
+      },
+      {
+        user_id: 1,
+        content_type: 'movie',
+        quota_type: 'daily',
+        quota_limit: 3,
+      },
+      {
+        user_id: 1,
+        content_type: 'show',
+        quota_type: 'daily',
+        quota_limit: 3,
+      },
+    ])
+
+    await db('quota_usage').insert([
+      { user_id: 1, content_type: 'movie', request_date: '2026-08-01' },
+    ])
+
+    await db('approval_requests').insert([
+      {
+        user_id: 2,
+        content_type: 'movie',
+        content_title: 'Shared',
+        content_key: 'ck-shared',
+        router_decision: '{}',
+        triggered_by: 'quota_exceeded',
+      },
+      {
+        user_id: 1,
+        content_type: 'movie',
+        content_title: 'Shared',
+        content_key: 'ck-shared',
+        router_decision: '{}',
+        triggered_by: 'quota_exceeded',
+      },
+      {
+        user_id: 1,
+        content_type: 'movie',
+        content_title: 'Solo',
+        content_key: 'ck-solo',
+        router_decision: '{}',
+        triggered_by: 'quota_exceeded',
+      },
+    ])
+
+    // rk2 matches the keeper on guids and type but tracks a different Plex
+    // item, so it must be repointed, not dropped as a collision
+    await db('plex_label_tracking').insert([
+      {
+        user_id: 2,
+        content_guids: '["g1"]',
+        content_type: 'movie',
+        plex_rating_key: 'rk1',
+        labels_applied: '[]',
+      },
+      {
+        user_id: 1,
+        content_guids: '["g1"]',
+        content_type: 'movie',
+        plex_rating_key: 'rk1',
+        labels_applied: '[]',
+      },
+      {
+        user_id: 1,
+        content_guids: '["g1"]',
+        content_type: 'movie',
+        plex_rating_key: 'rk2',
+        labels_applied: '[]',
+      },
+    ])
+
+    await db('watchlist_exclusions').insert([
+      {
+        user_id: 2,
+        key: 'ex-shared',
+        title: 'Shared',
+        type: 'movie',
+        guids: '[]',
+      },
+      {
+        user_id: 1,
+        key: 'ex-shared',
+        title: 'Shared',
+        type: 'movie',
+        guids: '[]',
+      },
+      {
+        user_id: 1,
+        key: 'ex-solo',
+        title: 'Solo',
+        type: 'movie',
+        guids: '[]',
+      },
+    ])
+
+    const [, files] = (await db.migrate.up()) as [number, string[]]
+    expect(files[0]).toContain('098')
+  })
+
+  afterAll(async () => {
+    await db.destroy()
+  })
+
+  it('keeps the primary-token row over an older duplicate', async () => {
+    const alices = await db('users').where({ name: 'alice' })
+    expect(alices).toHaveLength(1)
+    expect(alices[0].id).toBe(2)
+  })
+
+  it('keeps the oldest row when no duplicate is primary', async () => {
+    const bobs = await db('users').where({ name: 'bob' })
+    expect(bobs).toHaveLength(1)
+    expect(bobs[0].id).toBe(3)
+  })
+
+  it('leaves non-duplicated users untouched', async () => {
+    // 'System' is seeded by an earlier migration
+    const users = await db('users').orderBy('id')
+    expect(users.map((u) => u.name)).toEqual([
+      'System',
+      'alice',
+      'bob',
+      'carol',
+    ])
+  })
+
+  it('repoints non-colliding watchlist items and drops colliding ones', async () => {
+    const items = await db('watchlist_items').orderBy('id')
+    expect(items).toEqual([
+      expect.objectContaining({ id: 10, user_id: 2, key: 'shared' }),
+      expect.objectContaining({ id: 12, user_id: 2, key: 'solo' }),
+    ])
+  })
+
+  it('cascades notifications of dropped items and repoints the rest', async () => {
+    const notifications = await db('notifications').orderBy('id')
+    expect(notifications).toEqual([
+      expect.objectContaining({ id: 21, user_id: 2, watchlist_item_id: 12 }),
+    ])
+  })
+
+  it('keeps the keeper quota on collision and repoints the other content type', async () => {
+    const quotas = await db('user_quotas')
+      .where({ user_id: 2 })
+      .orderBy('content_type')
+    expect(quotas).toEqual([
+      expect.objectContaining({ content_type: 'movie', quota_limit: 5 }),
+      expect.objectContaining({ content_type: 'show', quota_limit: 3 }),
+    ])
+    expect(await db('user_quotas').whereNot({ user_id: 2 })).toHaveLength(0)
+  })
+
+  it('repoints quota usage wholesale', async () => {
+    const usage = await db('quota_usage')
+    expect(usage).toEqual([expect.objectContaining({ user_id: 2 })])
+  })
+
+  it('merges approval requests by content key', async () => {
+    const requests = await db('approval_requests').orderBy('content_key')
+    expect(requests).toEqual([
+      expect.objectContaining({ user_id: 2, content_key: 'ck-shared' }),
+      expect.objectContaining({ user_id: 2, content_key: 'ck-solo' }),
+    ])
+  })
+
+  it('repoints label tracking rows that differ only by rating key', async () => {
+    const tracking = await db('plex_label_tracking').orderBy('plex_rating_key')
+    expect(tracking).toEqual([
+      expect.objectContaining({ user_id: 2, plex_rating_key: 'rk1' }),
+      expect.objectContaining({ user_id: 2, plex_rating_key: 'rk2' }),
+    ])
+  })
+
+  it('merges watchlist exclusions by key', async () => {
+    const exclusions = await db('watchlist_exclusions').orderBy('key')
+    expect(exclusions).toEqual([
+      expect.objectContaining({ user_id: 2, key: 'ex-shared' }),
+      expect.objectContaining({ user_id: 2, key: 'ex-solo' }),
+    ])
+  })
+
+  it('enforces the unique name constraint after migrating', async () => {
+    const error = await db('users')
+      .insert({ name: 'alice' })
+      .then(
+        () => null,
+        (e: unknown) => e,
+      )
+    expect(error).toBeInstanceOf(Error)
+    expect(isUniqueViolation(error)).toBe(true)
+  })
+})

--- a/test/unit/utils/db-errors.test.ts
+++ b/test/unit/utils/db-errors.test.ts
@@ -1,0 +1,77 @@
+import { isUniqueViolation } from '@utils/db-errors.js'
+import knex, { type Knex } from 'knex'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+describe('isUniqueViolation', () => {
+  describe('better-sqlite3 (real driver errors)', () => {
+    let db: Knex
+
+    beforeAll(async () => {
+      db = knex({
+        client: 'better-sqlite3',
+        connection: { filename: ':memory:' },
+        useNullAsDefault: true,
+      })
+      await db.schema.createTable('things', (table) => {
+        table.increments('id')
+        table.string('name').unique()
+        table.integer('amount').notNullable()
+      })
+      await db('things').insert({ name: 'taken', amount: 1 })
+    })
+
+    afterAll(async () => {
+      await db.destroy()
+    })
+
+    it('detects a real unique violation', async () => {
+      const error = await db('things')
+        .insert({ name: 'taken', amount: 2 })
+        .then(
+          () => null,
+          (e: unknown) => e,
+        )
+      expect(error).toBeInstanceOf(Error)
+      expect(isUniqueViolation(error)).toBe(true)
+    })
+
+    it('rejects a not-null constraint error', async () => {
+      const error = await db('things')
+        .insert({ name: 'other', amount: null })
+        .then(
+          () => null,
+          (e: unknown) => e,
+        )
+      expect(error).toBeInstanceOf(Error)
+      expect(isUniqueViolation(error)).toBe(false)
+    })
+  })
+
+  describe('postgres error shape (SQLSTATE codes)', () => {
+    it('detects 23505 unique_violation', () => {
+      const error = Object.assign(
+        new Error(
+          'duplicate key value violates unique constraint "users_name_unique"',
+        ),
+        { code: '23505', constraint: 'users_name_unique' },
+      )
+      expect(isUniqueViolation(error)).toBe(true)
+    })
+
+    it('rejects 23502 not_null_violation', () => {
+      const error = Object.assign(
+        new Error('null value in column "amount" violates not-null constraint'),
+        { code: '23502' },
+      )
+      expect(isUniqueViolation(error)).toBe(false)
+    })
+  })
+
+  it('rejects non-Error values', () => {
+    expect(isUniqueViolation('UNIQUE constraint failed: things.name')).toBe(
+      false,
+    )
+    expect(isUniqueViolation(null)).toBe(false)
+    expect(isUniqueViolation(undefined)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User names are now unique, preventing duplicate accounts.
  * Existing duplicate users are consolidated while preserving associated data where possible.
  * User creation now safely reuses an existing account when a matching name is found.
* **Bug Fixes**
  * Duplicate-name conflicts now return a clear conflict response instead of a server error.
  * User and invitation synchronization now avoids creating duplicate records and sends setup notifications only for newly created users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->