### PR TITLE
fix(notifications): escape poster url and cap delete sync description

### DIFF
--- a/src/services/notifications/templates/apprise-html.ts
+++ b/src/services/notifications/templates/apprise-html.ts
@@ -115,7 +115,7 @@ function createPosterHtml(
 ): string {
   if (!posterUrl) return ''
   return `<div style="${CENTER_BLOCK_STYLE}">
-       <img src="${posterUrl}" alt="${escapeHtml(title)} poster" style="max-width: ${maxWidth}px; ${POSTER_STYLE}">
+       <img src="${escapeHtml(posterUrl)}" alt="${escapeHtml(title)} poster" style="max-width: ${maxWidth}px; ${POSTER_STYLE}">
      </div>`
 }
 

--- a/src/services/notifications/templates/discord-embeds.ts
+++ b/src/services/notifications/templates/discord-embeds.ts
@@ -209,9 +209,12 @@ export function createDeleteSyncEmbed(
 ): DiscordEmbed {
   const summary = summarizeDeleteSync(results, dryRun)
 
-  const description = summary.protectedText
-    ? `${summary.summaryText}\n\n${summary.protectedText}`
-    : summary.summaryText
+  const description = truncate(
+    summary.protectedText
+      ? `${summary.summaryText}\n\n${summary.protectedText}`
+      : summary.summaryText,
+    EMBED_DESCRIPTION_MAX,
+  )
 
   const fields: EmbedField[] = [
     {

--- a/test/unit/services/notifications/templates/apprise-html.test.ts
+++ b/test/unit/services/notifications/templates/apprise-html.test.ts
@@ -175,6 +175,20 @@ describe('apprise-html', () => {
       expect(withoutPoster.htmlBody).not.toContain('<img')
     })
 
+    it('should escape the poster URL inside the src attribute', () => {
+      const result = createMediaNotificationHtml({
+        type: 'movie',
+        title: 'Dune',
+        username: 'alice',
+        posterUrl: 'https://plex.example/poster.jpg" onerror="alert(1)',
+      })
+
+      expect(result.htmlBody).toContain(
+        'src="https://plex.example/poster.jpg&quot; onerror=&quot;alert(1)"',
+      )
+      expect(result.htmlBody).not.toContain('" onerror="')
+    })
+
     it('should escape the title in HTML but leave it raw in text', () => {
       const result = createMediaNotificationHtml({
         type: 'movie',

--- a/test/unit/services/notifications/templates/discord-embeds.test.ts
+++ b/test/unit/services/notifications/templates/discord-embeds.test.ts
@@ -211,6 +211,20 @@ describe('discord-embeds', () => {
       expect(fieldValue(embed, 'Safety Reason')).toBe('Too many deletions')
     })
 
+    it('should truncate a long safety message in the description', () => {
+      const embed = createDeleteSyncEmbed(
+        deleteSyncResult({
+          safetyTriggered: true,
+          safetyMessage: 'x'.repeat(5000),
+          total: { deleted: 0, skipped: 0, processed: 0, protected: 4 },
+        }),
+        false,
+      )
+
+      expect(embed.description).toHaveLength(4096)
+      expect(embed.description?.endsWith('...')).toBe(true)
+    })
+
     it('should build the summary field from the totals', () => {
       const embed = createDeleteSyncEmbed(
         deleteSyncResult({


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved notification security by safely escaping poster image URLs in HTML notifications.
  - Prevented delete-sync notifications from exceeding Discord’s description length limit.
  - Preserved complete notification delivery by truncating oversized descriptions with an ellipsis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->