### PR TITLE
Fix/metadata refresh gate

### DIFF
--- a/docs/static/openapi.json
+++ b/docs/static/openapi.json
@@ -1904,8 +1904,7 @@
         "type": "object",
         "properties": {
           "success": {
-            "type": "boolean",
-            "const": true
+            "type": "boolean"
           },
           "message": {
             "type": "string"

--- a/docs/static/openapi.json
+++ b/docs/static/openapi.json
@@ -1900,6 +1900,24 @@
         "additionalProperties": false,
         "description": "Standard success message response"
       },
+      "MetadataRefreshAccepted": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "const": true
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "success",
+          "message"
+        ],
+        "additionalProperties": false,
+        "description": "The metadata refresh was started in the background."
+      },
       "MonitoringType": {
         "type": "string",
         "enum": [
@@ -9011,43 +9029,28 @@
     "/v1/metadata/refresh": {
       "post": {
         "operationId": "refreshMetadata",
-        "summary": "Refresh metadata for all watchlist items",
+        "summary": "Start a metadata refresh for all watchlist items",
         "tags": [
           "Metadata"
         ],
-        "description": "Forces a refresh of metadata (posters, GUIDs, genres) for all existing watchlist items by re-fetching data from Plex API",
+        "description": "Starts a background refresh of metadata (posters, GUIDs, genres) for all existing watchlist items by re-fetching data from Plex API. Returns immediately; only one refresh runs at a time.",
         "responses": {
-          "200": {
+          "202": {
             "description": "Default Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean"
-                    },
-                    "message": {
-                      "type": "string"
-                    },
-                    "totalItems": {
-                      "type": "number"
-                    },
-                    "selfItems": {
-                      "type": "number"
-                    },
-                    "othersItems": {
-                      "type": "number"
-                    }
-                  },
-                  "required": [
-                    "success",
-                    "message",
-                    "totalItems",
-                    "selfItems",
-                    "othersItems"
-                  ],
-                  "additionalProperties": false
+                  "$ref": "#/components/schemas/MetadataRefreshAccepted"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
                 }
               }
             }

--- a/src/client/types/api.d.ts
+++ b/src/client/types/api.d.ts
@@ -546,8 +546,8 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Refresh metadata for all watchlist items
-         * @description Forces a refresh of metadata (posters, GUIDs, genres) for all existing watchlist items by re-fetching data from Plex API
+         * Start a metadata refresh for all watchlist items
+         * @description Starts a background refresh of metadata (posters, GUIDs, genres) for all existing watchlist items by re-fetching data from Plex API. Returns immediately; only one refresh runs at a time.
          */
         post: operations["refreshMetadata"];
         delete?: never;
@@ -3535,6 +3535,12 @@ export interface components {
             /** @description Human-readable result message */
             message: string;
         };
+        /** @description The metadata refresh was started in the background. */
+        MetadataRefreshAccepted: {
+            /** @constant */
+            success: true;
+            message: string;
+        };
         /**
          * @description Rolling monitoring strategy for a show
          * @enum {string}
@@ -6323,18 +6329,21 @@ export interface operations {
         requestBody?: never;
         responses: {
             /** @description Default Response */
-            200: {
+            202: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        success: boolean;
-                        message: string;
-                        totalItems: number;
-                        selfItems: number;
-                        othersItems: number;
-                    };
+                    "application/json": components["schemas"]["MetadataRefreshAccepted"];
+                };
+            };
+            /** @description Default Response */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
             /** @description Rate limit exceeded */

--- a/src/client/types/api.d.ts
+++ b/src/client/types/api.d.ts
@@ -3537,8 +3537,7 @@ export interface components {
         };
         /** @description The metadata refresh was started in the background. */
         MetadataRefreshAccepted: {
-            /** @constant */
-            success: true;
+            success: boolean;
             message: string;
         };
         /**

--- a/src/plugins/custom/metadata-refresh.ts
+++ b/src/plugins/custom/metadata-refresh.ts
@@ -1,47 +1,29 @@
+import { MetadataRefreshService } from '@services/metadata-refresh.service.js'
 import type { FastifyPluginAsync } from 'fastify'
 import fp from 'fastify-plugin'
 
-/**
- * Metadata Refresh Plugin
- *
- * Registers a weekly scheduled job to refresh metadata for all watchlist items.
- * The job runs every Sunday at 2 AM to refresh posters, GUIDs, and genres from Plex API.
- */
+declare module 'fastify' {
+  interface FastifyInstance {
+    metadataRefresh: MetadataRefreshService
+  }
+}
+
 const plugin: FastifyPluginAsync = async (fastify) => {
   const JOB_NAME = 'metadata-refresh'
 
-  // Define the job handler
-  const metadataRefreshHandler = async (jobName: string): Promise<void> => {
-    try {
-      fastify.log.info(`Starting scheduled metadata refresh job: ${jobName}`)
+  fastify.decorate(
+    'metadataRefresh',
+    new MetadataRefreshService({
+      plexWatchlist: fastify.plexWatchlist,
+      log: fastify.log,
+    }),
+  )
 
-      // Refresh both watchlists with force refresh in parallel
-      const [selfWatchlistResult, othersWatchlistResult] = await Promise.all([
-        fastify.plexWatchlist.getSelfWatchlist(true),
-        fastify.plexWatchlist.getOthersWatchlists(true),
-      ])
-
-      const totalSelfItems = selfWatchlistResult.total
-      const totalOthersItems = othersWatchlistResult.total
-      const totalItems = totalSelfItems + totalOthersItems
-
-      fastify.log.info(
-        `Scheduled metadata refresh completed successfully: ${totalItems} items refreshed (${totalSelfItems} self, ${totalOthersItems} others)`,
-      )
-    } catch (error) {
-      fastify.log.error({ error, jobName }, 'Scheduled metadata refresh failed')
-      throw error
-    }
-  }
-
-  // Register the job handler with the scheduler using onReady hook
   fastify.addHook('onReady', async () => {
     try {
-      // Check if metadata refresh schedule exists
       const existingSchedule = await fastify.db.getScheduleByName(JOB_NAME)
 
       if (!existingSchedule) {
-        // Create the schedule - refresh weekly on Sundays at 2 AM
         const now = new Date()
         const nextRun = new Date(now)
         const daysUntilSunday = (7 - now.getDay()) % 7
@@ -69,17 +51,15 @@ const plugin: FastifyPluginAsync = async (fastify) => {
         fastify.log.debug('Created metadata refresh schedule')
       }
 
-      // Register the job handler with the scheduler
       await fastify.scheduler.scheduleJob(JOB_NAME, async (jobName) => {
         try {
-          // Check if job is still enabled
           const currentSchedule = await fastify.db.getScheduleByName(jobName)
           if (!currentSchedule?.enabled) {
             fastify.log.debug(`Job ${jobName} is disabled, skipping`)
             return
           }
 
-          await metadataRefreshHandler(jobName)
+          await fastify.metadataRefresh.run()
         } catch (error) {
           fastify.log.error({ error }, `Error in scheduled job ${jobName}:`)
           throw error

--- a/src/routes/v1/metadata/refresh.ts
+++ b/src/routes/v1/metadata/refresh.ts
@@ -1,6 +1,6 @@
 import {
+  MetadataRefreshAcceptedResponseSchema,
   MetadataRefreshErrorResponseSchema,
-  MetadataRefreshSuccessResponseSchema,
 } from '@schemas/metadata/metadata.schema.js'
 import { logRouteError } from '@utils/route-errors.js'
 import type { FastifyPluginAsyncZodOpenApi } from 'fastify-zod-openapi'
@@ -10,12 +10,13 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (fastify) => {
     '/refresh',
     {
       schema: {
-        summary: 'Refresh metadata for all watchlist items',
+        summary: 'Start a metadata refresh for all watchlist items',
         operationId: 'refreshMetadata',
         description:
-          'Forces a refresh of metadata (posters, GUIDs, genres) for all existing watchlist items by re-fetching data from Plex API',
+          'Starts a background refresh of metadata (posters, GUIDs, genres) for all existing watchlist items by re-fetching data from Plex API. Returns immediately; only one refresh runs at a time.',
         response: {
-          200: MetadataRefreshSuccessResponseSchema,
+          202: MetadataRefreshAcceptedResponseSchema,
+          409: MetadataRefreshErrorResponseSchema,
           500: MetadataRefreshErrorResponseSchema,
         },
         tags: ['Metadata'],
@@ -23,32 +24,21 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (fastify) => {
     },
     async (request, reply) => {
       try {
-        fastify.log.info('Starting metadata refresh for all watchlist items')
+        if (fastify.metadataRefresh.isRunning()) {
+          return reply.conflict('Metadata refresh already running')
+        }
 
-        const selfWatchlistResult =
-          await fastify.plexWatchlist.getSelfWatchlist(true)
+        fastify.metadataRefresh.start()
 
-        const othersWatchlistResult =
-          await fastify.plexWatchlist.getOthersWatchlists(true)
-
-        const totalSelfItems = selfWatchlistResult.total
-        const totalOthersItems = othersWatchlistResult.total
-        const totalItems = totalSelfItems + totalOthersItems
-
-        fastify.log.info(
-          `Metadata refresh completed: ${totalItems} items refreshed (${totalSelfItems} self, ${totalOthersItems} others)`,
-        )
+        reply.code(202)
 
         return {
-          success: true,
-          message: `Successfully refreshed metadata for ${totalItems} watchlist items (${totalSelfItems} self, ${totalOthersItems} others)`,
-          totalItems,
-          selfItems: totalSelfItems,
-          othersItems: totalOthersItems,
+          success: true as const,
+          message: 'Metadata refresh started',
         }
       } catch (error) {
         logRouteError(fastify.log, request, error, {
-          message: 'Failed to refresh metadata',
+          message: 'Failed to start metadata refresh',
         })
 
         return reply.internalServerError('Unable to refresh metadata')

--- a/src/routes/v1/metadata/refresh.ts
+++ b/src/routes/v1/metadata/refresh.ts
@@ -30,10 +30,10 @@ const plugin: FastifyPluginAsyncZodOpenApi = async (fastify) => {
 
         fastify.metadataRefresh.start()
 
-        reply.code(202)
+        reply.status(202)
 
         return {
-          success: true as const,
+          success: true,
           message: 'Metadata refresh started',
         }
       } catch (error) {

--- a/src/schemas/metadata/metadata.schema.ts
+++ b/src/schemas/metadata/metadata.schema.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 
 export const MetadataRefreshAcceptedResponseSchema = z
   .object({
-    success: z.literal(true),
+    success: z.boolean(),
     message: z.string(),
   })
   .meta({

--- a/src/schemas/metadata/metadata.schema.ts
+++ b/src/schemas/metadata/metadata.schema.ts
@@ -1,20 +1,19 @@
 import { ErrorSchema } from '@root/schemas/common/error.schema.js'
 import { z } from 'zod'
 
-// Metadata refresh success response schema
-export const MetadataRefreshSuccessResponseSchema = z.object({
-  success: z.boolean(),
-  message: z.string(),
-  totalItems: z.number(),
-  selfItems: z.number(),
-  othersItems: z.number(),
-})
+export const MetadataRefreshAcceptedResponseSchema = z
+  .object({
+    success: z.literal(true),
+    message: z.string(),
+  })
+  .meta({
+    id: 'MetadataRefreshAccepted',
+    description: 'The metadata refresh was started in the background.',
+  })
 
-// Re-export shared ErrorSchema with domain-specific alias
 export { ErrorSchema as MetadataRefreshErrorResponseSchema }
 
-// Type exports
-export type MetadataRefreshSuccessResponse = z.infer<
-  typeof MetadataRefreshSuccessResponseSchema
+export type MetadataRefreshAcceptedResponse = z.infer<
+  typeof MetadataRefreshAcceptedResponseSchema
 >
 export type MetadataRefreshErrorResponse = z.infer<typeof ErrorSchema>

--- a/src/services/metadata-refresh.service.ts
+++ b/src/services/metadata-refresh.service.ts
@@ -1,0 +1,74 @@
+import type { PlexWatchlistService } from '@services/plex-watchlist.service.js'
+import { createServiceLogger } from '@utils/logger.js'
+import type { FastifyBaseLogger } from 'fastify'
+
+export interface MetadataRefreshDeps {
+  plexWatchlist: Pick<
+    PlexWatchlistService,
+    'getSelfWatchlist' | 'getOthersWatchlists'
+  >
+  log: FastifyBaseLogger
+}
+
+export class MetadataRefreshService {
+  private readonly log: FastifyBaseLogger
+  private readonly plexWatchlist: MetadataRefreshDeps['plexWatchlist']
+  private inFlight: Promise<void> | null = null
+
+  constructor(deps: MetadataRefreshDeps) {
+    this.log = createServiceLogger(deps.log, 'METADATA_REFRESH')
+    this.plexWatchlist = deps.plexWatchlist
+  }
+
+  start(): boolean {
+    if (this.inFlight) {
+      return false
+    }
+
+    this.execute().catch((error) => {
+      this.log.error({ error }, 'Metadata refresh failed')
+    })
+
+    return true
+  }
+
+  async run(): Promise<void> {
+    if (this.inFlight) {
+      this.log.info('Metadata refresh already running, skipping')
+      return
+    }
+
+    await this.execute()
+  }
+
+  isRunning(): boolean {
+    return this.inFlight !== null
+  }
+
+  private execute(): Promise<void> {
+    const inFlight = this.runRefresh().finally(() => {
+      this.inFlight = null
+    })
+
+    this.inFlight = inFlight
+
+    return inFlight
+  }
+
+  private async runRefresh(): Promise<void> {
+    this.log.info('Starting metadata refresh for all watchlist items')
+
+    const [selfWatchlistResult, othersWatchlistResult] = await Promise.all([
+      this.plexWatchlist.getSelfWatchlist(true),
+      this.plexWatchlist.getOthersWatchlists(true),
+    ])
+
+    const totalSelfItems = selfWatchlistResult.total
+    const totalOthersItems = othersWatchlistResult.total
+    const totalItems = totalSelfItems + totalOthersItems
+
+    this.log.info(
+      `Metadata refresh completed: ${totalItems} items refreshed (${totalSelfItems} self, ${totalOthersItems} others)`,
+    )
+  }
+}

--- a/src/services/metadata-refresh.service.ts
+++ b/src/services/metadata-refresh.service.ts
@@ -58,13 +58,27 @@ export class MetadataRefreshService {
   private async runRefresh(): Promise<void> {
     this.log.info('Starting metadata refresh for all watchlist items')
 
-    const [selfWatchlistResult, othersWatchlistResult] = await Promise.all([
+    // Both refreshes must settle before the guard clears, or a retry overlaps the survivor
+    const [selfWatchlist, othersWatchlist] = await Promise.allSettled([
       this.plexWatchlist.getSelfWatchlist(true),
       this.plexWatchlist.getOthersWatchlists(true),
     ])
 
-    const totalSelfItems = selfWatchlistResult.total
-    const totalOthersItems = othersWatchlistResult.total
+    if (selfWatchlist.status === 'rejected') {
+      if (othersWatchlist.status === 'rejected') {
+        this.log.error(
+          { error: othersWatchlist.reason },
+          "Others' watchlist refresh failed",
+        )
+      }
+      throw selfWatchlist.reason
+    }
+    if (othersWatchlist.status === 'rejected') {
+      throw othersWatchlist.reason
+    }
+
+    const totalSelfItems = selfWatchlist.value.total
+    const totalOthersItems = othersWatchlist.value.total
     const totalItems = totalSelfItems + totalOthersItems
 
     this.log.info(

--- a/test/helpers/deferred.ts
+++ b/test/helpers/deferred.ts
@@ -1,0 +1,15 @@
+export interface Deferred<T> {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (error: Error) => void
+}
+
+export function createDeferred<T>(): Deferred<T> {
+  let resolve: (value: T) => void = () => {}
+  let reject: (error: Error) => void = () => {}
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}

--- a/test/integration/routes/metadata-refresh.test.ts
+++ b/test/integration/routes/metadata-refresh.test.ts
@@ -1,0 +1,137 @@
+import type { MetadataRefreshDeps } from '@services/metadata-refresh.service.js'
+import type { FastifyInstance } from 'fastify'
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+import { build } from '../../helpers/app.js'
+import { getTestDatabase, resetDatabase } from '../../helpers/database.js'
+import { createDeferred } from '../../helpers/deferred.js'
+import { seedAll } from '../../helpers/seeds/index.js'
+
+type WatchlistResult = Awaited<
+  ReturnType<MetadataRefreshDeps['plexWatchlist']['getSelfWatchlist']>
+>
+
+function stubWatchlists(app: FastifyInstance) {
+  const self = createDeferred<WatchlistResult>()
+  const others = createDeferred<WatchlistResult>()
+  app.plexWatchlist.getSelfWatchlist = vi.fn().mockReturnValue(self.promise)
+  app.plexWatchlist.getOthersWatchlists = vi
+    .fn()
+    .mockReturnValue(others.promise)
+  return { self, others }
+}
+
+describe('POST /v1/metadata/refresh', () => {
+  let app: FastifyInstance
+
+  beforeAll(async () => {
+    app = await build()
+    await app.ready()
+  })
+
+  afterAll(async () => {
+    await app.close()
+  })
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    await resetDatabase()
+    await seedAll(getTestDatabase())
+    app.config.authenticationMethod = 'disabled'
+  })
+
+  const postRefresh = () =>
+    app.inject({ method: 'POST', url: '/v1/metadata/refresh' })
+
+  const waitForIdle = () =>
+    vi.waitFor(() => expect(app.metadataRefresh.isRunning()).toBe(false))
+
+  it('returns 202 and starts the refresh in the background', async () => {
+    const { self, others } = stubWatchlists(app)
+
+    const res = await postRefresh()
+
+    expect(res.statusCode).toBe(202)
+    expect(res.json()).toEqual({
+      success: true,
+      message: 'Metadata refresh started',
+    })
+    expect(app.plexWatchlist.getSelfWatchlist).toHaveBeenCalledTimes(1)
+    expect(app.plexWatchlist.getOthersWatchlists).toHaveBeenCalledTimes(1)
+    expect(app.metadataRefresh.isRunning()).toBe(true)
+
+    self.resolve({ total: 3, users: [] })
+    others.resolve({ total: 2, users: [] })
+    await waitForIdle()
+  })
+
+  it('returns 409 while a refresh is already running', async () => {
+    const { self, others } = stubWatchlists(app)
+
+    const first = await postRefresh()
+    expect(first.statusCode).toBe(202)
+
+    const second = await postRefresh()
+    expect(second.statusCode).toBe(409)
+    expect(second.json()).toEqual({
+      statusCode: 409,
+      error: 'Conflict',
+      message: 'Metadata refresh already running',
+    })
+    expect(app.plexWatchlist.getSelfWatchlist).toHaveBeenCalledTimes(1)
+    expect(app.plexWatchlist.getOthersWatchlists).toHaveBeenCalledTimes(1)
+
+    self.resolve({ total: 0, users: [] })
+    others.resolve({ total: 0, users: [] })
+    await waitForIdle()
+  })
+
+  it('accepts a new refresh once the previous one finishes', async () => {
+    const first = stubWatchlists(app)
+
+    expect((await postRefresh()).statusCode).toBe(202)
+
+    first.self.resolve({ total: 1, users: [] })
+    first.others.resolve({ total: 1, users: [] })
+    await waitForIdle()
+
+    const second = stubWatchlists(app)
+    const res = await postRefresh()
+
+    expect(res.statusCode).toBe(202)
+    expect(app.plexWatchlist.getSelfWatchlist).toHaveBeenCalledTimes(1)
+    expect(app.plexWatchlist.getOthersWatchlists).toHaveBeenCalledTimes(1)
+
+    second.self.resolve({ total: 1, users: [] })
+    second.others.resolve({ total: 1, users: [] })
+    await waitForIdle()
+  })
+
+  it('clears the guard when the refresh fails', async () => {
+    const failing = stubWatchlists(app)
+
+    expect((await postRefresh()).statusCode).toBe(202)
+
+    failing.self.reject(new Error('Plex unavailable'))
+    failing.others.reject(new Error('Plex unavailable'))
+    await waitForIdle()
+
+    const retry = stubWatchlists(app)
+    const res = await postRefresh()
+
+    expect(res.statusCode).toBe(202)
+    expect(app.plexWatchlist.getSelfWatchlist).toHaveBeenCalledTimes(1)
+    expect(app.plexWatchlist.getOthersWatchlists).toHaveBeenCalledTimes(1)
+
+    retry.self.resolve({ total: 0, users: [] })
+    retry.others.resolve({ total: 0, users: [] })
+    await waitForIdle()
+  })
+})

--- a/test/integration/routes/metadata-refresh.test.ts
+++ b/test/integration/routes/metadata-refresh.test.ts
@@ -114,6 +114,20 @@ describe('POST /v1/metadata/refresh', () => {
     await waitForIdle()
   })
 
+  it('still returns 409 when one refresh has failed and the other is pending', async () => {
+    const stubs = stubWatchlists(app)
+
+    expect((await postRefresh()).statusCode).toBe(202)
+
+    stubs.self.reject(new Error('Plex unavailable'))
+    await Promise.resolve()
+
+    expect((await postRefresh()).statusCode).toBe(409)
+
+    stubs.others.resolve({ total: 0, users: [] })
+    await waitForIdle()
+  })
+
   it('clears the guard when the refresh fails', async () => {
     const failing = stubWatchlists(app)
 

--- a/test/unit/services/metadata-refresh.service.test.ts
+++ b/test/unit/services/metadata-refresh.service.test.ts
@@ -71,6 +71,20 @@ describe('MetadataRefreshService', () => {
     expect(getOthersWatchlists).toHaveBeenCalledTimes(2)
   })
 
+  it('keeps the guard while one refresh has failed and the other is pending', async () => {
+    service.start()
+
+    self.reject(new Error('Plex unavailable'))
+    await Promise.resolve()
+
+    expect(service.isRunning()).toBe(true)
+    expect(service.start()).toBe(false)
+
+    others.resolve({ total: 0, users: [] })
+    await waitForIdle()
+    expect(getSelfWatchlist).toHaveBeenCalledTimes(1)
+  })
+
   it('clears the guard once the refresh rejects', async () => {
     service.start()
 

--- a/test/unit/services/metadata-refresh.service.test.ts
+++ b/test/unit/services/metadata-refresh.service.test.ts
@@ -1,0 +1,142 @@
+import {
+  type MetadataRefreshDeps,
+  MetadataRefreshService,
+} from '@services/metadata-refresh.service.js'
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
+import { createDeferred, type Deferred } from '../../helpers/deferred.js'
+import { createMockLogger } from '../../mocks/logger.js'
+
+type PlexWatchlistDeps = MetadataRefreshDeps['plexWatchlist']
+type WatchlistResult = Awaited<
+  ReturnType<PlexWatchlistDeps['getSelfWatchlist']>
+>
+
+describe('MetadataRefreshService', () => {
+  let self: Deferred<WatchlistResult>
+  let others: Deferred<WatchlistResult>
+  let getSelfWatchlist: Mock<PlexWatchlistDeps['getSelfWatchlist']>
+  let getOthersWatchlists: Mock<PlexWatchlistDeps['getOthersWatchlists']>
+  let service: MetadataRefreshService
+
+  const queueNextRefresh = () => {
+    self = createDeferred<WatchlistResult>()
+    others = createDeferred<WatchlistResult>()
+    getSelfWatchlist.mockReturnValueOnce(self.promise)
+    getOthersWatchlists.mockReturnValueOnce(others.promise)
+  }
+
+  const waitForIdle = () =>
+    vi.waitFor(() => expect(service.isRunning()).toBe(false))
+
+  beforeEach(() => {
+    getSelfWatchlist = vi.fn<PlexWatchlistDeps['getSelfWatchlist']>()
+    getOthersWatchlists = vi.fn<PlexWatchlistDeps['getOthersWatchlists']>()
+    service = new MetadataRefreshService({
+      plexWatchlist: { getSelfWatchlist, getOthersWatchlists },
+      log: createMockLogger(),
+    })
+    queueNextRefresh()
+  })
+
+  it('starts a refresh and reports it as running', () => {
+    expect(service.isRunning()).toBe(false)
+
+    expect(service.start()).toBe(true)
+
+    expect(service.isRunning()).toBe(true)
+    expect(getSelfWatchlist).toHaveBeenCalledTimes(1)
+    expect(getSelfWatchlist).toHaveBeenCalledWith(true)
+    expect(getOthersWatchlists).toHaveBeenCalledTimes(1)
+    expect(getOthersWatchlists).toHaveBeenCalledWith(true)
+  })
+
+  it('refuses a second start while one is in flight', () => {
+    expect(service.start()).toBe(true)
+
+    expect(service.start()).toBe(false)
+    expect(getSelfWatchlist).toHaveBeenCalledTimes(1)
+    expect(getOthersWatchlists).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears the guard once the refresh resolves', async () => {
+    service.start()
+
+    self.resolve({ total: 3, users: [] })
+    others.resolve({ total: 2, users: [] })
+    await waitForIdle()
+
+    queueNextRefresh()
+    expect(service.start()).toBe(true)
+    expect(getSelfWatchlist).toHaveBeenCalledTimes(2)
+    expect(getOthersWatchlists).toHaveBeenCalledTimes(2)
+  })
+
+  it('clears the guard once the refresh rejects', async () => {
+    service.start()
+
+    self.reject(new Error('Plex unavailable'))
+    others.reject(new Error('Plex unavailable'))
+    await waitForIdle()
+
+    queueNextRefresh()
+    expect(service.start()).toBe(true)
+    expect(getSelfWatchlist).toHaveBeenCalledTimes(2)
+    expect(getOthersWatchlists).toHaveBeenCalledTimes(2)
+  })
+
+  it('run awaits the refresh before resolving', async () => {
+    const running = service.run()
+    expect(service.isRunning()).toBe(true)
+
+    self.resolve({ total: 3, users: [] })
+    others.resolve({ total: 2, users: [] })
+    await running
+
+    expect(service.isRunning()).toBe(false)
+  })
+
+  it('run rejects when the refresh fails', async () => {
+    const running = service.run()
+
+    self.reject(new Error('Plex unavailable'))
+    others.reject(new Error('Plex unavailable'))
+
+    await expect(running).rejects.toThrow('Plex unavailable')
+    expect(service.isRunning()).toBe(false)
+  })
+
+  it('run resolves without a second refresh while one is in flight', async () => {
+    const running = service.run()
+
+    await service.run()
+
+    expect(service.isRunning()).toBe(true)
+    expect(getSelfWatchlist).toHaveBeenCalledTimes(1)
+    expect(getOthersWatchlists).toHaveBeenCalledTimes(1)
+
+    self.resolve({ total: 0, users: [] })
+    others.resolve({ total: 0, users: [] })
+    await running
+  })
+
+  it('shares the guard between run and start', async () => {
+    const running = service.run()
+    expect(service.start()).toBe(false)
+
+    self.resolve({ total: 1, users: [] })
+    others.resolve({ total: 1, users: [] })
+    await running
+
+    queueNextRefresh()
+    expect(service.start()).toBe(true)
+
+    await service.run()
+
+    expect(getSelfWatchlist).toHaveBeenCalledTimes(2)
+    expect(getOthersWatchlists).toHaveBeenCalledTimes(2)
+
+    self.resolve({ total: 1, users: [] })
+    others.resolve({ total: 1, users: [] })
+    await waitForIdle()
+  })
+})


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Performance improvement
- [x] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Metadata refreshes now run in the background, allowing requests to return immediately.
  - Successful requests return `202 Accepted` with a confirmation message.
  - Only one refresh can run at a time; additional requests receive `409 Conflict`.
  - Refreshes clear their running state after completion or failure, enabling retries.

- **API Changes**
  - Refresh responses no longer include item-count details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->