### PR TITLE
fix(watchlist): resolve Plex-hosted thumbs to TMDB poster paths at sync

### DIFF
--- a/src/client/components/tmdb-metadata-display.tsx
+++ b/src/client/components/tmdb-metadata-display.tsx
@@ -14,6 +14,7 @@ import { Badge } from '@/components/ui/badge'
 import { Separator } from '@/components/ui/separator'
 import { TmdbRegionSelector } from '@/components/ui/tmdb-region-selector'
 import { useConfig } from '@/hooks/useConfig'
+import { buildPosterUrl } from '@/lib/poster-url'
 
 interface TmdbMetadataDisplayProps {
   data: TmdbMetadataSuccessResponse
@@ -44,9 +45,7 @@ export function TmdbMetadataDisplay({
   const isMovie = 'title' in details
   const title = isMovie ? details.title : details.name
   const releaseDate = isMovie ? details.release_date : details.first_air_date
-  const posterUrl = details.poster_path
-    ? `https://image.tmdb.org/t/p/w500${details.poster_path}`
-    : null
+  const posterUrl = buildPosterUrl(details.poster_path, 'detail')
   const backdropUrl = details.backdrop_path
     ? `https://image.tmdb.org/t/p/w1280${details.backdrop_path}`
     : null

--- a/src/services/plex-watchlist/enrichment/index.ts
+++ b/src/services/plex-watchlist/enrichment/index.ts
@@ -1,6 +1,7 @@
 // Enrichment layer exports for Plex watchlist service
 
 export { toItemsBatch } from './batch-processor.js'
+export { needsTmdbPoster, resolveTmdbPosters } from './poster-resolver.js'
 export { parseRatings } from './rating-parser.js'
 export {
   batchLookupByGuid,

--- a/src/services/plex-watchlist/enrichment/poster-resolver.ts
+++ b/src/services/plex-watchlist/enrichment/poster-resolver.ts
@@ -1,0 +1,80 @@
+import type { Friend, Item as WatchlistItem } from '@root/types/plex.types.js'
+import type { TmdbService } from '@services/tmdb.service.js'
+import type { FastifyBaseLogger } from 'fastify'
+import pLimit from 'p-limit'
+
+export interface PosterResolverDeps {
+  tmdb: Pick<TmdbService, 'getPosterPath' | 'isConfigured'>
+  logger: FastifyBaseLogger
+}
+
+const POSTER_LOOKUP_CONCURRENCY = 5
+
+export function needsTmdbPoster(thumb: string | undefined): boolean {
+  return !thumb || thumb.startsWith('http')
+}
+
+// Thumbs are patched in place because callers forward these same objects to watchlist-added notifications
+export async function resolveTmdbPosters(
+  items: Map<Friend, Set<WatchlistItem>>,
+  deps: PosterResolverDeps,
+): Promise<void> {
+  const { tmdb, logger } = deps
+
+  if (!tmdb.isConfigured()) {
+    return
+  }
+
+  const itemsByKey = new Map<string, WatchlistItem[]>()
+
+  for (const userItems of items.values()) {
+    for (const item of userItems) {
+      if (!needsTmdbPoster(item.thumb)) {
+        continue
+      }
+
+      const group = itemsByKey.get(item.key)
+      if (group) {
+        group.push(item)
+      } else {
+        itemsByKey.set(item.key, [item])
+      }
+    }
+  }
+
+  if (itemsByKey.size === 0) {
+    return
+  }
+
+  const limit = pLimit(POSTER_LOOKUP_CONCURRENCY)
+
+  const results = await Promise.allSettled(
+    Array.from(itemsByKey.values()).map((group) =>
+      limit(async () => {
+        const [first] = group
+        const posterPath = await tmdb.getPosterPath(
+          first.guids,
+          first.type === 'show' ? 'show' : 'movie',
+        )
+
+        if (!posterPath) {
+          return false
+        }
+
+        for (const item of group) {
+          item.thumb = posterPath
+        }
+
+        return true
+      }),
+    ),
+  )
+
+  const resolved = results.filter(
+    (result) => result.status === 'fulfilled' && result.value,
+  ).length
+
+  logger.debug(
+    `Resolved ${resolved} of ${itemsByKey.size} watchlist posters from TMDB`,
+  )
+}

--- a/src/services/plex-watchlist/orchestration/item-processor.ts
+++ b/src/services/plex-watchlist/orchestration/item-processor.ts
@@ -17,6 +17,7 @@ import { parseGenres, parseGuids } from '@utils/guid-handler.js'
 import type { FastifyBaseLogger, FastifyInstance } from 'fastify'
 import pLimit from 'p-limit'
 import type { PlexLabelSyncService } from '../../plex-label-sync.service.js'
+import { resolveTmdbPosters } from '../enrichment/index.js'
 import { processWatchlistItems } from '../index.js'
 
 /**
@@ -177,6 +178,8 @@ export async function processAndSaveNewItems(
   )
 
   if (processedItems instanceof Map) {
+    await resolveTmdbPosters(processedItems, { tmdb: fastify.tmdb, logger })
+
     const itemsToInsert = await prepareItemsForInsertion(processedItems, {
       db,
       logger,

--- a/src/services/tmdb.service.ts
+++ b/src/services/tmdb.service.ts
@@ -28,6 +28,8 @@ import { createServiceLogger } from '@utils/logger.js'
 import { USER_AGENT } from '@utils/version.js'
 import type { FastifyBaseLogger, FastifyInstance } from 'fastify'
 
+const TMDB_API_TIMEOUT = 30_000
+
 export class TmdbService {
   private static readonly BASE_URL = 'https://api.themoviedb.org/3'
 
@@ -944,7 +946,11 @@ export class TmdbService {
   ): Promise<Response> {
     return new Promise((resolve, reject) => {
       this.requestQueue.push({
-        execute: () => fetch(url, options),
+        execute: () =>
+          fetch(url, {
+            ...options,
+            signal: AbortSignal.timeout(TMDB_API_TIMEOUT),
+          }),
         resolve,
         reject,
       })

--- a/src/services/tmdb.service.ts
+++ b/src/services/tmdb.service.ts
@@ -567,6 +567,7 @@ export class TmdbService {
     }
 
     let tmdbId = extractTmdbId(guids)
+    let resolvedType = type
 
     if (tmdbId === 0) {
       const tvdbId = extractTvdbId(guids)
@@ -580,17 +581,21 @@ export class TmdbService {
       }
 
       tmdbId = found.tmdbId
+      resolvedType = found.type === 'tv' ? 'show' : 'movie'
     }
 
     try {
       const details =
-        type === 'show'
+        resolvedType === 'show'
           ? await this.fetchTvDetails(tmdbId)
           : await this.fetchMovieDetails(tmdbId)
 
       return details?.poster_path ?? null
     } catch (error) {
-      this.log.debug({ error, tmdbId, type }, 'Failed to fetch poster path')
+      this.log.debug(
+        { error, tmdbId, type: resolvedType },
+        'Failed to fetch poster path',
+      )
       return null
     }
   }

--- a/src/services/tmdb.service.ts
+++ b/src/services/tmdb.service.ts
@@ -23,6 +23,7 @@ import type {
   TmdbTvDetails,
   TmdbTvMetadata,
 } from '@schemas/tmdb/tmdb.schema.js'
+import { extractTmdbId, extractTvdbId } from '@utils/guid-handler.js'
 import { createServiceLogger } from '@utils/logger.js'
 import { USER_AGENT } from '@utils/version.js'
 import type { FastifyBaseLogger, FastifyInstance } from 'fastify'
@@ -551,6 +552,43 @@ export class TmdbService {
       return null
     } catch (error) {
       this.log.error({ error }, `Error finding content by TVDB ID ${tvdbId}:`)
+      return null
+    }
+  }
+
+  async getPosterPath(
+    guids: string[] | string | undefined,
+    type: 'movie' | 'show',
+  ): Promise<string | null> {
+    if (!this.isConfigured()) {
+      return null
+    }
+
+    let tmdbId = extractTmdbId(guids)
+
+    if (tmdbId === 0) {
+      const tvdbId = extractTvdbId(guids)
+      if (tvdbId === 0) {
+        return null
+      }
+
+      const found = await this.findByTvdbId(tvdbId)
+      if (!found) {
+        return null
+      }
+
+      tmdbId = found.tmdbId
+    }
+
+    try {
+      const details =
+        type === 'show'
+          ? await this.fetchTvDetails(tmdbId)
+          : await this.fetchMovieDetails(tmdbId)
+
+      return details?.poster_path ?? null
+    } catch (error) {
+      this.log.debug({ error, tmdbId, type }, 'Failed to fetch poster path')
       return null
     }
   }

--- a/test/integration/services/tmdb.service.test.ts
+++ b/test/integration/services/tmdb.service.test.ts
@@ -418,6 +418,30 @@ describe('TmdbService Integration', () => {
       expect(result).toBe('/bb.jpg')
     })
 
+    it('should use the movie endpoint when a TVDB guid resolves to a movie', async () => {
+      const tvRequested = vi.fn()
+      server.use(
+        http.get('https://api.themoviedb.org/3/find/4242', () => {
+          return HttpResponse.json({
+            tv_results: [],
+            movie_results: [{ id: 603, title: 'The Matrix' }],
+          })
+        }),
+        http.get('https://api.themoviedb.org/3/movie/603', () => {
+          return HttpResponse.json({ id: 603, poster_path: '/matrix.jpg' })
+        }),
+        http.get('https://api.themoviedb.org/3/tv/603', () => {
+          tvRequested()
+          return new HttpResponse(null, { status: 404 })
+        }),
+      )
+
+      const result = await fastify.tmdb.getPosterPath(['tvdb:4242'], 'show')
+
+      expect(result).toBe('/matrix.jpg')
+      expect(tvRequested).not.toHaveBeenCalled()
+    })
+
     it('should return null when TMDB responds 404', async () => {
       server.use(
         http.get('https://api.themoviedb.org/3/movie/999', () => {

--- a/test/integration/services/tmdb.service.test.ts
+++ b/test/integration/services/tmdb.service.test.ts
@@ -386,4 +386,75 @@ describe('TmdbService Integration', () => {
       expect(result?.type).toBe('tv')
     })
   })
+
+  describe('getPosterPath', () => {
+    it('should return the poster path for a movie TMDB guid', async () => {
+      server.use(
+        http.get('https://api.themoviedb.org/3/movie/550', () => {
+          return HttpResponse.json({ id: 550, poster_path: '/x.jpg' })
+        }),
+      )
+
+      const result = await fastify.tmdb.getPosterPath(['tmdb:550'], 'movie')
+
+      expect(result).toBe('/x.jpg')
+    })
+
+    it('should resolve a TVDB-only guid through the find endpoint', async () => {
+      server.use(
+        http.get('https://api.themoviedb.org/3/find/81189', () => {
+          return HttpResponse.json({
+            tv_results: [{ id: 1396, name: 'Breaking Bad' }],
+            movie_results: [],
+          })
+        }),
+        http.get('https://api.themoviedb.org/3/tv/1396', () => {
+          return HttpResponse.json({ id: 1396, poster_path: '/bb.jpg' })
+        }),
+      )
+
+      const result = await fastify.tmdb.getPosterPath(['tvdb:81189'], 'show')
+
+      expect(result).toBe('/bb.jpg')
+    })
+
+    it('should return null when TMDB responds 404', async () => {
+      server.use(
+        http.get('https://api.themoviedb.org/3/movie/999', () => {
+          return new HttpResponse(null, { status: 404 })
+        }),
+      )
+
+      const result = await fastify.tmdb.getPosterPath(['tmdb:999'], 'movie')
+
+      expect(result).toBeNull()
+    })
+
+    it('should return null without requesting TMDB when there are no guids', async () => {
+      const requested = vi.fn()
+      server.use(
+        http.get('https://api.themoviedb.org/3/*', () => {
+          requested()
+          return HttpResponse.json({})
+        }),
+      )
+
+      const result = await fastify.tmdb.getPosterPath([], 'movie')
+
+      expect(result).toBeNull()
+      expect(requested).not.toHaveBeenCalled()
+    })
+
+    it('should return null when details carry no poster path', async () => {
+      server.use(
+        http.get('https://api.themoviedb.org/3/movie/550', () => {
+          return HttpResponse.json({ id: 550, poster_path: null })
+        }),
+      )
+
+      const result = await fastify.tmdb.getPosterPath(['tmdb:550'], 'movie')
+
+      expect(result).toBeNull()
+    })
+  })
 })

--- a/test/unit/services/plex-watchlist/enrichment/poster-resolver.test.ts
+++ b/test/unit/services/plex-watchlist/enrichment/poster-resolver.test.ts
@@ -1,0 +1,189 @@
+import type { Friend, Item } from '@root/types/plex.types.js'
+import {
+  needsTmdbPoster,
+  type PosterResolverDeps,
+  resolveTmdbPosters,
+} from '@services/plex-watchlist/enrichment/poster-resolver.js'
+import type { TmdbService } from '@services/tmdb.service.js'
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
+import { createMockLogger } from '../../../../mocks/logger.js'
+
+function friend(userId: number, username: string): Friend {
+  return {
+    watchlistId: `watchlist-${userId}`,
+    username,
+    userId,
+  }
+}
+
+function item(overrides: Partial<Item> & Pick<Item, 'key'>): Item {
+  return {
+    title: 'Some Title',
+    type: 'movie',
+    guids: ['tmdb:550'],
+    genres: [],
+    user_id: 1,
+    status: 'pending',
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('needsTmdbPoster', () => {
+  it('returns true for a missing thumb', () => {
+    expect(needsTmdbPoster(undefined)).toBe(true)
+  })
+
+  it('returns true for an empty thumb', () => {
+    expect(needsTmdbPoster('')).toBe(true)
+  })
+
+  it('returns true for a Plex-hosted thumb', () => {
+    expect(needsTmdbPoster('https://metadata-static.plex.tv/x.jpg')).toBe(true)
+  })
+
+  it('returns true for a plain http thumb', () => {
+    expect(needsTmdbPoster('http://example.com/x.jpg')).toBe(true)
+  })
+
+  it('returns false for a TMDB path', () => {
+    expect(needsTmdbPoster('/abc.jpg')).toBe(false)
+  })
+})
+
+describe('resolveTmdbPosters', () => {
+  let getPosterPath: Mock<TmdbService['getPosterPath']>
+  let isConfigured: Mock<TmdbService['isConfigured']>
+  let deps: PosterResolverDeps
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getPosterPath = vi.fn<TmdbService['getPosterPath']>()
+    getPosterPath.mockResolvedValue('/resolved.jpg')
+    isConfigured = vi.fn<TmdbService['isConfigured']>()
+    isConfigured.mockReturnValue(true)
+
+    deps = {
+      tmdb: { getPosterPath, isConfigured },
+      logger: createMockLogger(),
+    }
+  })
+
+  it('does nothing when TMDB is not configured', async () => {
+    isConfigured.mockReturnValue(false)
+    const target = item({ key: 'a', thumb: 'https://plex.tv/a.jpg' })
+
+    await resolveTmdbPosters(
+      new Map([[friend(1, 'alice'), new Set([target])]]),
+      deps,
+    )
+
+    expect(getPosterPath).not.toHaveBeenCalled()
+    expect(target.thumb).toBe('https://plex.tv/a.jpg')
+  })
+
+  it('skips items that already carry a TMDB path', async () => {
+    const target = item({ key: 'a', thumb: '/already.jpg' })
+
+    await resolveTmdbPosters(
+      new Map([[friend(1, 'alice'), new Set([target])]]),
+      deps,
+    )
+
+    expect(getPosterPath).not.toHaveBeenCalled()
+    expect(target.thumb).toBe('/already.jpg')
+  })
+
+  it('replaces an http thumb with the resolved poster path', async () => {
+    const target = item({
+      key: 'a',
+      thumb: 'https://metadata-static.plex.tv/a.jpg',
+    })
+
+    await resolveTmdbPosters(
+      new Map([[friend(1, 'alice'), new Set([target])]]),
+      deps,
+    )
+
+    expect(getPosterPath).toHaveBeenCalledTimes(1)
+    expect(target.thumb).toBe('/resolved.jpg')
+  })
+
+  it('fills in a missing thumb', async () => {
+    const target = item({ key: 'a' })
+
+    await resolveTmdbPosters(
+      new Map([[friend(1, 'alice'), new Set([target])]]),
+      deps,
+    )
+
+    expect(target.thumb).toBe('/resolved.jpg')
+  })
+
+  it('leaves the thumb untouched on a miss', async () => {
+    getPosterPath.mockResolvedValue(null)
+    const target = item({ key: 'a', thumb: 'https://plex.tv/a.jpg' })
+
+    await resolveTmdbPosters(
+      new Map([[friend(1, 'alice'), new Set([target])]]),
+      deps,
+    )
+
+    expect(target.thumb).toBe('https://plex.tv/a.jpg')
+  })
+
+  it('leaves the thumb untouched when the lookup rejects and still resolves the rest', async () => {
+    getPosterPath.mockImplementation(async (guids) => {
+      if (Array.isArray(guids) && guids.includes('tmdb:1')) {
+        throw new Error('boom')
+      }
+      return '/ok.jpg'
+    })
+
+    const failing = item({
+      key: 'a',
+      guids: ['tmdb:1'],
+      thumb: 'https://plex.tv/a.jpg',
+    })
+    const succeeding = item({ key: 'b', guids: ['tmdb:2'] })
+
+    await resolveTmdbPosters(
+      new Map([[friend(1, 'alice'), new Set([failing, succeeding])]]),
+      deps,
+    )
+
+    expect(failing.thumb).toBe('https://plex.tv/a.jpg')
+    expect(succeeding.thumb).toBe('/ok.jpg')
+  })
+
+  it('looks up a shared key once and updates every copy', async () => {
+    const alicesCopy = item({ key: 'shared', user_id: 1 })
+    const bobsCopy = item({ key: 'shared', user_id: 2 })
+
+    await resolveTmdbPosters(
+      new Map([
+        [friend(1, 'alice'), new Set([alicesCopy])],
+        [friend(2, 'bob'), new Set([bobsCopy])],
+      ]),
+      deps,
+    )
+
+    expect(getPosterPath).toHaveBeenCalledTimes(1)
+    expect(alicesCopy.thumb).toBe('/resolved.jpg')
+    expect(bobsCopy.thumb).toBe('/resolved.jpg')
+  })
+
+  it('passes the content type through for shows and movies', async () => {
+    const show = item({ key: 'show', type: 'show', guids: ['tvdb:81189'] })
+    const movie = item({ key: 'movie', type: 'movie', guids: ['tmdb:550'] })
+
+    await resolveTmdbPosters(
+      new Map([[friend(1, 'alice'), new Set([show, movie])]]),
+      deps,
+    )
+
+    expect(getPosterPath).toHaveBeenCalledWith(['tvdb:81189'], 'show')
+    expect(getPosterPath).toHaveBeenCalledWith(['tmdb:550'], 'movie')
+  })
+})


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plex watchlist items can receive poster artwork from TMDB when local or remote artwork is unavailable.
  * Poster lookup supports movies and shows, including TMDB and TVDB identifiers.
  * Watchlist processing avoids duplicate poster lookups and limits concurrent requests.

* **Bug Fixes**
  * Detail views now use standardized poster URLs for more consistent artwork display.
  * TMDB requests now time out when services do not respond, preventing stalled watchlist processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->