### PR TITLE
fix(client): use relative font paths so vite emits the woff2 files

### DIFF
--- a/src/client/styles/fonts.css
+++ b/src/client/styles/fonts.css
@@ -1,6 +1,6 @@
 @font-face {
   font-family: "Shuttleblock";
-  src: url("@/assets/fonts/Shuttleblock-Medium.woff2") format("woff2");
+  src: url("../assets/fonts/Shuttleblock-Medium.woff2") format("woff2");
   font-weight: 400;
   font-style: normal;
   font-display: swap;
@@ -8,7 +8,7 @@
 
 @font-face {
   font-family: "Shuttleblock";
-  src: url("@/assets/fonts/Shuttleblock-Bold.woff2") format("woff2");
+  src: url("../assets/fonts/Shuttleblock-Bold.woff2") format("woff2");
   font-weight: 700;
   font-style: normal;
   font-display: swap;
@@ -16,7 +16,7 @@
 
 @font-face {
   font-family: "Shuttleblock";
-  src: url("@/assets/fonts/Shuttleblock-MediumItalic.woff2") format("woff2");
+  src: url("../assets/fonts/Shuttleblock-MediumItalic.woff2") format("woff2");
   font-weight: 400;
   font-style: italic;
   font-display: swap;


### PR DESCRIPTION
## Description
<!-- A clear and concise description of the changes in this PR -->

## Related Issues
<!-- Link to any related issues this PR addresses (e.g., "Fixes #123", "Addresses #456") -->

## Type of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Dependency update

## Testing Performed
<!-- Describe the testing you've done to verify your changes -->

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] My changes work with existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Shuttleblock fonts failing to load in some environments by using compatible relative file paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->